### PR TITLE
fix(plugins/plugin-kubectl): client can't modify the styles of CurrentNamespace and CurrentContext widget via classname

### DIFF
--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -38,6 +38,10 @@ import {
   offKubectlConfigChangeEvents
 } from '@kui-shell/plugin-kubectl'
 
+interface Props {
+  className?: string
+}
+
 interface State {
   currentContext: string
   allContexts: KubeContext[]
@@ -61,10 +65,10 @@ function KubernetesIcon() {
   )
 }
 
-export default class CurrentContext extends React.PureComponent<{}, State> {
+export default class CurrentContext extends React.PureComponent<Props, State> {
   private readonly handler = this.reportCurrentContext.bind(this)
 
-  public constructor(props = {}) {
+  public constructor(props: Props) {
     super(props)
 
     this.state = {
@@ -242,6 +246,7 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
 
     return (
       <TextWithIconWidget
+        className={this.props.className}
         text={this.state.currentContext}
         viewLevel={this.state.viewLevel}
         id="kui--plugin-kubeui--current-context"

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -41,6 +41,10 @@ import {
 
 import { isInternalNamespace } from '@kui-shell/plugin-kubectl/heuristics'
 
+interface Props {
+  className?: string
+}
+
 interface State {
   currentNamespace: string
   allNamespaces: string[]
@@ -49,10 +53,10 @@ interface State {
 
 const strings = i18n('plugin-kubectl')
 
-export default class CurrentNamespace extends React.PureComponent<{}, State> {
+export default class CurrentNamespace extends React.PureComponent<Props, State> {
   private readonly handler = this.reportCurrentNamespace.bind(this)
 
-  public constructor(props = {}) {
+  public constructor(props: Props) {
     super(props)
 
     this.state = {
@@ -236,6 +240,7 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
 
     return (
       <TextWithIconWidget
+        className={this.props.className}
         text={this.state.currentNamespace}
         viewLevel={this.state.viewLevel}
         id="kui--plugin-kubeui--current-namespace"


### PR DESCRIPTION
Fixes #7295 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
