### PR TITLE
fix(plugins/plugin-electron-components): use github api to get the latest release

### DIFF
--- a/plugins/plugin-client-default/config.d/repo.json
+++ b/plugins/plugin-client-default/config.d/repo.json
@@ -1,3 +1,3 @@
 {
-  "url": "https://github.com/kubernetes-sigs/kui"
+  "url": "https://api.github.com/repos/kubernetes-sigs/kui"
 }


### PR DESCRIPTION
Fixes #7438 

In this PR, I changed UpdateChecker to get the latest release via Github API, as Github API will return the most recent non-prerelease and non-draft release. We're currently fetching feed from https://github.com/kubernetes-sigs/kui/releases.atom and have to find the latest release by ourselves, since the feed doesn't contain assets and pre-release information. For example, we were checking if a release is pre-release by checking whether the release title contains alpha, beta or rc. This won’t exclude empty releases, such as v10.3.3. If we switched to github.api, then we can get the latest release for free. 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
