### PR TITLE
feat(plugins/plugin-client-common): export the command line rendering…

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,6 +142,7 @@ export { PluginRegistration, PreloadRegistration, PreloadRegistrar } from './mod
 // REPL utils
 export { default as REPL } from './models/repl'
 export { split, _split, Split } from './repl/split'
+export { splitIntoPipeStages } from './repl/pipe-stages'
 export { ReplEval, DirectReplEval } from './repl/types'
 export { default as encodeComponent } from './repl/encode'
 export { exec as internalBeCarefulExec, pexec as internalBeCarefulPExec, setEvaluatorImpl, doEval } from './repl/exec'

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/FancyPipeline.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/FancyPipeline.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+import { Arguments } from '@kui-shell/core'
+
+type Props = Pick<Arguments['pipeStages'], 'prefix' | 'stages' | 'redirect'> & Pick<Arguments, 'REPL'>
+
+export default class FancyPipeline extends React.PureComponent<Props> {
+  private linebreak() {
+    return <span className="kui--line-break">&nbsp;</span>
+  }
+
+  private pipe(c: string) {
+    return <strong className="pre-wrap left-pad sub-text">{c} </strong>
+  }
+
+  /**
+   * Pretty-print the command line with `pipeStages`
+   * e.g. somePrefix -- foo | bar > baz
+   */
+  public render() {
+    const { prefix, stages, redirect, REPL } = this.props
+
+    return (
+      <span className="repl-input-element flex-fill">
+        {/* somePrefix -- */}
+        {prefix && (
+          <React.Fragment>
+            <span className="pre-wrap">prefix -- </span>
+            {(stages.length > 0 || redirect) && (
+              <React.Fragment>
+                {this.linebreak()}
+                {this.pipe('\u00a0')}
+              </React.Fragment>
+            )}
+          </React.Fragment>
+        )}
+
+        {/* bar | baz */}
+        {stages.map((pipePart, pidx, parts) => (
+          <React.Fragment key={pidx}>
+            {pidx > 0 && this.pipe('|')}
+            {pipePart.map((word, widx) =>
+              widx === 0 ? (
+                <span key={widx} className="color-base0D">
+                  {word}
+                </span>
+              ) : (
+                ` ${word}`
+              )
+            )}
+            {pidx < parts.length - 1 && this.linebreak()}
+          </React.Fragment>
+        ))}
+        {redirect && (
+          <React.Fragment>
+            {this.linebreak()}
+            {this.pipe('>')}
+            <span className="clickable" onClick={() => REPL.pexec(`ls ${redirect}`)}>
+              {redirect}
+            </span>
+          </React.Fragment>
+        )}
+      </span>
+    )
+  }
+}

--- a/plugins/plugin-client-common/src/index.ts
+++ b/plugins/plugin-client-common/src/index.ts
@@ -70,6 +70,7 @@ export {
 export { default as defaultOnKeyDown } from './components/Views/Terminal/Block/OnKeyDown'
 export { default as defaultOnKeyPress } from './components/Views/Terminal/Block/OnKeyPress'
 export { onKeyUp as defaultOnKeyUp } from './components/Views/Terminal/Block/ActiveISearch'
+export { default as FancyPipeline } from './components/Views/Terminal/Block/FancyPipeline'
 
 // spi
 export { default as Icons } from './components/spi/Icons'


### PR DESCRIPTION
… component

This PR introduces a component to render bash pipelines

```jsx
import { FancyPipeline } from '@kui-shell/plugin-client-common'
<FancyPipeline prefix={...} stages={...} redirect={...} REPL={...} />
```

where the prefix, stages, and redirect can be had from the `splitIntoPipeStages` exported interface of `@kui-shell/core`

Fixes #7365

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
