### PR TITLE
fix(plugins/plugin-client-common): table drilldowns in popup act oddly

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -23,6 +23,7 @@ import {
   Row as KuiRow,
   Tab,
   REPL,
+  isPopup,
   eventBus,
   pexecInCurrentTab
 } from '@kui-shell/core'
@@ -77,7 +78,7 @@ export function onClickForCell(
       return whenNothingIsSelected((evt: React.MouseEvent) => {
         evt.stopPropagation()
         selectRow()
-        if (drilldownTo === 'side-split' && !XOR(evt.metaKey, !!process.env.KUI_SPLIT_DRILLDOWN)) {
+        if (!isPopup() && drilldownTo === 'side-split' && !XOR(evt.metaKey, !!process.env.KUI_SPLIT_DRILLDOWN)) {
           pexecInCurrentTab(`split --ifnot is-split --cmdline "${handler}"`, undefined, false, true)
         } else {
           repl.pexec(handler, opts)


### PR DESCRIPTION
This PR updates table drilldowns in popup mode always to send to the current split. In the future, we may decide to change the UX, but at least this PR fixes the glaring bug that we have right now: in popup mode, table drilldowns open a new split, but the drilldown is nonetheless still sent to the current split.

Fixes #7287 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
