### PR TITLE
fix(packages/webpack): not possible to build development webpack bund…

### DIFF
--- a/packages/webpack/build.sh
+++ b/packages/webpack/build.sh
@@ -67,11 +67,11 @@ function webpack {
 
     if [ -n "$KUI_HEADLESS_WEBPACK" ]; then
         echo "Building headless bundles via webpack"
-        npx --no-install webpack-cli --config ./node_modules/@kui-shell/webpack/headless-webpack.config.js  --mode=production &
+        npx --no-install webpack-cli --config ./node_modules/@kui-shell/webpack/headless-webpack.config.js --mode=$MODE &
     fi
 
     echo "Building electron bundles via webpack"
-    npx --no-install webpack-cli --config ./node_modules/@kui-shell/webpack/webpack.config.js --mode production
+    npx --no-install webpack-cli --config ./node_modules/@kui-shell/webpack/webpack.config.js --mode $MODE
 
     wait
 


### PR DESCRIPTION
…les with kui-build-webpack

part of #7328

With this PR, you should be able to set the env var `MODE=development npx kui-build-webpack`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
