### PR TITLE
10.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ kubectl kui get pods
 After the final command, you should see a popup window listing pods in
 your current namespace.
 
+> **Windows Warnings**: Kui currently has some bugs in its treatment of backslashes in filepaths. Please use forward slashes for now. Thanks!
+
 ### Rolling Your Own
 
 Don't trust the prebuilt binaries? We hear you. [Roll your own

--- a/package-lock.json
+++ b/package-lock.json
@@ -674,7 +674,8 @@
         "util": "0.12.3",
         "webpack": "5.35.0",
         "webpack-cli": "4.6.0",
-        "webpack-dev-server": "3.11.2"
+        "webpack-dev-server": "3.11.2",
+        "zip-webpack-plugin": "4.0.1"
       },
       "dependencies": {
         "buffer": {
@@ -14897,6 +14898,15 @@
         "fd-slicer": "~1.1.0"
       }
     },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -14925,6 +14935,15 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "zip-webpack-plugin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/zip-webpack-plugin/-/zip-webpack-plugin-4.0.1.tgz",
+      "integrity": "sha512-G041Q4qUaog44Ynit6gs4o+o3JIv0WWfOLvc8Q3IxvPfuqd2KBHhpJWAXUB9Cm1JcWHTIOp9vS3oGMWa1p1Ehw==",
+      "dev": true,
+      "requires": {
+        "yazl": "^2.5.1"
       }
     },
     "zwitch": {

--- a/packages/core/src/main/save.ts
+++ b/packages/core/src/main/save.ts
@@ -16,6 +16,7 @@
 
 import { filters } from './open'
 import tellRendererToExecute from './tell'
+import encodeComponent from '../repl/encode'
 
 let previousChoice: string
 
@@ -35,6 +36,6 @@ export default async function saveAsNotebook() {
   if (!resp.canceled) {
     const thisChoice = resp.filePath
     previousChoice = thisChoice
-    tellRendererToExecute(`snapshot "${thisChoice}"`, 'pexec')
+    tellRendererToExecute(`snapshot ${encodeComponent(thisChoice)}`, 'pexec')
   }
 }

--- a/packages/webpack/headless-webpack.config.js
+++ b/packages/webpack/headless-webpack.config.js
@@ -22,6 +22,9 @@ const target = process.env.HEADLESS_TARGET || 'node'
 const TerserJSPlugin = require('terser-webpack-plugin')
 const { IgnorePlugin } = require('webpack')
 
+// this lets us create a headless.zip file
+const ZipPlugin = require('zip-webpack-plugin')
+
 // in case the client has some oddities that require classnames to be preserved
 const terserOptions = process.env.KEEP_CLASSNAMES
   ? {
@@ -153,6 +156,15 @@ plugins.push({
     })
   }
 })
+
+// zip after emit, so we get a dist/headless.zip
+plugins.push(
+  new ZipPlugin({
+    filename: 'headless.zip', // ZipPlugin by default names it based on the name of the main bundle
+    path: '..', // ZipPlugin seems to treat this as relative to the output path specified below
+    include: /.*/ // ZipPlugin by default only includes the main bundle file
+  })
+)
 
 // console.log('webpack plugins', plugins)
 

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -68,7 +68,8 @@
     "util": "0.12.3",
     "webpack": "5.35.0",
     "webpack-cli": "4.6.0",
-    "webpack-dev-server": "3.11.2"
+    "webpack-dev-server": "3.11.2",
+    "zip-webpack-plugin": "4.0.1"
   },
   "kui": {
     "headless": false,

--- a/plugins/plugin-bash-like/fs/src/lib/fstat.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/fstat.ts
@@ -16,7 +16,7 @@
 
 import { readFile, stat } from 'fs'
 
-import { Arguments, ParsedOptions, CodedError, findFileWithViewer, expandHomeDir } from '@kui-shell/core'
+import { Arguments, ParsedOptions, CodedError, expandHomeDir } from '@kui-shell/core'
 
 export interface FStat {
   viewer: string
@@ -53,7 +53,8 @@ export const fstat = ({
   parsedOptions
 }: Pick<Arguments<FStatOptions>, 'argvNoOptions' | 'parsedOptions'>) => {
   const filepath = argvNoOptions[1]
-  const { resolved: fullpath, viewer = 'open' } = findFileWithViewer(expandHomeDir(filepath))
+  const viewer = 'open'
+  const fullpath = expandHomeDir(filepath)
 
   const prettyFullPath = fullpath.replace(new RegExp(`^${process.env.HOME}`), '~')
 

--- a/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
@@ -16,7 +16,7 @@
 
 import Debug from 'debug'
 import { basename } from 'path'
-import { Arguments, CodedError, flatten } from '@kui-shell/core'
+import { Arguments, CodedError, cwd, flatten } from '@kui-shell/core'
 import { DirEntry, VFS, absolute, findMount, multiFindMount, findMatchingMounts } from '.'
 
 const debug = Debug('plugin/bash-like/fs/vfs/delegates')
@@ -105,7 +105,7 @@ async function lsMounts(path: string): Promise<DirEntry[]> {
  *
  */
 export async function ls(...parameters: Parameters<VFS['ls']>): Promise<DirEntry[]> {
-  const filepaths = parameters[1].length === 0 ? [process.env.PWD] : parameters[1].map(absolute)
+  const filepaths = parameters[1].length === 0 ? [cwd()] : parameters[1].map(absolute)
 
   const mounts = await multiFindMount(filepaths, true)
   const vfsContentP = Promise.all(

--- a/plugins/plugin-bash-like/fs/src/vfs/local.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/local.ts
@@ -16,7 +16,7 @@
 
 import { createGunzip } from 'zlib'
 import { createReadStream } from 'fs'
-import { Arguments, CodedError, expandHomeDir, findFileWithViewer } from '@kui-shell/core'
+import { Arguments, CodedError, expandHomeDir } from '@kui-shell/core'
 
 import { VFS, mount } from '.'
 import { kuiglob, KuiGlobOptions } from '../lib/glob'
@@ -77,7 +77,7 @@ class LocalVFS implements VFS {
 
   /** Fetch content slice */
   public async fslice(filepath: string, offset: number, _length: number): Promise<string> {
-    const { resolved: fullpath } = findFileWithViewer(expandHomeDir(filepath))
+    const fullpath = expandHomeDir(filepath)
 
     return new Promise((resolve, reject) => {
       let data = ''

--- a/plugins/plugin-client-common/src/components/Content/Eval.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Eval.tsx
@@ -33,11 +33,13 @@ import { Loading } from '../../'
 import KuiMMRContent, { KuiMMRProps } from './KuiContent'
 
 interface EvalProps extends Omit<KuiMMRProps, 'mode'> {
+  execUUID: string
   command: string | FunctionThatProducesContent
   contentType?: SupportedStringContent
 }
 
 interface EvalState {
+  execUUID: string
   isLoading: boolean
   command: string | FunctionThatProducesContent
   react: ReactProvider
@@ -63,17 +65,24 @@ interface EvalState {
 export default class Eval extends React.PureComponent<EvalProps, EvalState> {
   public constructor(props: EvalProps) {
     super(props)
-
-    this.state = {
-      isLoading: true,
-      command: props.command,
-      react: undefined,
-      spec: undefined,
-      content: undefined,
-      contentType: props.contentType
-    }
-
+    this.state = Eval.getDerivedStateFromProps(props)
     this.startLoading()
+  }
+
+  public static getDerivedStateFromProps(props: EvalProps, state?: EvalState) {
+    if (!state || state.execUUID !== props.execUUID) {
+      return {
+        execUUID: props.execUUID,
+        isLoading: true,
+        command: props.command,
+        react: undefined,
+        spec: undefined,
+        content: undefined,
+        contentType: props.contentType
+      }
+    } else {
+      return state
+    }
   }
 
   private startLoading() {

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -61,36 +61,20 @@ export type KuiMMRProps = ToolbarProps & {
 
 interface State {
   mode: Content
-  isRendered: boolean
+  execUUID: string
 }
 
-export default class KuiContent extends React.Component<KuiMMRProps, State> {
+export default class KuiContent extends React.PureComponent<KuiMMRProps, State> {
   public constructor(props: KuiMMRProps) {
     super(props)
-
-    this.state = {
-      mode: props.mode,
-      isRendered: false
-    }
+    this.state = KuiContent.getDerivedStateFromProps(props)
   }
 
-  public static getDerivedStateFromProps(props: KuiMMRProps, state: State) {
-    if (state && state.isRendered && state.mode === props.mode) {
-      return state
+  public static getDerivedStateFromProps(props: KuiMMRProps, state?: State) {
+    if (!state || state.mode !== props.mode || state.execUUID !== props.execUUID) {
+      return Object.assign(state || {}, { mode: props.mode, execUUID: props.execUUID })
     } else {
-      return Object.assign(state || {}, { isRendered: false, mode: props.mode })
-    }
-  }
-
-  public shouldComponentUpdate(nextProps: KuiMMRProps) {
-    return nextProps.isActive && (!this.state || !this.state.isRendered)
-  }
-
-  public componentDidUpdate() {
-    if (this.props.isActive) {
-      this.setState({
-        isRendered: true
-      })
+      return state
     }
   }
 
@@ -148,9 +132,11 @@ export default class KuiContent extends React.Component<KuiMMRProps, State> {
         />
       )
     } else if (isCommandStringContent(mode)) {
-      return <Eval {...this.props} command={mode.contentFrom} contentType={mode.contentType} />
+      const key = `${mode.contentFrom} ${mode.contentType}`
+      return <Eval {...this.props} key={key} command={mode.contentFrom} contentType={mode.contentType} />
     } else if (isFunctionContent(mode)) {
-      return <Eval {...this.props} command={mode.content} />
+      const command = mode.content
+      return <Eval {...this.props} key={command.toString()} command={command} />
     } else if (isScalarContent(mode)) {
       if (isReactProvider(mode)) {
         return mode.react({ willUpdateToolbar })

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -187,7 +187,9 @@ export default class Output extends React.PureComponent<Props, State> {
         const combined = this.streamingOutput.join('')
         return (
           <div className="repl-result-like result-vertical" data-stream>
-            <Ansi>{combined}</Ansi>
+            <React.Suspense fallback={<div />}>
+              <Ansi>{combined}</Ansi>
+            </React.Suspense>
           </div>
         )
       }

--- a/plugins/plugin-kubectl/src/tab-state.ts
+++ b/plugins/plugin-kubectl/src/tab-state.ts
@@ -60,7 +60,9 @@ async function capture(tabState: TabState) {
 
       debug('captured tab state', tab.uuid, currentContext, currentNamespace)
     } catch (err) {
-      console.error(`plugin-kubectl: failed to capture tab-state`, err, tabState)
+      if (!/command not found/.test(err)) {
+        console.error(`plugin-kubectl: failed to capture tab-state`, err, tabState)
+      }
 
       // clear state
       setTabState(tabState, 'context', '')
@@ -86,7 +88,9 @@ async function restore(tabState: TabState) {
 
     debug('restored tab state', tab.uuid, context, namespace)
   } catch (err) {
-    console.error(`plugin-kubectl: failed to restore tab-state`, err, tabState)
+    if (!/command not found/.test(err)) {
+      console.error(`plugin-kubectl: failed to restore tab-state`, err, tabState)
+    }
   }
 }
 


### PR DESCRIPTION
[10.3.3 159d3da35] fix(plugins/plugin-bash-like): stop resolve to absolute path in fstat and fslice
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Fri May 21 16:38:41 2021 -0400
 2 files changed, 5 insertions(+), 4 deletions(-)

[10.3.3 e2293167c] fix(plugins/plugin-bash-like): on windows ls with no arguments results in Cannot read property 'replace' of undefined
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Fri May 21 16:17:51 2021 -0400
 1 file changed, 2 insertions(+), 2 deletions(-)

[10.3.3 db2b6da2b] docs: notify windows users about potential bugs with backslashes
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Fri May 21 16:02:10 2021 -0400
 1 file changed, 2 insertions(+)
Auto-merging packages/webpack/package.json

[10.3.3 8597f056a] feat(packages/webpack): when building a headless bundle set via webpack, also create a zip file
 Date: Thu May 20 20:35:32 2021 -0400
 3 files changed, 34 insertions(+), 2 deletions(-)

[10.3.3 c559b940d] fix(packages/core): File->Save does not properly handle backslash paths
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Fri May 21 16:32:20 2021 -0400
 1 file changed, 2 insertions(+), 1 deletion(-)

[10.3.3 8d350d771] fix(plugins/plugin-client-common): the first time PTY output appears, Kui flashes briefly
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Fri May 21 17:18:32 2021 -0400
 1 file changed, 3 insertions(+), 1 deletion(-)

[10.3.3 29efa3af4] fix(plugins/plugin-client-common): clicking on YAML tab incorrectly shows "You are in edit mode" even if you aren't
 Date: Fri May 21 11:31:22 2021 -0400
 6 files changed, 134 insertions(+), 65 deletions(-)

[10.3.3 a199372ba] fix(plugins/plugin-kubectl): tab state manager shoud not log "command not found" errors for systems without kubectl
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Thu May 20 16:19:47 2021 -0400
 1 file changed, 6 insertions(+), 2 deletions(-)