### PR TITLE
fix: update UpdateChecker to point to new kubernetes-sigs/kui repo

### DIFF
--- a/plugins/plugin-client-default/config.d/repo.json
+++ b/plugins/plugin-client-default/config.d/repo.json
@@ -1,0 +1,3 @@
+{
+  "url": "https://github.com/kubernetes-sigs/kui"
+}

--- a/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
+++ b/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
@@ -31,14 +31,23 @@ import '../../web/scss/components/UpdateChecker/_index.scss'
 
 const strings = i18n('plugin-core-support')
 
-/** Releases page */
-const RELEASE = (tag: string) => `https://github.com/IBM/kui/releases/tag/v${tag}`
+/** Default repo/org */
+const repo = 'kubernetes-sigs/kui'
 
-/** Base URL for image references */
-const baseUrl = 'https://github.com'
+/** Base URL for feeds */
+const baseUrl = () => {
+  try {
+    return require('@kui-shell/client/config.d/repo.json').url
+  } catch (err) {
+    return `https://github.com/${repo}`
+  }
+}
+
+/** Releases page */
+const RELEASE = (tag: string) => `${baseUrl()}/releases/tag/v${tag}`
 
 /** Releases feed */
-const FEED = `${baseUrl}/IBM/kui/releases.atom`
+const FEED = () => `${baseUrl()}/releases.atom`
 
 /** By default, check for updates once a day */
 const DEFAULT_INTERVAL = 24 * 60 * 60 * 1000
@@ -123,7 +132,7 @@ export default class UpdateChecker extends React.PureComponent<Props, State> {
 
   /** Ping the release feed to check for the latest release */
   private checkForUpdates() {
-    needle('get', FEED, { json: true })
+    needle('get', FEED(), { json: true })
       .then(res => {
         const entryForLatestVersion = res.body.children
           .filter(_ => _.name === 'entry')
@@ -245,7 +254,7 @@ export default class UpdateChecker extends React.PureComponent<Props, State> {
                   <Markdown
                     source={this.state.entryForLatestVersion.content}
                     contentType="text/html"
-                    baseUrl={baseUrl}
+                    baseUrl={baseUrl()}
                   />
                 </React.Fragment>
               ),


### PR DESCRIPTION
This also introduces a way for custom clients to specify their own repo. See plugin-client-default/config.d/repo.json for an example.

Fixes #7266

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
