### PR TITLE
fix: using / for division is deprecated for sass

### DIFF
--- a/packages/builder/dist/electron/build.sh
+++ b/packages/builder/dist/electron/build.sh
@@ -258,7 +258,6 @@ else
 fi
 ' >> kubectl-kui)
             KUI_LAUNCHER="$PWD/kubectl-kui"
-            echo "!!!YOYOYO"
             ls -l "$KUI_LAUNCHER"
         fi
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@use 'sass:math';
 @import 'mixins';
 @import '../Sidecar/mixins';
 
@@ -346,7 +347,7 @@ body[kui-theme-style] .kui--repl-block-right-element {
 }
 
 @mixin timestamp-like {
-  margin: $inset / $right-element-font-size-factor;
+  margin: math.div($inset, $right-element-font-size-factor);
   display: flex;
   align-items: flex-start;
   transition-delay: $action-hover-delay;

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Spinner.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Spinner.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@use 'sass:math';
 @import 'mixins';
 
 @mixin Spinner {
@@ -46,7 +47,7 @@
   @include Spinner {
     /* see https://github.com/IBM/kui/issues/7129 */
     /* also be careful: https://github.com/IBM/kui/issues/7155 */
-    margin: $inset / $right-element-font-size-factor 0;
+    margin: math.div($inset, $right-element-font-size-factor) 0;
   }
 }
 


### PR DESCRIPTION
Fixes #7462 
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
