### PR TITLE
fix: vi doesn't take up the full dimensions of the viewport

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -118,9 +118,17 @@ export default class Output extends React.PureComponent<Props, State> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private async streamingConsumer(part: Streamable) {
     if (hasUUID(this.props.model)) {
+      const tabUUID = this.props.uuid
+      const execUUID = this.props.model.execUUID
+      const done = () => {
+        this.props.onRender()
+        eventChannelUnsafe.emit(`/command/stdout/done/${tabUUID}/${execUUID}`)
+      }
+
       // part === null: the controller wants to clear any prior output
       if (part === null) {
         this.streamingOutput = []
+        done()
         return {
           // remove all output
           nStreamingOutputs: 0
@@ -131,10 +139,9 @@ export default class Output extends React.PureComponent<Props, State> {
           this.setState({
             nStreamingOutputs: this.streamingOutput.length
           })
+          setTimeout(done, 10)
         }, 10)
       }
-      this.props.onRender()
-      eventChannelUnsafe.emit(`/command/stdout/done/${this.props.uuid}/${this.props.model.execUUID}`)
     }
   }
 


### PR DESCRIPTION
We need to delay the initial resize() until the xtermContainer is mounted.

Fixes #7482

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
