### PR TITLE
fix: invoking a non-popup window from headless kui will have incorrect uuid for splits

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -65,9 +65,6 @@ export type Props = Partial<KuiConfiguration> &
     /** Elements to place between TabContainer and StatusStripe */
     toplevel?: React.ReactNode | React.ReactNode[]
 
-    /** Operate in popup mode? */
-    isPopup?: boolean
-
     /** do not echo the command? */
     quietExecCommand?: boolean
 

--- a/plugins/plugin-client-common/src/components/Client/props/FeatureFlags.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/FeatureFlags.ts
@@ -24,6 +24,9 @@ type FeatureFlags = {
   /** [Optional] Enable Split Terminals? */
   splitTerminals?: boolean
 
+  /** Operate in popup mode? */
+  isPopup?: boolean
+
   /** [Optional] automatically pin watchable command ouptut to the WatchPane? */
   enableWatcherAutoPin?: boolean
 

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -367,7 +367,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
   }
 
   private allocateUUIDForScrollback() {
-    if (this.props.config.splitTerminals && !isPopup()) {
+    if (this.props.config.splitTerminals && !this.props.config.isPopup) {
       // this.props.uuid is the uuid for the whole tab
       // on top of that, we allocate a "v5" uuid for this scrollback
       const sbidx = this.scrollbackCounter++

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c-via-table.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c-via-table.ts
@@ -29,7 +29,7 @@ const inputEncoded = inputBuffer.toString('base64')
 /** The number of seconds to sleep while we wait for more log entries
  * to accumulate. Making this value larger will provide more test
  * stability, but also increase test time. */
-const sleepTime = 4
+const sleepTime = 12
 
 function getTextContent(app: Application, selector: string) {
   return app.client.$(selector).then(_ => _.getText())

--- a/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec-vi.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec-vi.ts
@@ -94,6 +94,11 @@ describe(`kubectl exec vi ${process.env.MOCHA_RUN_TARGET || ''}`, function(this:
         return this.app.client.$(lastRowSelector).then(_ => _.getText())
       }
 
+      sleep(3)
+
+      // click the sidecar tab content
+      await this.app.client.$(focusArea).then(_ => _.click())
+
       // wait for vi to come up
       await this.app.client.waitUntil(
         async () => {
@@ -102,8 +107,6 @@ describe(`kubectl exec vi ${process.env.MOCHA_RUN_TARGET || ''}`, function(this:
         },
         { timeout: CLI.waitTimeout }
       )
-
-      sleep(3)
 
       // enter insert mode, and wait for INSERT to appear at the bottom
       let iter = 0


### PR DESCRIPTION
Fixes #7303

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
