### PR TITLE
fix(packages/core): core repl pipe-stage splitter fails for \ line co…

### DIFF
--- a/packages/core/src/repl/split.ts
+++ b/packages/core/src/repl/split.ts
@@ -80,7 +80,7 @@ export const _split = (
   for (let idx = startIdx; idx < endIdx; idx++) {
     let char = str.charAt(idx)
 
-    if (char === splitBy) {
+    if (splitBy === ' ' && char === splitBy) {
       if (
         process.platform === 'win32' &&
         idx < str.length - 3 &&


### PR DESCRIPTION
…ntinuations

The repl splitter has some handling for windows filepaths. We were mistakenly applying this logic when splitting by `|`

Fixes #7279

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
