### PR TITLE
feat(packages/webpack): when building a headless bundle set via webpa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -674,7 +674,8 @@
         "util": "0.12.3",
         "webpack": "5.35.0",
         "webpack-cli": "4.6.0",
-        "webpack-dev-server": "3.11.2"
+        "webpack-dev-server": "3.11.2",
+        "zip-webpack-plugin": "4.0.1"
       },
       "dependencies": {
         "buffer": {
@@ -14897,6 +14898,15 @@
         "fd-slicer": "~1.1.0"
       }
     },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -14925,6 +14935,15 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "zip-webpack-plugin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/zip-webpack-plugin/-/zip-webpack-plugin-4.0.1.tgz",
+      "integrity": "sha512-G041Q4qUaog44Ynit6gs4o+o3JIv0WWfOLvc8Q3IxvPfuqd2KBHhpJWAXUB9Cm1JcWHTIOp9vS3oGMWa1p1Ehw==",
+      "dev": true,
+      "requires": {
+        "yazl": "^2.5.1"
       }
     },
     "zwitch": {

--- a/packages/webpack/headless-webpack.config.js
+++ b/packages/webpack/headless-webpack.config.js
@@ -22,6 +22,9 @@ const target = process.env.HEADLESS_TARGET || 'node'
 const TerserJSPlugin = require('terser-webpack-plugin')
 const { IgnorePlugin } = require('webpack')
 
+// this lets us create a headless.zip file
+const ZipPlugin = require('zip-webpack-plugin')
+
 // in case the client has some oddities that require classnames to be preserved
 const terserOptions = process.env.KEEP_CLASSNAMES
   ? {
@@ -153,6 +156,15 @@ plugins.push({
     })
   }
 })
+
+// zip after emit, so we get a dist/headless.zip
+plugins.push(
+  new ZipPlugin({
+    filename: 'headless.zip', // ZipPlugin by default names it based on the name of the main bundle
+    path: '..', // ZipPlugin seems to treat this as relative to the output path specified below
+    include: /.*/ // ZipPlugin by default only includes the main bundle file
+  })
+)
 
 // console.log('webpack plugins', plugins)
 

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -68,7 +68,8 @@
     "util": "0.12.3",
     "webpack": "5.35.0",
     "webpack-cli": "4.6.0",
-    "webpack-dev-server": "3.11.2"
+    "webpack-dev-server": "3.11.2",
+    "zip-webpack-plugin": "4.0.1"
   },
   "kui": {
     "headless": false,


### PR DESCRIPTION
…ck, also create a zip file

This PR adds zip-webpack-plugin to the headless bundle builder. This has no effect on electron or browser-based builds.

Fixes #7427

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
