### PR TITLE
fix(plugins/plugin-client-common): input cursor will move to the end after tab-completes

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/TabCompletion.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/TabCompletion.tsx
@@ -244,11 +244,12 @@ class TabCompletionInitialState extends TabCompletionState {
  *
  */
 function setPromptValue(prompt: HTMLInputElement, newValue: string, selectionStart: number) {
+  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set
+  nativeInputValueSetter.call(prompt, newValue)
+
   prompt.selectionStart = selectionStart
   prompt.selectionEnd = selectionStart
 
-  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set
-  nativeInputValueSetter.call(prompt, newValue)
   setTimeout(() => prompt.dispatchEvent(new Event('change', { bubbles: true })))
 }
 


### PR DESCRIPTION
Fixes #7452 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
