### PR TITLE
fix(plugins/plugin-kubectl): --kubeconfig path in commands are not always expanded

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/options.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Arguments, ExecOptions, ParsedOptions } from '@kui-shell/core'
+import { Arguments, ExecOptions, expandHomeDir, ParsedOptions } from '@kui-shell/core'
 
 import { FinalState } from '../../lib/model/states'
 import { getCurrentDefaultNamespace } from './contexts'
@@ -316,7 +316,7 @@ export function withKubeconfigFrom(args: Pick<Arguments<KubeOptions>, 'parsedOpt
   let extras = ' '
 
   if (args.parsedOptions.kubeconfig && !/--kubeconfig/.test(cmdline)) {
-    extras += ` --kubeconfig ${args.parsedOptions.kubeconfig}`
+    extras += ` --kubeconfig ${expandHomeDir(args.parsedOptions.kubeconfig)}`
   }
 
   if (args.parsedOptions.context && !/--context/.test(cmdline)) {


### PR DESCRIPTION
Fixes #7363 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
