### PR TITLE
fix(plugins/plugin-bash-like): stop resolve to absolute path in fstat and fslice

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/fstat.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/fstat.ts
@@ -16,7 +16,7 @@
 
 import { readFile, stat } from 'fs'
 
-import { Arguments, ParsedOptions, CodedError, findFileWithViewer, expandHomeDir } from '@kui-shell/core'
+import { Arguments, ParsedOptions, CodedError, expandHomeDir } from '@kui-shell/core'
 
 export interface FStat {
   viewer: string
@@ -53,7 +53,8 @@ export const fstat = ({
   parsedOptions
 }: Pick<Arguments<FStatOptions>, 'argvNoOptions' | 'parsedOptions'>) => {
   const filepath = argvNoOptions[1]
-  const { resolved: fullpath, viewer = 'open' } = findFileWithViewer(expandHomeDir(filepath))
+  const viewer = 'open'
+  const fullpath = expandHomeDir(filepath)
 
   const prettyFullPath = fullpath.replace(new RegExp(`^${process.env.HOME}`), '~')
 

--- a/plugins/plugin-bash-like/fs/src/vfs/local.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/local.ts
@@ -16,7 +16,7 @@
 
 import { createGunzip } from 'zlib'
 import { createReadStream } from 'fs'
-import { Arguments, CodedError, expandHomeDir, findFileWithViewer } from '@kui-shell/core'
+import { Arguments, CodedError, expandHomeDir } from '@kui-shell/core'
 
 import { VFS, mount } from '.'
 import { kuiglob, KuiGlobOptions } from '../lib/glob'
@@ -77,7 +77,7 @@ class LocalVFS implements VFS {
 
   /** Fetch content slice */
   public async fslice(filepath: string, offset: number, _length: number): Promise<string> {
-    const { resolved: fullpath } = findFileWithViewer(expandHomeDir(filepath))
+    const fullpath = expandHomeDir(filepath)
 
     return new Promise((resolve, reject) => {
       let data = ''


### PR DESCRIPTION
Fixes #7405

This prevents some odd interactions with windows path resolving of backslashes. 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
