### PR TITLE
feat: core/repl handles redirecting command output to files in VFS

### DIFF
--- a/packages/core/src/models/execOptions.ts
+++ b/packages/core/src/models/execOptions.ts
@@ -62,6 +62,7 @@ export interface ExecOptions {
   quiet?: boolean
   intentional?: boolean
   noHistory?: boolean
+  noCoreRedirect?: boolean // controller wants to handle redirect
   pip?: { container: string; returnTo: string }
   history?: number
   echo?: boolean

--- a/plugins/plugin-bash-like/fs/src/vfs/controller/client-side.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/controller/client-side.ts
@@ -16,7 +16,7 @@
 
 import { CommandHandler, KResponse, ParsedOptions, Registrar } from '@kui-shell/core'
 
-import { fstatImpl, lsImpl } from './server-side'
+import { fstatImpl, fwriteImpl, lsImpl } from './server-side'
 import { cp, grep, gzip, gunzip, rm, mkdir, rmdir } from '../delegates'
 
 /**
@@ -69,6 +69,22 @@ export default function(registrar: Registrar) {
       }
     },
     ['with-data', 'enoent-ok']
+  )
+
+  on(
+    'vfs/fwrite',
+    async args => {
+      try {
+        return await fwriteImpl(args)
+      } catch (err) {
+        // no virtual (client-only) mount found; try contacting the
+        // proxy server
+        return args.REPL.qexec(args.command.replace('vfs fwrite', 'vfs _fwrite'), undefined, undefined, {
+          data: args.execOptions.data
+        })
+      }
+    },
+    'data'
   )
 
   on(

--- a/plugins/plugin-bash-like/fs/src/vfs/controller/server-side.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/controller/server-side.ts
@@ -16,7 +16,7 @@
 
 import { Arguments, RawResponse, Registrar } from '@kui-shell/core'
 
-import { ls, fslice, fstat } from '../delegates'
+import { ls, fslice, fstat, fwrite } from '../delegates'
 import { KuiGlobOptions, GlobStats } from '../../lib/glob'
 
 export async function lsImpl(args: Arguments<KuiGlobOptions>): Promise<RawResponse<GlobStats[]>> {
@@ -25,6 +25,18 @@ export async function lsImpl(args: Arguments<KuiGlobOptions>): Promise<RawRespon
     content: await ls(args, args.argvNoOptions.slice(2))
   }
 }
+
+export async function fwriteImpl(args: Arguments) {
+  return {
+    mode: 'raw',
+    content: await fwrite(
+      args,
+      args.argvNoOptions[2],
+      args.execOptions.data as string | Buffer
+    )
+  }
+}
+
 
 export async function fstatImpl(args: Arguments) {
   return {
@@ -51,6 +63,10 @@ export default function(registrar: Registrar) {
     flags: {
       boolean: ['with-data', 'enoent-ok']
     }
+  })
+
+  registrar.listen('/vfs/_fwrite', fwriteImpl, {
+    requiresLocal: true
   })
 
   registrar.listen(

--- a/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
@@ -230,6 +230,16 @@ export async function fstat(...parameters: Parameters<VFS['fstat']>): ReturnType
 }
 
 /**
+ * fwrite delegate
+ *
+ */
+ export async function fwrite(...parameters: Parameters<VFS['fwrite']>): ReturnType<VFS['fwrite']> {
+  const mount = findMount(parameters[1])
+  return mount.fwrite(parameters[0], parameters[1], parameters[2])
+}
+
+
+/**
  * fslice delegate
  *
  */

--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -99,6 +99,9 @@ export interface VFS {
   /** Fetch content slice */
   fslice(filename: string, offset: number, length: number): Promise<string>
 
+  /** write data to file */
+  fwrite(opts: Pick<Arguments, 'REPL'>, fullpath: string, data: string | Buffer): Promise<boolean>
+
   /** Create a directory/bucket */
   mkdir(
     opts: Pick<Arguments, 'command' | 'REPL' | 'argvNoOptions' | 'parsedOptions' | 'execOptions'>,

--- a/plugins/plugin-bash-like/fs/src/vfs/local.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/local.ts
@@ -21,6 +21,7 @@ import { Arguments, CodedError, encodeComponent, expandHomeDir, findFileWithView
 import { VFS, mount } from '.'
 import { kuiglob, KuiGlobOptions } from '../lib/glob'
 import { fstat, FStat } from '../lib/fstat'
+import { _fwrite } from '../lib/fwrite'
 
 class LocalVFS implements VFS {
   public readonly mountPath = '/'
@@ -67,6 +68,15 @@ class LocalVFS implements VFS {
       argvNoOptions: ['fstat', filepath],
       parsedOptions: { 'with-data': withData, 'enoent-ok': enoentOk }
     })
+  }
+
+  /** Write data to a files */
+  public async fwrite(
+    opts: Pick<Arguments, 'REPL'>,
+    filepath: string,
+    data: string | Buffer
+  ): Promise<boolean> {
+    return _fwrite(filepath, data)
   }
 
   /** Fetch content slice */

--- a/plugins/plugin-client-common/src/components/Content/Editor/SaveFileButton.ts
+++ b/plugins/plugin-client-common/src/components/Content/Editor/SaveFileButton.ts
@@ -37,7 +37,7 @@ export default function SaveFileButton(
 
     command: async () => {
       try {
-        await repl.rexec(`fwrite ${repl.encodeComponent(response.spec.fullpath)}`, { data: editor.getValue() })
+        await repl.rexec(`vfs fwrite ${repl.encodeComponent(response.spec.fullpath)}`, { data: editor.getValue() })
         onSave(true)
       } catch (err) {
         onSave(false)

--- a/plugins/plugin-core-support/src/lib/cmds/replay.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/replay.ts
@@ -153,7 +153,7 @@ export default function(registrar: Registrar) {
             cb: async (snapshot: Buffer) => {
               try {
                 const filepath = expandHomeDir(argvNoOptions[argvNoOptions.indexOf('snapshot') + 1])
-                await REPL.rexec<{ data: string }>(`fwrite ${REPL.encodeComponent(filepath)}`, {
+                await REPL.rexec<{ data: string }>(`vfs fwrite ${REPL.encodeComponent(filepath)}`, {
                   data: Buffer.from(snapshot).toString()
                 })
                 resolve(true)

--- a/plugins/plugin-core-support/src/notebooks/vfs/index.ts
+++ b/plugins/plugin-core-support/src/notebooks/vfs/index.ts
@@ -242,6 +242,15 @@ export class NotebookVFS implements VFS {
     }
   }
 
+  public async fwrite(
+    opts: Pick<Arguments, 'REPL'>,
+    filepath: string,
+    data: string | Buffer
+  ) {
+    console.error('Unsupported operation')
+    return false
+  }
+
   /** Fetch content slice */
   public async fslice(filename: string, offset: number, length: number): Promise<string> {
     const entry = this.findExact(filename, true)


### PR DESCRIPTION
Fixes #7214

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
