### PR TITLE
fix(plugins/plugin-bash-like): on windows ls with no arguments results in Cannot read property 'replace' of undefined

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
@@ -16,7 +16,7 @@
 
 import Debug from 'debug'
 import { basename } from 'path'
-import { Arguments, CodedError, flatten } from '@kui-shell/core'
+import { Arguments, CodedError, cwd, flatten } from '@kui-shell/core'
 import { DirEntry, VFS, absolute, findMount, multiFindMount, findMatchingMounts } from '.'
 
 const debug = Debug('plugin/bash-like/fs/vfs/delegates')
@@ -105,7 +105,7 @@ async function lsMounts(path: string): Promise<DirEntry[]> {
  *
  */
 export async function ls(...parameters: Parameters<VFS['ls']>): Promise<DirEntry[]> {
-  const filepaths = parameters[1].length === 0 ? [process.env.PWD] : parameters[1].map(absolute)
+  const filepaths = parameters[1].length === 0 ? [cwd()] : parameters[1].map(absolute)
 
   const mounts = await multiFindMount(filepaths, true)
   const vfsContentP = Promise.all(


### PR DESCRIPTION
Fixes #7430 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
