### PR TITLE
fix(plugins/plugin-kubectl): don't retry file fetches so many times i…

### DIFF
--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -18,7 +18,17 @@ import Debug from 'debug'
 import { join } from 'path'
 import needle, { BodyData } from 'needle'
 import { DirEntry } from '@kui-shell/plugin-bash-like/fs'
-import { Arguments, CodedError, ExecOptions, REPL, inBrowser, hasProxy, encodeComponent, i18n } from '@kui-shell/core'
+import {
+  Arguments,
+  CodedError,
+  ExecOptions,
+  REPL,
+  isHeadless,
+  inBrowser,
+  hasProxy,
+  encodeComponent,
+  i18n
+} from '@kui-shell/core'
 
 import JSONStream from './json'
 import getProxyState from '../../controller/client/proxy'
@@ -28,7 +38,7 @@ const strings = i18n('plugin-kubectl')
 const debug = Debug('plugin-kubectl/util/fetch-file')
 
 /** Maximum number of times to retry on ECONNREFUSED */
-const MAX_ECONNREFUSED_RETRIES = 10
+const MAX_ECONNREFUSED_RETRIES = isHeadless() ? 0 : 10
 
 const httpScheme = /http(s)?:\/\//
 const openshiftScheme = /^openshift:\/\//


### PR DESCRIPTION
…n headless mode

Fixes #7225 

git cherry-pick 2867ecf8aa1e9069e764827484836caf2953a4a7
[cherrypick10 e0e8fd202] fix(plugins/plugin-kubectl): don't retry file fetches so many times in headless mode

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
