### PR TITLE
feat(packages/core): allow controllers to stream to stderr

### DIFF
--- a/packages/core/src/main/headless-support.ts
+++ b/packages/core/src/main/headless-support.ts
@@ -27,25 +27,26 @@ import { Streamable } from '../models/streamable'
  * @see cli.ts for the webapp implementation
  *
  */
-export const streamTo = async () => {
+export const streamTo = async (which: 'stdout' | 'stderr') => {
   const [{ clearLine, cursorTo }, { print }] = await Promise.all([
     import('readline'),
     import('./headless-pretty-print')
   ])
 
+  const stdout = process[which]
   return (response: Streamable, killLine?: boolean) => {
     debug('streaming response', killLine)
 
     if (killLine) {
-      clearLine(process.stdout, 0)
-      cursorTo(process.stdout, 0, null)
+      clearLine(stdout, 0)
+      cursorTo(stdout, 0, null)
     }
 
-    print(response)
+    print(response, which === 'stdout' ? console.log : console.error, process[which])
 
     if (!killLine) {
       if (typeof response !== 'string' || !/\n$/.test(response)) {
-        process.stdout.write('\n')
+        stdout.write('\n')
       }
     }
 

--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -185,6 +185,11 @@ export interface EvaluatorArgs<Options = ParsedOptions> extends CommandLine<Opti
   createOutputStream: StreamableFactory
 
   /**
+   * Same as createOutputStream, but for stderr
+   */
+  createErrorStream: StreamableFactory
+
+  /**
    * EXPERT MODE: The REPL block in which this command was initiated
    * (rarely used, but useful for more complex UI extensions)
    */

--- a/packages/core/src/models/execOptions.ts
+++ b/packages/core/src/models/execOptions.ts
@@ -85,6 +85,7 @@ export interface ExecOptions {
   showHeader?: boolean
   alreadyWatching?: boolean
 
+  createErrorStream?: StreamableFactory
   createOutputStream?: StreamableFactory
   stdout?: (str: Streamable) => any // eslint-disable-line @typescript-eslint/no-explicit-any
   stderr?: (str: string) => any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -449,7 +449,8 @@ class InProcessExecutor implements Executor {
         argvNoOptions,
         pipeStages,
         parsedOptions: parsedOptions as O,
-        createOutputStream: execOptions.createOutputStream || (() => this.makeStream(getTabId(tab), execUUID))
+        createErrorStream: execOptions.createErrorStream || (() => this.makeStream(getTabId(tab), execUUID, 'stderr')),
+        createOutputStream: execOptions.createOutputStream || (() => this.makeStream(getTabId(tab), execUUID, 'stdout'))
       }
 
       let response: T | Promise<T> | MixedResponse
@@ -555,10 +556,10 @@ class InProcessExecutor implements Executor {
     }
   }
 
-  private async makeStream(tabUUID: string, execUUID: string): Promise<Stream> {
+  private async makeStream(tabUUID: string, execUUID: string, which: 'stdout' | 'stderr'): Promise<Stream> {
     if (isHeadless()) {
       const { streamTo: headlessStreamTo } = await import('../main/headless-support')
-      return headlessStreamTo()
+      return headlessStreamTo(which)
     } else {
       const stream = (response: Streamable) =>
         new Promise<void>(resolve => {


### PR DESCRIPTION
This PR adds `createErrorStream()` to go alongside the existing `createOutputStream()`

Fixes #7293

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
