### PR TITLE
feat: use webpack to build headless bundles

### DIFF
--- a/bin/kubectl-kui
+++ b/bin/kubectl-kui
@@ -1,20 +1,90 @@
-#!/usr/bin/env node
+#!/usr/bin/env bash
+# -*- mode: shell-script
 
-/**
- * Note: this kubectl plugin wrapper is intended only for use while
- * developing Kui plugins. The kubectl plugin used by production
- * builds will be different, because, in that case, we need to launch
- * the built Kui electron app, rather than (as we do here) launching
- * Kui by requiring from the unpackaged node_modules.
- *
- */
+#
+# Note: this kubectl plugin wrapper is intended only for use while
+# developing Kui plugins. The kubectl plugin used by production
+# builds will be different, because, in that case, we need to launch
+# the built Kui electron app, rather than (as we do here) launching
+# Kui by requiring from the unpackaged node_modules.
+#
+#
 
-// get node off the argv
-process.argv.shift()
+# export KUI_HEADLESS=true
+export NODE_NO_WARNINGS=1
+# export ELECTRON_RUN_AS_NODE=true
+export NODE_OPTIONS="--no-warnings"
 
-// insert 'kubectl' into argv
-process.argv.splice(1, 0, 'kubectl')
+# This tells the core Kui plugin resolver that we are using webpack to
+# build our headless bundles, not the old headless hacks
+# export KUI_HEADLESS_WEBPACK=true
 
-process.env.KUI_POPUP_WINDOW_RESIZE = true
+SCRIPTDIR=$(cd $(dirname "$0") && pwd)                                                              
 
-require('@kui-shell/core').main(process.argv)
+if [ -f ./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron ]; then
+    # development mode
+    NODE=./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron
+    HEADLESS=./dist/headless
+elif [ -f /Applications/Kui.app/Contents/MacOS/Kui ]; then
+    # Kui installed in /Applications on macOS
+    BASE=/Applications/Kui.app
+    NODE="$BASE/Contents/MacOS/Kui"
+    HEADLESS=$BASE/Contents/Resources/headless
+elif [ -f ./Kui.app/Contents/MacOS/Kui ]; then
+    # Kui installed in CWD on macOS
+    BASE="$PWD/Kui.app"
+    NODE="$BASE/Contents/MacOS/Kui"
+    HEADLESS="$BASE/Contents/Resources/headless"
+elif [ -f /usr/local/bin/Kui/Kui ]; then
+    # Kui installed in /usr/local/bin on Linux or Windows
+    BASE=/usr/local/bin/Kui
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f ./Kui/Kui ]; then
+    # Kui installed in CWD on Linux or Windows
+    BASE="$PWD/Kui"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f ./Kui ]; then
+    # Kui installed in CWD on Linux or Windows (variant)
+    BASE="$PWD"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f "$SCRIPTDIR/Kui.app/Contents/MacOS/Kui" ]; then
+    # Kui installed in SCRIPTDIR on macOS
+    BASE="$SCRIPTDIR/Kui.app"
+    NODE="$BASE/Contents/MacOS/Kui"
+    HEADLESS="$BASE/Contents/Resources/headless"
+elif [ -f "$SCRIPTDIR/Kui/Kui" ]; then
+    # Kui installed in SCRIPTDIR on Linux or Windows
+    BASE="$SCRIPTDIR/Kui"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f "$SCRIPTDIR/Kui" ]; then
+    # Kui installed in SCRIPTDIR on Linux or Windows (variant)
+    BASE="$SCRIPTDIR"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f "$KUI_HOME/Kui.app/Contents/MacOS/Kui" ]; then
+    # Kui installed in KUI_HOME on macOS
+    BASE="$KUI_HOME/Kui.app"
+    NODE="$BASE/Contents/MacOS/Kui"
+    HEADLESS="$BASE/Contents/Resources/headless"
+elif [ -f "$KUI_HOME/Kui" ]; then
+    # Kui installed in KUI_HOME on Linux or Windows
+    BASE="$KUI_HOME"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+else
+    echo "Error: Could not find Kui. Try setting KUI_HOME=/path/to/Kui"
+    exit 1
+fi
+
+# This points the headless->electron launcher to our Electron
+export KUI_ELECTRON_HOME="${KUI_ELECTRON_HOME-$NODE}"
+
+# for when we switch over to webpack headless builds:
+# exec "$NODE" -e 'require("'$HEADLESS'/kui.min.js").kiwi.main(process.argv)' . -- kubectl $@
+
+# for now
+exec "$NODE" . -- kubectl $@

--- a/bin/kui
+++ b/bin/kui
@@ -1,8 +1,81 @@
-#!/usr/bin/env node
+#!/usr/bin/env sh
+# -*- mode: shell-script
 
-// get node off the argv
-process.argv.shift()
+# export KUI_HEADLESS=true
+export NODE_NO_WARNINGS=1
+# export ELECTRON_RUN_AS_NODE=true
+export NODE_OPTIONS="--no-warnings"
 
-process.env.KUI_HEADLESS = true
+# This tells the core Kui plugin resolver that we are using webpack to
+# build our headless bundles, not the old headless hacks
+# export KUI_HEADLESS_WEBPACK=true
 
-require('@kui-shell/core').main(process.argv)
+SCRIPTDIR=$(cd $(dirname "$0") && pwd)                                                              
+
+if [ -f ./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron ]; then
+    # development mode
+    NODE=./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron
+    HEADLESS=./dist/headless
+elif [ -f /Applications/Kui.app/Contents/MacOS/Kui ]; then
+    # Kui installed in /Applications on macOS
+    BASE=/Applications/Kui.app
+    NODE="$BASE/Contents/MacOS/Kui"
+    HEADLESS=$BASE/Contents/Resources/headless
+elif [ -f ./Kui.app/Contents/MacOS/Kui ]; then
+    # Kui installed in CWD on macOS
+    BASE="$PWD/Kui.app"
+    NODE="$BASE/Contents/MacOS/Kui"
+    HEADLESS="$BASE/Contents/Resources/headless"
+elif [ -f /usr/local/bin/Kui/Kui ]; then
+    # Kui installed in /usr/local/bin on Linux or Windows
+    BASE=/usr/local/bin/Kui
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f ./Kui/Kui ]; then
+    # Kui installed in CWD on Linux or Windows
+    BASE="$PWD/Kui"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f ./Kui ]; then
+    # Kui installed in CWD on Linux or Windows (variant)
+    BASE="$PWD"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f "$SCRIPTDIR/Kui.app/Contents/MacOS/Kui" ]; then
+    # Kui installed in SCRIPTDIR on macOS
+    BASE="$SCRIPTDIR/Kui.app"
+    NODE="$BASE/Contents/MacOS/Kui"
+    HEADLESS="$BASE/Contents/Resources/headless"
+elif [ -f "$SCRIPTDIR/Kui/Kui" ]; then
+    # Kui installed in SCRIPTDIR on Linux or Windows
+    BASE="$SCRIPTDIR/Kui"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f "$SCRIPTDIR/Kui" ]; then
+    # Kui installed in SCRIPTDIR on Linux or Windows (variant)
+    BASE="$SCRIPTDIR"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+elif [ -f "$KUI_HOME/Kui.app/Contents/MacOS/Kui" ]; then
+    # Kui installed in KUI_HOME on macOS
+    BASE="$KUI_HOME/Kui.app"
+    NODE="$BASE/Contents/MacOS/Kui"
+    HEADLESS="$BASE/Contents/Resources/headless"
+elif [ -f "$KUI_HOME/Kui" ]; then
+    # Kui installed in KUI_HOME on Linux or Windows
+    BASE="$KUI_HOME"
+    NODE="$BASE/Kui"
+    HEADLESS="$BASE/headless"
+else
+    echo "Error: Could not find Kui. Try setting KUI_HOME=/path/to/Kui"
+    exit 1
+fi
+
+# This points the headless->electron launcher to our Electron
+export KUI_ELECTRON_HOME="${KUI_ELECTRON_HOME-$NODE}"
+
+# for when we switch over to webpack headless builds:
+# exec "$NODE" -e 'require("'$HEADLESS'/kui.min.js").kiwi.main(process.argv)' . shell
+
+# for now:
+exec "$NODE" . shell

--- a/packages/core/src/main/main.ts
+++ b/packages/core/src/main/main.ts
@@ -42,10 +42,7 @@ export const main = async (argv: string[], env = process.env, execOptions?: Exec
     // then spawn the electron graphics
     debug('shortcut to graphics')
     const { getCommand, initElectron } = await import('./spawn-electron')
-    const { argv: strippedArgv, subwindowPlease, subwindowPrefs } = getCommand(
-      argv,
-      async () => (await import('electron')).screen
-    )
+    const { argv: strippedArgv, subwindowPlease, subwindowPrefs } = getCommand(argv, async () => import('electron'))
     initElectron(
       strippedArgv,
       { isRunningHeadless },

--- a/packages/core/src/plugins/plugins.ts
+++ b/packages/core/src/plugins/plugins.ts
@@ -24,7 +24,7 @@ import { PrescanModel, unify } from './prescan'
 
 import { KuiPlugin } from '../models/plugin'
 import { userDataDir } from '../core/userdata'
-import { isHeadless } from '../core/capabilities'
+// import { isHeadless } from '../core/capabilities'
 import { setPluginResolver } from '../core/command-tree'
 import { registerTypeahead } from '../commands/typeahead'
 
@@ -101,7 +101,7 @@ export const init = async (): Promise<boolean> => {
   // pre-installed plugins
   basePrescan = prescan
 
-  if (isHeadless() && prescan) {
+  /* if (isHeadless() && prescan) {
     try {
       const [{ existsSync }, { join }] = await Promise.all([import('fs'), import('path')])
       const userPath = join(await userInstalledHome(), 'node_modules/@kui-shell/prescan.json')
@@ -114,9 +114,9 @@ export const init = async (): Promise<boolean> => {
       }
       debug('user-installed prescan loaded')
     } catch (err) {
-      console.error('error loading user-installed prescan', err)
+      debug('error loading user-installed prescan', err)
     }
-  }
+  } */
 
   /* const { default: eventChannelUnsafe } = await import('../core/events')
   eventChannelUnsafe.on('/plugin/compile/request', async (pluginToBeRemoved?: string) => {

--- a/packages/core/src/plugins/preloader.ts
+++ b/packages/core/src/plugins/preloader.ts
@@ -77,7 +77,7 @@ export default async (prescan: PrescanModel) => {
         const registrationRef =
           module.path.charAt(0) === '/'
             ? await import(/* webpackIgnore: true */ module.path)
-            : isHeadless()
+            : isHeadless() && !process.env.KUI_HEADLESS_WEBPACK
             ? await import(/* webpackIgnore: true */ mainPath(module.path))
             : module.route === 'client'
             ? require(/* webpackMode: "lazy" */ '@kui-shell/client/' + 'mdist/preload')
@@ -120,7 +120,7 @@ export default async (prescan: PrescanModel) => {
             const registrationRef =
               module.path.charAt(0) === '/'
                 ? await import(/* webpackIgnore: true */ module.path)
-                : isHeadless()
+                : isHeadless() && !process.env.KUI_HEADLESS_WEBPACK
                 ? await import(/* webpackIgnore: true */ mainPath(module.path))
                 : module.route === 'client'
                 ? require(/* webpackMode: "lazy" */ '@kui-shell/client/' + 'mdist/preload')

--- a/packages/core/src/plugins/resolver.ts
+++ b/packages/core/src/plugins/resolver.ts
@@ -81,7 +81,7 @@ const prequire = async (
             const registrationRef =
               module.path.charAt(0) === '/'
                 ? await import(/* webpackIgnore: true */ module.path)
-                : isHeadless()
+                : isHeadless() && !process.env.KUI_HEADLESS_WEBPACK
                 ? await import(/* webpackIgnore: true */ mainPath(module.path))
                 : module.route === 'client'
                 ? await import(

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -403,7 +403,7 @@ class InProcessExecutor implements Executor {
         return
       }
 
-      const historyIdx = this.pushHistory(originalCommand, execOptions, tab)
+      const historyIdx = isHeadless() ? -1 : this.pushHistory(originalCommand, execOptions, tab)
 
       try {
         enforceUsage(argv, evaluator, execOptions)

--- a/packages/webpack/build.sh
+++ b/packages/webpack/build.sh
@@ -64,7 +64,17 @@ export KUI_BUILDER_HOME="$BUILDER_HOME"
 function webpack {
     pushd "$STAGING" > /dev/null
     rm -f "$BUILDDIR"/*.js*
+
+    if [ -n "$KUI_HEADLESS_WEBPACK" ]; then
+        echo "Building headless bundles via webpack"
+        npx --no-install webpack-cli --config ./node_modules/@kui-shell/webpack/headless-webpack.config.js  --mode=production &
+    fi
+
+    echo "Building electron bundles via webpack"
     npx --no-install webpack-cli --config ./node_modules/@kui-shell/webpack/webpack.config.js --mode production
+
+    wait
+
     popd > /dev/null
 }
 

--- a/packages/webpack/headless-webpack.config.js
+++ b/packages/webpack/headless-webpack.config.js
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2018 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const mode = process.env.MODE || 'development'
+const target = process.env.HEADLESS_TARGET || 'node'
+const TerserJSPlugin = require('terser-webpack-plugin')
+const { IgnorePlugin } = require('webpack')
+
+// in case the client has some oddities that require classnames to be preserved
+const terserOptions = process.env.KEEP_CLASSNAMES
+  ? {
+      terserOptions: {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        keep_classnames: true
+      }
+    }
+  : {}
+
+const optimization = {}
+if (process.env.NO_OPT) {
+  console.log('optimization? disabled')
+  optimization.minimize = false
+} else {
+  optimization.minimizer = [new TerserJSPlugin(terserOptions)]
+}
+
+console.log('mode?', mode)
+console.log('target?', target)
+
+/** point webpack to the root directory */
+const stageDir = process.cwd()
+console.log('stageDir', stageDir)
+
+/** point webpack to the output directory */
+const buildDir = path.join(stageDir, 'dist/headless')
+console.log('buildDir', buildDir)
+
+/** this is the full path in which will be serving up bundles */
+const outputPath = buildDir
+console.log('outputPath', outputPath)
+
+/**
+ * Note: these are _webpack plugins_ not Kui plugins; we will assemble
+ * this list of webpack plugins as we go.
+ */
+const plugins = []
+
+// ignore these bits for headless
+plugins.push(new IgnorePlugin({ contextRegExp: /\/tests\// }))
+plugins.push(new IgnorePlugin({ contextRegExp: /\/@kui-shell\/build/ }))
+;[
+  /^d3$/,
+  /^elkjs\/lib\/elk.bundled.js$/,
+  /^react$/,
+  /^jquery$/,
+  /^electron$/,
+  /^monaco-editor$/,
+  /^@patternfly\/react-core$/,
+  /^@patternfly\/react-chart$/,
+  /^@patternfly\/react-table$/
+].forEach(resourceRegExp => plugins.push(new IgnorePlugin({ resourceRegExp })))
+;[
+  /plugin-wskflow/,
+  /plugin-\w+-themes/,
+  /plugin-client-common/,
+  // /plugin-kubectl-flow-views/,
+  /plugin-electron-components/
+].forEach(resourceRegExp => plugins.push(new IgnorePlugin({ resourceRegExp, contextRegExp: /@kui-shell/ })))
+
+/**
+ * Define the set of bundle entry points; there is one default entry
+ * point (the main: entry below). On top of this, we scan the plugins,
+ * looking to see if they define a `webpack.entry` field in their
+ * package.json; if so, we add this to the mix. See plugin-editor for
+ * an example of this.
+ *
+ */
+const main = path.join(stageDir, 'node_modules/@kui-shell/core/mdist/main/main.js')
+const pluginBase = path.join(stageDir, 'node_modules/@kui-shell')
+console.log('main', main)
+console.log('pluginBase', pluginBase)
+const allKuiPlugins = fs.readdirSync(pluginBase)
+const kuiPluginRules = []
+const kuiPluginExternals = []
+allKuiPlugins.forEach(dir => {
+  try {
+    const pjson = path.join(pluginBase, dir, 'package.json')
+    const { kui } = require(pjson)
+    const providedEntries = (kui && kui.webpack && kui.webpack.entry) || {}
+
+    // does the kui plugin need any webpack plugins?
+    if (kui && kui.webpack) {
+      if (kui.webpack.externals) {
+        kui.webpack.externals.forEach(_ => {
+          kuiPluginExternals.push(_)
+        })
+      }
+
+      if (kui.webpack.rules) {
+        if (kui.webpack.rules['file-loader']) {
+          kui.webpack.rules['file-loader'].forEach(test => {
+            kuiPluginRules.push({
+              test: new RegExp(test.replace(/(\S)\/(\S)/g, `$1\\${path.sep}$2`)),
+              use: 'file-loader'
+            })
+          })
+        }
+      }
+    }
+
+    return providedEntries
+  } catch (err) {
+    return {}
+  }
+})
+const entry = main
+console.log('entry', entry)
+
+const { productName } = require('@kui-shell/client/config.d/name.json')
+console.log(`productName=${productName}`)
+
+//
+// touch the LOCKFILE when we are done
+//
+plugins.push({
+  apply: compiler => {
+    compiler.hooks.done.tap('done', () => {
+      // touch the lockfile to indicate that we are done
+      try {
+        if (process.env.LOCKFILE) {
+          fs.closeSync(fs.openSync(process.env.LOCKFILE, 'w'))
+        }
+      } catch (err) {
+        console.error(err)
+        throw err
+      }
+    })
+  }
+})
+
+// console.log('webpack plugins', plugins)
+
+// Notes: we want to pull
+// node-pty-prebuilt-multiarch in as a commonjs external module; this
+// is because node-pty has binary bits, and we are building one set of
+// bundles for all electron platforms. If, in the future, we decide to
+// rebuild the bundles for each platform, we can remove this 'commonjs
+// node-pty...' bit, and, below, restore the `rule` pertaining to
+// node-pty (i will leave that rule in the code here, for now, though
+// commented out; just make sure to remove the commonjs bit here, and
+// uncomment the node-pty rule below, if you decide to rebuild the
+// bundles, once for each platform, in the future). The kui issue
+// covering this topic is here:
+// https://github.com/IBM/kui/issues/3381; and if you're curious about
+// the 'commonjs node-pty' syntax, see
+// https://github.com/webpack/webpack/issues/4238
+const externals = [
+  /* 'd3',
+  'elkjs',
+  'react',
+  'jquery',
+  'electron',
+  'monaco-editor',
+  '@patternfly/react-core': '',
+  '@patternfly/react-chart',
+  '@patternfly/react-table', */
+  { 'node-pty-prebuilt-multiarch': 'commonjs node-pty-prebuilt-multiarch' }
+]
+
+kuiPluginExternals.forEach(_ => {
+  externals[_] = _
+})
+
+module.exports = {
+  context: stageDir,
+  stats: {
+    // while developing, you should set this to true
+    warnings: false
+  },
+  entry,
+  target,
+  mode,
+  node: {
+    __filename: true,
+    __dirname: true
+  },
+  externals,
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js']
+  },
+  optimization,
+  module: {
+    rules: kuiPluginRules.concat([
+      // ignore commonjs bits
+      {
+        test: new RegExp(`\\${path.sep}node_modules\\${path.sep}@kui-shell\\${path.sep}\\.*\\${path.sep}dist`),
+        use: 'ignore-loader'
+      },
+      {
+        test: /\.css$/i,
+        use: 'ignore-loader'
+      },
+      {
+        test: /\.scss$/i,
+        use: 'ignore-loader'
+      },
+      {
+        test: /\.(eot)$/i,
+        use: 'ignore-loader'
+      },
+      {
+        test: /\.(ttf)$/i,
+        use: 'file-loader'
+      },
+      {
+        test: /\.(woff2?)$/i,
+        use: 'file-loader'
+      },
+
+      //
+      // typescript exclusion rules
+      { test: /\/node_modules\/typescript\//, use: 'ignore-loader' },
+      { test: /\/node_modules\/proxy-agent\//, use: 'ignore-loader' },
+      { test: /\/node_modules\/@types\//, use: 'ignore-loader' },
+      // end of typescript rules
+      { test: /\/terser\/tools/, use: 'ignore-loader' },
+      { test: /beautify-html\.js/, use: 'ignore-loader' },
+      { test: /jquery\.map/, use: 'ignore-loader' },
+      { test: /sizzle\.min\.map/, use: 'ignore-loader' },
+      { test: /\/modules\/queue-view\//, use: 'ignore-loader' },
+      { test: /\/node_modules\/proxy-agent\//, use: 'ignore-loader' },
+      // { test: /\/node_modules\/fsevents\//, use: 'ignore-loader' },
+      { test: /\/node_modules\/nan\//, use: 'ignore-loader' },
+      { test: /translation-demo\/composition.js$/, use: 'ignore-loader' },
+      { test: /\.DOCS/, use: 'ignore-loader' },
+      { test: /plugins\/*\/node_modules/, use: 'ignore-loader' },
+      { test: /packages\/*\/node_modules/, use: 'ignore-loader' },
+      // { test: /modules\/composer\/@demos\/.*\.js/, use: 'raw-loader' },
+      // DANGEROUS: some node modules must have critical files under src/: { test: /\/src\//, use: 'ignore-loader' },
+      // { test: /\/test\//, use: 'ignore-loader' },
+      { test: /AUTHORS/, use: 'ignore-loader' },
+      { test: /LICENSE/, use: 'ignore-loader' },
+      { test: /license.txt/, use: 'ignore-loader' },
+
+      // was: file-loader; but that loader does not allow for dynamic
+      // loading of markdown *content* in a browser-based client
+      { test: /\.md$/, use: 'raw-loader' },
+      { test: /\.markdown$/, use: 'raw-loader' },
+      { test: /CHANGELOG\.md$/, use: 'ignore-loader' }, // too big to pull in to the bundles
+
+      { test: /~$/, use: 'ignore-loader' },
+      { test: /Dockerfile$/, use: 'ignore-loader' },
+      { test: /flycheck*\.js/, use: 'ignore-loader' },
+      { test: /flycheck*\.d.ts/, use: 'ignore-loader' },
+      // end of ignore-loader
+      //
+      { test: /\.py$/, use: 'file-loader' },
+      { test: /\.ico$/, use: 'ignore-loader' },
+      { test: /\.jpg$/, use: 'ignore-loader' },
+      { test: /\.png$/, use: 'ignore-loader' },
+      { test: /\.svg$/, use: 'ignore-loader' },
+      { test: /\.sh$/, use: 'raw-loader' },
+      { test: /\.html$/, use: 'raw-loader' },
+      { test: /\.yaml$/, use: 'raw-loader' },
+      { test: /JSONStream\/index.js$/, use: 'shebang-loader' }
+    ])
+  },
+  plugins,
+  // stats: 'verbose',
+  output: {
+    filename: productName.toLowerCase() + '.min.js',
+    publicPath: '',
+    path: outputPath,
+    library: {
+      name: productName.toLowerCase(),
+      type: 'commonjs'
+    }
+  }
+}

--- a/plugins/plugin-client-default/src/preload.ts
+++ b/plugins/plugin-client-default/src/preload.ts
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
+import { isHeadless, inProxy } from '@kui-shell/core'
+
 /**
  * Register the welcome notebook
  *
  */
 export default async () => {
-  const { notebookVFS } = await import('@kui-shell/plugin-core-support')
-  notebookVFS.cp(
-    undefined,
-    [
-      'plugin://plugin-client-common/notebooks/welcome.json',
-      'plugin://plugin-client-common/notebooks/settings.json',
-      'plugin://plugin-client-common/notebooks/make-notebook.json'
-    ],
-    '/kui'
-  )
+  if (!isHeadless() || inProxy()) {
+    const { notebookVFS } = await import('@kui-shell/plugin-core-support')
+    notebookVFS.cp(
+      undefined,
+      [
+        'plugin://plugin-client-common/notebooks/welcome.json',
+        'plugin://plugin-client-common/notebooks/settings.json',
+        'plugin://plugin-client-common/notebooks/make-notebook.json'
+      ],
+      '/kui'
+    )
+  }
 }

--- a/plugins/plugin-core-support/src/preload.ts
+++ b/plugins/plugin-core-support/src/preload.ts
@@ -18,7 +18,7 @@ import Debug from 'debug'
 const debug = Debug('plugins/core-support/preload')
 debug('loading')
 
-import { isHeadless, PreloadRegistration } from '@kui-shell/core'
+import { isHeadless, inProxy, PreloadRegistration } from '@kui-shell/core'
 
 /**
  * This is the module
@@ -31,7 +31,10 @@ const registration: PreloadRegistration = () => {
     asyncs.push(import('./lib/cmds/zoom').then(_ => _.preload()))
   }
 
-  asyncs.push(import('./notebooks/vfs').then(_ => _.preload()))
+  if (!isHeadless() || inProxy()) {
+    asyncs.push(import('./notebooks/vfs').then(_ => _.preload()))
+  }
+
   return Promise.all(asyncs)
 }
 

--- a/plugins/plugin-kubectl-flow-views/tekton/src/plugin.ts
+++ b/plugins/plugin-kubectl-flow-views/tekton/src/plugin.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { Registrar } from '@kui-shell/core'
+import { isHeadless, inProxy, Registrar } from '@kui-shell/core'
 
 import getStep from './controller/get/step'
 import getTask from './controller/get/task'
 import preview from './controller/preview'
 
 export default async (registrar: Registrar) => {
-  return Promise.all([getStep(registrar), getTask(registrar), preview(registrar)])
+  if (!isHeadless() || inProxy()) {
+    return Promise.all([getStep(registrar), getTask(registrar), preview(registrar)])
+  }
 }


### PR DESCRIPTION
Part of #7221 

cherry-picked three commits and squash the last two into the first one. 

git cherry-pick 6de45d75d4c7591336ef17a2bfa97ada35d3cbc1
[cherrypick 3831b18e2] feat: use webpack to build headless bundles

git cherry-pick c5061c631d1fe59fe9adfdf8fbd9a9546d487b28
[cherrypick c4d37d139] fix(packages/builder): headless+webpack additional fix (CHERRY PICK WITH PRIOR COMMIT FOR MASTER)

git cherry-pick 725dbde5056eeaabea0838a5bcaef67c37c77458
[cherrypick cd833e204] fix(packages/webpack): another headless webpack fix (CHERRY PICK WITH HEADLESS WEBPACK COMMIT FOR MASTER)
