### PR TITLE
fix(plugins/plugin-kubectl): redirection of output on a get resource command is ignored

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
@@ -115,6 +115,9 @@ export async function doExecWithPty<
       args.execOptions.echo = false // do not even echo "ok"
     }
 
+    // let pty handle redirection
+    args.execOptions.noCoreRedirect = true
+
     return args.REPL.qexec<string | Response>(
       `sendtopty ${commandToPTY}`,
       args.block,
@@ -189,7 +192,7 @@ export async function exec<O extends KubeOptions>(
   prepare: Prepare<O> = NoPrepare,
   exec = 'kubectl'
 ): Promise<RawResponse> {
-  if (args.argvNoOptions.includes('|')) {
+  if (args.argvNoOptions.includes('|') || args.argvNoOptions.includes('>') || args.argvNoOptions.includes('>>')) {
     return Promise.resolve({
       content: {
         code: 0,

--- a/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
@@ -55,7 +55,8 @@ export function flags(booleans: string[] = []): CommandOptions {
       narg: { w: 0, watch: 0, 'watch-only': 0 },
       string: ['_'], // enforce positional arguments to be parsed as string
       boolean: booleans.concat(defaultBooleans)
-    }
+    },
+    noCoreRedirect: true
   }
 }
 

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -268,6 +268,8 @@ async function rawGet(
   if (
     (command === 'oc' || command === 'kubectl') &&
     !args.argvNoOptions.includes('|') &&
+    !args.argvNoOptions.includes('>') &&
+    !args.argvNoOptions.includes('>>') &&
     !requestWithoutKind &&
     !args.parsedOptions.context &&
     !args.parsedOptions.kubeconfig
@@ -457,7 +459,7 @@ function viewTransformerForGet(args: Arguments<KubeOptions>, response: KubeResou
   }
 }
 
-export const getFlags = Object.assign({}, flags, { viewTransformer: viewTransformerForGet })
+export const getFlags = Object.assign({}, flags, { viewTransformer: viewTransformerForGet, noCoreRedirect: true })
 
 /** Register a command listener */
 export function getter(registrar: Registrar, command: string, cli = command) {

--- a/plugins/plugin-kubectl/src/test/k8s4/get-redirect.ts
+++ b/plugins/plugin-kubectl/src/test/k8s4/get-redirect.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect } from '@kui-shell/test'
+import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+
+const commands = ['kubectl']
+if (process.env.NEEDS_OC) {
+  commands.push('oc')
+}
+
+describe('kubectl get redirect', function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const ns: string = createNS()
+  const testFile = '/tmp/testredirect'
+
+  allocateNS(this, ns)
+
+  function grepInTestFile(ctx: Common.ISuite, str: string) {
+    it(`should grep ${str} in the test file`, async () =>
+      CLI.command(`grep "${str}" ${testFile}`, ctx.app)
+        .then(ReplExpect.okWithString(str))
+        .catch(Common.oops(ctx, true)))
+  }
+
+  commands.forEach(kubectl => {
+    it(`should get namespace yaml and redirect to a file`, async () =>
+      CLI.command(`${kubectl} get namespace ${ns} -o yaml > ${testFile}`, this.app)
+        .then(ReplExpect.justOK)
+        .catch(Common.oops(this, true)))
+
+    grepInTestFile(this, `name: ${ns}`)
+
+    it(`should get namespace table and append result to the test file`, async () =>
+      CLI.command(`${kubectl} get namespace ${ns} >> ${testFile}`, this.app)
+        .then(ReplExpect.justOK)
+        .catch(Common.oops(this, true)))
+
+    grepInTestFile(this, `name: ${ns}`)
+    grepInTestFile(this, 'AGE')
+
+    it('should remove the test file', () =>
+      CLI.command(`rm -f ${testFile}`, this.app)
+        .then(ReplExpect.ok)
+        .catch(Common.oops(this, true)))
+  })
+
+  deleteNS(this, ns)
+})


### PR DESCRIPTION
Fixes #7406 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
