### PR TITLE
fix(plugins/plugin-bash-like): in headless mode, don't bother trying …

### DIFF
--- a/packages/core/src/core/capabilities.ts
+++ b/packages/core/src/core/capabilities.ts
@@ -107,6 +107,14 @@ export const assertHasProxy = () => {
 }
 
 /**
+ * Are we the Kui proxy?
+ *
+ */
+export const inProxy = () => {
+  return process.env.KUI_REPL_MODE !== undefined
+}
+
+/**
  * Yes, we are running in a sandbox
  *
  */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
   inElectron,
   isHeadless,
   inSandbox,
+  inProxy,
   assertInSandbox,
   assertLocalAccess,
   assertHasProxy,

--- a/plugins/plugin-bash-like/src/preload.ts
+++ b/plugins/plugin-bash-like/src/preload.ts
@@ -18,14 +18,14 @@ import Debug from 'debug'
 const debug = Debug('plugins/bash-like/preload')
 debug('loading')
 
-import { inBrowser, CapabilityRegistration, PreloadRegistrar } from '@kui-shell/core'
+import { inBrowser, isHeadless, inProxy, CapabilityRegistration, PreloadRegistrar } from '@kui-shell/core'
 
 import { preload as registerCatchAll } from './lib/cmds/catchall'
 
 export const registerCapability: CapabilityRegistration = async (registrar: PreloadRegistrar) => {
   if (inBrowser()) {
     await import('./pty/session').then(({ init }) => init(registrar))
-  } else {
+  } else if (!isHeadless() || inProxy()) {
     try {
       const prefetchShellState = (await import('./pty/prefetch')).default
       await prefetchShellState()


### PR DESCRIPTION
…to memoize user's alias and env

Fixes #7229 

git cherry-pick 692fc3db32b557f87bce72bc9d7e7025536e13c2
[cherrypick13 33b572f82] fix(plugins/plugin-bash-like): in headless mode, don't bother trying to memoize user's alias and env