### PR TITLE
fix(plugins/plugin-bash-like): vfs ls fails for files named as a number

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -198,7 +198,7 @@ export async function mount(vfs: VFS | VFSProducingFunction) {
 
 /** @return the absolute path to `filepath` */
 export function absolute(filepath: string): string {
-  return isAbsolute(expandHomeDir(filepath)) ? filepath : join(cwd(), filepath)
+  return isAbsolute(expandHomeDir(filepath.toString())) ? filepath : join(cwd(), filepath.toString())
 }
 
 /** Lookup compiatible matching mount */


### PR DESCRIPTION
git cherry-pick 3d2cad8fce4a0293d4d74a45fd00caf8e0505b18
[cherrypick3 1115e0d3f] fix(plugins/plugin-bash-like): vfs ls fails for files named as a number

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
