### PR TITLE
fix(plugins/plugin-client-common): watchable blocks when replaced by rerun/reexec are not aborted

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -703,6 +703,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
         if (rerunIdx >= 0) {
           const block = curState.blocks[rerunIdx]
+          this.removeWatchableBlock(block)
           // The use case here is that the user clicked the Rerun
           // button in the UI or clicked on an Input and hit Enter. In
           // either case, the command execution will reuse the


### PR DESCRIPTION
Fixes #7419 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
