### PR TITLE
fix(packages/core): after opening window from headless, console outpu…

### DIFF
--- a/packages/core/src/main/headless-pretty-print.ts
+++ b/packages/core/src/main/headless-pretty-print.ts
@@ -67,8 +67,11 @@ const colorMap: Record<string, ColorFunction> = {
 }
 
 let graphicalShellIsOpen = false
+let graphicalShellIsPopup = false
 /** @return whether the state has changed as a result of this call */
-export const setGraphicalShellIsOpen = () => {
+export const setGraphicalShellIsOpen = (isPopup: boolean) => {
+  graphicalShellIsPopup = isPopup
+
   if (!graphicalShellIsOpen) {
     graphicalShellIsOpen = true
     return true
@@ -352,7 +355,7 @@ export const print = (
   if (ok === 'error') {
     colorFn = colors.red
   }
-  if (msg && !graphicalShellIsOpen) {
+  if (msg && (!graphicalShellIsOpen || graphicalShellIsPopup)) {
     try {
       if (msg === true) {
         // true is the graphical shell's way of telling the repl to print 'ok'

--- a/packages/core/src/main/headless.ts
+++ b/packages/core/src/main/headless.ts
@@ -173,11 +173,16 @@ type CreateWindowFunction = (commandLine: string[], subwindowPlease: boolean, su
  *
  */
 let electronCreateWindowFn: CreateWindowFunction
-export const createWindow = async (argv: string[], subwindowPlease: boolean, subwindowPrefs: ISubwindowPrefs) => {
+export const createWindow = async (
+  argv: string[],
+  subwindowPlease: boolean,
+  subwindowPrefs: ISubwindowPrefs,
+  isPopup: boolean
+) => {
   try {
     graphicalShellIsOpen = true
     const { setGraphicalShellIsOpen } = await import('./headless-pretty-print')
-    if (!setGraphicalShellIsOpen()) {
+    if (!setGraphicalShellIsOpen(isPopup)) {
       debug('probably a bug somewhere; detected loop in opening window from headless mode')
       return
     }

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -362,7 +362,7 @@ class InProcessExecutor implements Executor {
         ((process.env.DEFAULT_TO_UI && !parsedOptions.cli) || (evaluator.options && evaluator.options.needsUI))
       ) {
         import('../main/headless').then(({ createWindow }) =>
-          createWindow(argv, evaluator.options.fullscreen, evaluator.options)
+          createWindow(argv, evaluator.options.fullscreen, evaluator.options, true)
         )
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (true as any) as T


### PR DESCRIPTION
…t stops

This PR refines the `!graphicalShellIsOpen` guard to recognize that we have just opened a popup window.

Fixes #7291

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
