### PR TITLE
fix(plugins/plugin-client-common): clicking on YAML tab incorrectly s…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Eval.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Eval.tsx
@@ -33,11 +33,13 @@ import { Loading } from '../../'
 import KuiMMRContent, { KuiMMRProps } from './KuiContent'
 
 interface EvalProps extends Omit<KuiMMRProps, 'mode'> {
+  execUUID: string
   command: string | FunctionThatProducesContent
   contentType?: SupportedStringContent
 }
 
 interface EvalState {
+  execUUID: string
   isLoading: boolean
   command: string | FunctionThatProducesContent
   react: ReactProvider
@@ -63,17 +65,24 @@ interface EvalState {
 export default class Eval extends React.PureComponent<EvalProps, EvalState> {
   public constructor(props: EvalProps) {
     super(props)
-
-    this.state = {
-      isLoading: true,
-      command: props.command,
-      react: undefined,
-      spec: undefined,
-      content: undefined,
-      contentType: props.contentType
-    }
-
+    this.state = Eval.getDerivedStateFromProps(props)
     this.startLoading()
+  }
+
+  public static getDerivedStateFromProps(props: EvalProps, state?: EvalState) {
+    if (!state || state.execUUID !== props.execUUID) {
+      return {
+        execUUID: props.execUUID,
+        isLoading: true,
+        command: props.command,
+        react: undefined,
+        spec: undefined,
+        content: undefined,
+        contentType: props.contentType
+      }
+    } else {
+      return state
+    }
   }
 
   private startLoading() {

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -61,36 +61,20 @@ export type KuiMMRProps = ToolbarProps & {
 
 interface State {
   mode: Content
-  isRendered: boolean
+  execUUID: string
 }
 
-export default class KuiContent extends React.Component<KuiMMRProps, State> {
+export default class KuiContent extends React.PureComponent<KuiMMRProps, State> {
   public constructor(props: KuiMMRProps) {
     super(props)
-
-    this.state = {
-      mode: props.mode,
-      isRendered: false
-    }
+    this.state = KuiContent.getDerivedStateFromProps(props)
   }
 
-  public static getDerivedStateFromProps(props: KuiMMRProps, state: State) {
-    if (state && state.isRendered && state.mode === props.mode) {
-      return state
+  public static getDerivedStateFromProps(props: KuiMMRProps, state?: State) {
+    if (!state || state.mode !== props.mode || state.execUUID !== props.execUUID) {
+      return Object.assign(state || {}, { mode: props.mode, execUUID: props.execUUID })
     } else {
-      return Object.assign(state || {}, { isRendered: false, mode: props.mode })
-    }
-  }
-
-  public shouldComponentUpdate(nextProps: KuiMMRProps) {
-    return nextProps.isActive && (!this.state || !this.state.isRendered)
-  }
-
-  public componentDidUpdate() {
-    if (this.props.isActive) {
-      this.setState({
-        isRendered: true
-      })
+      return state
     }
   }
 
@@ -148,9 +132,11 @@ export default class KuiContent extends React.Component<KuiMMRProps, State> {
         />
       )
     } else if (isCommandStringContent(mode)) {
-      return <Eval {...this.props} command={mode.contentFrom} contentType={mode.contentType} />
+      const key = `${mode.contentFrom} ${mode.contentType}`
+      return <Eval {...this.props} key={key} command={mode.contentFrom} contentType={mode.contentType} />
     } else if (isFunctionContent(mode)) {
-      return <Eval {...this.props} command={mode.content} />
+      const command = mode.content
+      return <Eval {...this.props} key={command.toString()} command={command} />
     } else if (isScalarContent(mode)) {
       if (isReactProvider(mode)) {
         return mode.react({ willUpdateToolbar })


### PR DESCRIPTION
…hows "You are in edit mode" even if you aren't

This fix involves a bug fix to Editor/index.tsx. We were calling `willUpdateToolbar()` for the first content, which resulted in (sometimes) showing a "you just modified" message in the sidecar toolbar text.
Fixes #7426

This PR also fixes a few paths that would result in double-rendering of the sidecar content (including the editor). Hopefully this will eliminate any chance for future races of this nature.
Fixes #7385

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
