### PR TITLE
fix: commands can register evaluator option so core/repl will not red…

### DIFF
--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -89,6 +89,9 @@ export interface CommandOptions extends CapabilityRequirements {
   plugin?: string
   okOptions?: string[]
 
+  /** controller wants to handle redirect */
+  noCoreRedirect?: boolean
+
   /** model to view transformer */
   viewTransformer?: ViewTransformer<KResponse, ParsedOptions>
 

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -329,17 +329,18 @@ class InProcessExecutor implements Executor {
     // pipeline splits, e.g. if command='a b|c', the pipeStages=[['a','b'],'c']
     const pipeStages = splitIntoPipeStages(command)
 
-    const originalCommand = command // remember the original command for history
-    if (!execOptions.noCoreRedirect && pipeStages.redirect) {
-      // If core handles redirect, argv and command shouldn't contain the redirect part;
-      // otherwise, controllers may use argv and command incorrectly e.g. kuiecho hi > file will print "hi > file" instead of "hi"
-      argv.splice(argv.indexOf('>'), 2)
-      command = command.replace(new RegExp(`\\s*>\\s*${pipeStages.redirect}\\s*$`), '')
-    }
-
     // debug('command', commandUntrimmed)
     const evaluator = await lookupCommandEvaluator<T, O>(argv, execOptions)
     if (isSuccessfulCommandResolution(evaluator)) {
+      // If core handles redirect, argv and command shouldn't contain the redirect part;
+      // otherwise, controllers may use argv and command incorrectly e.g. kuiecho hi > file will print "hi > file" instead of "hi"
+      const noCoreRedirect = execOptions.noCoreRedirect || (evaluator.options && evaluator.options.noCoreRedirect)
+      const originalCommand = command
+      if (!noCoreRedirect && pipeStages.redirect) {
+        argv.splice(argv.indexOf('>'), 2)
+        command = command.replace(new RegExp(`\\s*>\\s*${pipeStages.redirect}\\s*$`), '')
+      }
+
       const { argvNoOptions, parsedOptions } = this.parseOptions(argv, evaluator)
 
       if (evaluator.options && evaluator.options.requiresLocal && !hasLocalAccess()) {
@@ -484,6 +485,14 @@ class InProcessExecutor implements Executor {
         }
       }
 
+      if (!noCoreRedirect && pipeStages.redirect) {
+        try {
+          await redirectResponse(response, pipeStages.redirect)
+        } catch (err) {
+          response = err
+        }
+      }
+
       this.emitCompletionEvent(
         response || true,
         {
@@ -503,12 +512,7 @@ class InProcessExecutor implements Executor {
         historyIdx || -1
       )
 
-      if (pipeStages.redirect) {
-        await redirectResponse(response, pipeStages.redirect, execOptions)
-        return response
-      } else {
-        return response
-      }
+      return response
     } else {
       const err = new Error('Command not found') as CommandEvaluationError
       err.code = 404 // http not acceptable
@@ -719,24 +723,21 @@ export function getImpl(tab: Tab): REPL {
  * redirect a string response
  *
  */
-async function redirectResponse<T extends KResponse>(
-  _response: MixedResponse | T | Promise<T>,
-  filepath: string,
-  execOptions: ExecOptions
-) {
-  if (!execOptions.noCoreRedirect) {
-    const response = await _response
+async function redirectResponse<T extends KResponse>(_response: MixedResponse | T | Promise<T>, filepath: string) {
+  const response = await _response
 
-    if (typeof response === 'string' || isXtermResponse(response)) {
+  if (typeof response === 'string' || isXtermResponse(response)) {
+    try {
       await rexec<{ data: string }>(`vfs fwrite ${encodeComponent(expandHomeDir(filepath))}`, {
         data: isXtermResponse(response) ? response.rows.map(i => i.map(j => j.innerText)).join(' ') : response
       })
 
       debug(`redirected response to ${filepath}`)
-    } else {
-      throw new Error('Kui only supports redirecting a string or xterm response')
+    } catch (err) {
+      console.error(err)
+      throw new Error(`Error Redirect: ${err.message}`)
     }
   } else {
-    debug('let controller handle redirect')
+    throw new Error('Error: invalid response \n redirect only supports string or xterm responses')
   }
 }

--- a/plugins/plugin-bash-like/fs/src/lib/fwrite.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/fwrite.ts
@@ -21,7 +21,7 @@ export async function _fwrite(_fullpath: string, data: string | Buffer) {
   const { mkdir, writeFile } = await import('fs')
   const fullpath = _fullpath.replace(/"/g, '') // trim double quotes
 
-  return new Promise<boolean>((resolve, reject) => {
+  await new Promise<boolean>((resolve, reject) => {
     const write = (path: string, data: string | Buffer) =>
       writeFile(path, data, err => {
         if (err) {
@@ -57,7 +57,8 @@ const fwrite = async ({ argvNoOptions, execOptions }: Arguments) => {
   const fullpath = argvNoOptions[1]
   const data = execOptions.data as string | Buffer
 
-  return _fwrite(fullpath, data)
+  await _fwrite(fullpath, data)
+  return true
 }
 
 async function fwriteTemp(args: Arguments): Promise<RawResponse<string>> {

--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -100,7 +100,7 @@ export interface VFS {
   fslice(filename: string, offset: number, length: number): Promise<string>
 
   /** write data to file */
-  fwrite(opts: Pick<Arguments, 'REPL'>, fullpath: string, data: string | Buffer): Promise<boolean>
+  fwrite(opts: Pick<Arguments, 'REPL'>, fullpath: string, data: string | Buffer): Promise<void>
 
   /** Create a directory/bucket */
   mkdir(

--- a/plugins/plugin-bash-like/fs/src/vfs/local.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/local.ts
@@ -71,11 +71,7 @@ class LocalVFS implements VFS {
   }
 
   /** Write data to a files */
-  public async fwrite(
-    opts: Pick<Arguments, 'REPL'>,
-    filepath: string,
-    data: string | Buffer
-  ): Promise<boolean> {
+  public async fwrite(opts: Pick<Arguments, 'REPL'>, filepath: string, data: string | Buffer): Promise<void> {
     return _fwrite(filepath, data)
   }
 

--- a/plugins/plugin-client-common/src/controller/commentary.ts
+++ b/plugins/plugin-client-common/src/controller/commentary.ts
@@ -134,5 +134,5 @@ async function addComment(args: Arguments<CommentaryOptions>): Promise<true | Co
  */
 export default async (commandTree: Registrar) => {
   commandTree.listen('/commentary', addComment, { usage, outputOnly: true })
-  commandTree.listen('/#', addComment, { usage, outputOnly: true })
+  commandTree.listen('/#', addComment, { usage, outputOnly: true, noCoreRedirect: true })
 }

--- a/plugins/plugin-client-test/src/lib/cmds/pipe-stage-parsing.ts
+++ b/plugins/plugin-client-test/src/lib/cmds/pipe-stage-parsing.ts
@@ -23,15 +23,19 @@ interface Options extends ParsedOptions {
 }
 
 export default function(registrar: Registrar) {
-  registrar.listen<string, Options>('/kuiPipeStageParsing', args => {
-    const { stage = 0, prefix, redirect } = args.parsedOptions
+  registrar.listen<string, Options>(
+    '/kuiPipeStageParsing',
+    args => {
+      const { stage = 0, prefix, redirect } = args.parsedOptions
 
-    if (prefix) {
-      return args.pipeStages.prefix || 'nope'
-    } else if (redirect) {
-      return args.pipeStages.redirect || 'nope'
-    } else {
-      return args.pipeStages.stages[stage].join(' ')
-    }
-  })
+      if (prefix) {
+        return args.pipeStages.prefix || 'nope'
+      } else if (redirect) {
+        return args.pipeStages.redirect || 'nope'
+      } else {
+        return args.pipeStages.stages[stage].join(' ')
+      }
+    },
+    { noCoreRedirect: true }
+  )
 }

--- a/plugins/plugin-core-support/src/notebooks/vfs/index.ts
+++ b/plugins/plugin-core-support/src/notebooks/vfs/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import TrieSearch from 'trie-search'
 import micromatch from 'micromatch'
 import { basename, dirname, join } from './posix'
@@ -242,13 +243,8 @@ export class NotebookVFS implements VFS {
     }
   }
 
-  public async fwrite(
-    opts: Pick<Arguments, 'REPL'>,
-    filepath: string,
-    data: string | Buffer
-  ) {
-    console.error('Unsupported operation')
-    return false
+  public async fwrite(opts: Pick<Arguments, 'REPL'>, filepath: string, data: string | Buffer) {
+    throw new Error('Unsupported operation')
   }
 
   /** Fetch content slice */


### PR DESCRIPTION
…irect output

Also improves the error handling of core redirect

git cherry-pick 35de273ab13429e0525df60a96ca5576255dfe45
[cherrypick7 5c2139dbd] fix: commands can register evaluator option so core/repl will not redirect output

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
