### PR TITLE
fix(plugins/plugin-client-common): Custom Popup clients cannot specif…

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -35,6 +35,7 @@ import {
 
 import Card from '../spi/Card'
 import KuiContext from './context'
+import CommonClientProps from './props/Common'
 import KuiConfiguration from './KuiConfiguration'
 import StatusStripe, { Props as StatusStripeProps } from './StatusStripe'
 import { TabContainer, Loading, Alert } from '../..'
@@ -53,34 +54,26 @@ const defaultThemeProperties: ThemeProperties = {
   topTabNames: 'fixed'
 }
 
-export type Props = Partial<KuiConfiguration> & {
-  /** no Kui bootstrap needed? */
-  noBootstrap?: boolean
+export type Props = Partial<KuiConfiguration> &
+  CommonClientProps & {
+    /** no Kui bootstrap needed? */
+    noBootstrap?: boolean
 
-  /** operate in bottom Input mode? rather than as a conventional Input/Output terminal */
-  bottomInput?: true | React.ReactNode
+    /** operate in bottom Input mode? rather than as a conventional Input/Output terminal */
+    bottomInput?: true | React.ReactNode
 
-  /** Elements to place between TabContainer and StatusStripe */
-  toplevel?: React.ReactNode | React.ReactNode[]
+    /** Elements to place between TabContainer and StatusStripe */
+    toplevel?: React.ReactNode | React.ReactNode[]
 
-  /** Operate in popup mode? */
-  isPopup?: boolean
+    /** Operate in popup mode? */
+    isPopup?: boolean
 
-  /** If in popup mode, execute the given command line */
-  commandLine?: string[]
+    /** do not echo the command? */
+    quietExecCommand?: boolean
 
-  /** do not echo the command? */
-  quietExecCommand?: boolean
-
-  /** initial tab title */
-  initialTabTitle?: string
-
-  /** do not show <?> help widget */
-  noHelp?: boolean
-
-  /** do not show Settings/Themes widget */
-  noSettings?: boolean
-}
+    /** initial tab title */
+    initialTabTitle?: string
+  }
 
 type State = KuiConfiguration & {
   userOverrides?: KuiConfiguration
@@ -311,7 +304,9 @@ export class Kui extends React.PureComponent<Props, State> {
       return (
         <KuiContext.Provider value={this.state}>
           <React.Suspense fallback={<div />}>
-            <Popup commandLine={this.state.commandLine}>{this.props.children}</Popup>
+            <Popup commandLine={this.state.commandLine} noHelp={this.props.noHelp} noSettings={this.props.noSettings}>
+              {this.props.children}
+            </Popup>
           </React.Suspense>
         </KuiContext.Provider>
       )

--- a/plugins/plugin-client-common/src/components/Client/Popup.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Popup.tsx
@@ -20,13 +20,13 @@
 import React from 'react'
 import { eventBus, Tab as KuiTab, teeToFile } from '@kui-shell/core'
 
+import CommonClientProps from './props/Common'
 import InputStripe from '../Client/InputStripe'
 import { ContextWidgets, StatusStripe, TabContent, TabModel } from '../..'
 
 import '../../../web/css/static/Popup.scss'
 
-interface Props {
-  commandLine: string[]
+type Props = CommonClientProps & {
   children?: React.ReactNode
 }
 
@@ -90,7 +90,7 @@ export default class Popup extends React.PureComponent<Props, State> {
           state={this.state.model.state}
           onTabReady={this.onTabReady.bind(this)}
         ></TabContent>
-        <StatusStripe>
+        <StatusStripe noHelp={this.props.noHelp} noSettings={this.props.noSettings}>
           <ContextWidgets className="kui--input-stripe-in-status-stripe">
             {this.state.tab && (
               <InputStripe

--- a/plugins/plugin-client-common/src/components/Client/props/Common.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Common.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default interface CommonProps {
+  /** If in popup mode, execute the given command line */
+  commandLine?: string[]
+
+  /** do not show <?> help widget */
+  noHelp?: boolean
+
+  /** do not show Settings/Themes widget */
+  noSettings?: boolean
+}


### PR DESCRIPTION
…y noSettings and noHelp properties

Part of #7237

git cherry-pick 640c93dbbbca4ca98ecfcd1c1c09e7f9fbecdf51
[cherrypick17 f785286a2] fix(plugins/plugin-client-common): Custom Popup clients cannot specify noSettings and noHelp properties