### PR TITLE
fix(plugins/plugin-bash-like): VFS mount promise may fire before the …

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -187,8 +187,8 @@ export function mount(vfs: VFS | VFSProducingFunction, placeholderMountPath?: st
                 if (!debounce) {
                   debounce = true
                   await mountAll(tab, vfs)
+                  resolve(undefined)
                 }
-                resolve(undefined)
               } catch (err) {
                 console.error('Error in mount 1', err)
                 reject(err)


### PR DESCRIPTION
…mounting is actually done

The fix is to move the `resolve()` to be under the debounce guard. This way, only the winner of the debounce resolves the promise. Before this fix, the second-place finisher would not do the mount (within the debounce guard) but *would* resolve the promise. Nice.

Fixes #7346

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
