### PR TITLE
feat(packages/builder): add support for macOS signing and notarizatio…

### DIFF
--- a/packages/builder/dist/electron/builders/entitlements.plist
+++ b/packages/builder/dist/electron/builders/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
…n to electron builders

Requires three environment variables:

1) The name of your keychain entry for your signing certificate
OSX_SIGNING_IDENTITY='Developer ID Application: Your Name (xxx1xxx1xx)'

2) Your appleID
APPLEID=<you>@mac.com

3) An app-specific password:
APPLEID_PASSWORD=xxx

4) Your team short name
ASC_PROVIDER=xxx

5) Your app's bundleID
APP_BUNDLE_ID=xxx

part of #7336

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
