### PR TITLE
feat(packages/core): allow headless tasks to pop up windows and still…

### DIFF
--- a/packages/core/src/main/headless.ts
+++ b/packages/core/src/main/headless.ts
@@ -342,7 +342,7 @@ export function initHeadless(argv: string[], force = false, isRunningHeadless = 
             // craft a createWindow that has a first argument of true, which will indicate `noHeadless`
             // because this will be called for cases where we want a headless -> GUI transition
             const { createWindow: createElectronWindow } = await import('./spawn-electron')
-            return createElectronWindow(true, executeThisArgvPlease, subwindowPlease, subwindowPrefs)
+            return createElectronWindow(true, executeThisArgvPlease, subwindowPlease, subwindowPrefs, false, true)
           }
         },
         argv,

--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -105,7 +105,8 @@ export function createWindow(
   executeThisArgvPlease?: string[],
   subwindowPlease?: boolean,
   subwindowPrefs?: ISubwindowPrefs,
-  secondary = false
+  secondary = false,
+  isForPopup = false
 ) {
   debug('createWindow', executeThisArgvPlease)
 
@@ -137,7 +138,7 @@ export function createWindow(
     debug('we need to spawn electron', subwindowPlease, subwindowPrefs)
     delete subwindowPrefs.synonymFor // circular JSON
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    promise = initElectron(['--'].concat(executeThisArgvPlease), {}, subwindowPlease, subwindowPrefs)
+    promise = initElectron(['--'].concat(executeThisArgvPlease), {}, subwindowPlease, subwindowPrefs, isForPopup)
       .then(async () => {
         app = (await import('electron')).app as App
       })
@@ -533,7 +534,8 @@ export async function initElectron(
   command: string[] = [],
   { isRunningHeadless = false } = {},
   subwindowPlease?: boolean,
-  subwindowPrefs?: ISubwindowPrefs
+  subwindowPrefs?: ISubwindowPrefs,
+  isForPopup = false
 ) {
   debug('initElectron', command, subwindowPlease, subwindowPrefs)
 
@@ -581,7 +583,9 @@ export async function initElectron(
       }
 
       debug('spawning electron done, this process will soon exit')
-      process.exit(0)
+      if (!isForPopup) {
+        process.exit(0)
+      }
     }
   } else {
     debug('loading electron')


### PR DESCRIPTION
… continue

This PR allows headless tasks to pop open graphical windows and have Kui only exit once the headless task otherwise completes. Prior to this PR, the headless Kui would exit immediately after the window was opened.

Fixes #7289

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
