### PR TITLE
fix(plugins/plugin-client-common): in popup mode, terminal does not s…

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Popup.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Popup.tsx
@@ -49,7 +49,7 @@ export default class Popup extends React.PureComponent<Props, State> {
       tab.REPL.qexec('window close', undefined, undefined, { tab })
     })
 
-    eventBus.onCommandComplete(tabModel.uuid, async ({ command, response }) => {
+    eventBus.onCommandComplete(tabModel.uuid, async ({ tab, command, response }) => {
       if (process.env.KUI_TEE_TO_FILE) {
         // tee the response to a file
         // maybe in the future we could do this better
@@ -59,6 +59,10 @@ export default class Popup extends React.PureComponent<Props, State> {
 
       this.setState({ promptPlaceholder: command })
       this.doFocusInput()
+
+      // see https://github.com/kubernetes-sigs/kui/issues/7268
+      setTimeout(() => tab.scrollToBottom(), 50)
+      setTimeout(() => tab.scrollToBottom(), 150)
     })
 
     this.state = {


### PR DESCRIPTION
…croll to the bottom after command execution

re: the `setTimeout` calls in this PR, unfortunately, we still have that long-standing issue where… we have an event for when a command completes, but no event for when the async rendering is done

So we still have to introduce some hacky hysteresis for cases like this.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
