### PR TITLE
test: temporarily disable to highly unstable tests

### DIFF
--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c-via-table.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c-via-table.ts
@@ -40,9 +40,7 @@ function sleep(N: number) {
   return new Promise(resolve => setTimeout(resolve, N * 1000))
 }
 
-const wdescribe = !process.env.USE_WATCH_PANE ? describe : xdescribe
-
-wdescribe(`kubectl logs dashC follow via table ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+xdescribe(`kubectl logs dashC follow via table ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
 

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-f-via-table.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-f-via-table.ts
@@ -40,9 +40,7 @@ function sleep(N: number) {
   return new Promise(resolve => setTimeout(resolve, N * 1000))
 }
 
-const wdescribe = !process.env.USE_WATCH_PANE ? describe : xdescribe
-
-wdescribe(`kubectl logs follow via table ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+xdescribe(`kubectl logs follow via table ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
 

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-tab-previous.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-tab-previous.ts
@@ -34,7 +34,7 @@ if (process.env.NEEDS_OC) {
 }
 
 commands.forEach(command => {
-  describe(`${command} Logs previous tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  xdescribe(`${command} Logs previous tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
     before(Common.before(this))
     after(Common.after(this))
 

--- a/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec-vi.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec-vi.ts
@@ -31,7 +31,7 @@ function sleep(N: number) {
   return new Promise(resolve => setTimeout(resolve, N * 1000))
 }
 
-describe(`kubectl exec vi ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+xdescribe(`kubectl exec vi ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
 


### PR DESCRIPTION
Until we can figure out what is going on, we will disable these tests. Local testing, on macOS and Linux, shows high stability. So we are not sure at all what is going on, yet. Or why they all of the sudden lost stability.

part of #7309

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
