### PR TITLE
fix(plugins/plugin-client-common): disable minisplit

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -1164,16 +1164,17 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
    * which indicates whether the given scrollback index is a
    * minisplit.
    *
+   * NOTE: minsplits are disable for now; see: https://github.com/kubernetes-sigs/kui/issues/7307
    */
   private readonly theseAreMiniSplits = {
     1: [false], // 1 split, not-minisplit
     2: [false, false], // 2 splits, both not-minisplit
-    3: [true, true, false], // etc.
-    4: [true, true, false, false],
-    5: [true, true, true, false, false],
-    6: [true, true, true, false, false, false],
-    7: [true, true, false, true, true, false, false],
-    8: [true, true, true, true, true, true, true, false]
+    3: [false, false, false], // etc.
+    4: [false, false, false, false],
+    5: [false, false, false, false, false],
+    6: [false, false, false, false, false, false],
+    7: [false, false, false, false, false, false, false],
+    8: [false, false, false, false, false, false, false, false]
   }
 
   /**

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout.scss
@@ -57,18 +57,18 @@
 .kui--terminal-split-container {
   /* two terminals */
   &[data-split-count='2'] {
-    @include Rows(2);
+    @include Rows(1);
     @include Columns(2);
-    grid-template-areas:
-      'T1 T2'
-      'T1 T2';
+    grid-template-areas: 'T1 T2';
   }
 
   /* three terminals */
   &[data-split-count='3'] {
-    @include Rows(3);
+    @include Rows(5);
     @include Columns(2);
     grid-template-areas:
+      'T1 T2'
+      'T1 T2'
       'T1 T2'
       'T3 T3'
       'T3 T3';
@@ -76,12 +76,11 @@
 
   /* four terminals */
   &[data-split-count='4'] {
-    @include Rows(3);
-    @include Columns(4);
+    @include Rows(2);
+    @include Columns(2);
     grid-template-areas:
-      'T1 T1 T2 T2'
-      'T3 T3 T4 T4'
-      'T3 T3 T4 T4';
+      'T1 T2'
+      'T3 T4';
   }
 
   /* five terminals */


### PR DESCRIPTION
Fixes #7307 

This PR also changed the layout of 3 and 4 splits:
![Screen Shot 2021-04-16 at 4 39 51 PM](https://user-images.githubusercontent.com/21212160/115081502-603f1600-9ed2-11eb-856f-b0113907f0ea.png)

![Screen Shot 2021-04-16 at 4 40 03 PM](https://user-images.githubusercontent.com/21212160/115081517-66cd8d80-9ed2-11eb-8744-fdcf0bb0fd94.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
