### PR TITLE
fix(plugins/plugin-kubectl): tab state manager shoud not log "command not found" errors for systems without kubectl

### DIFF
--- a/plugins/plugin-kubectl/src/tab-state.ts
+++ b/plugins/plugin-kubectl/src/tab-state.ts
@@ -60,7 +60,9 @@ async function capture(tabState: TabState) {
 
       debug('captured tab state', tab.uuid, currentContext, currentNamespace)
     } catch (err) {
-      console.error(`plugin-kubectl: failed to capture tab-state`, err, tabState)
+      if (!/command not found/.test(err)) {
+        console.error(`plugin-kubectl: failed to capture tab-state`, err, tabState)
+      }
 
       // clear state
       setTabState(tabState, 'context', '')
@@ -86,7 +88,9 @@ async function restore(tabState: TabState) {
 
     debug('restored tab state', tab.uuid, context, namespace)
   } catch (err) {
-    console.error(`plugin-kubectl: failed to restore tab-state`, err, tabState)
+    if (!/command not found/.test(err)) {
+      console.error(`plugin-kubectl: failed to restore tab-state`, err, tabState)
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #7416 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
