### PR TITLE
fix: in electron mode, ctrl/cmd+w should always close kui tab

### DIFF
--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -42,7 +42,7 @@ const newSplit = () => tellRendererToExecute('split')
  * tell the current window to close the current tab
  *
  */
-const closeTab = () => tellRendererToExecute('tab close')
+const closeTab = () => tellRendererToExecute('tab close -A')
 
 const isDarwin = process.platform === 'darwin'
 const closeAccelerator = isDarwin ? 'Command+W' : 'Control+Shift+W'

--- a/plugins/plugin-core-support/src/lib/cmds/quit.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/quit.ts
@@ -31,10 +31,6 @@ const usage = (command: string) => ({
 
 export default (commandTree: Registrar) => {
   if (!inBrowser()) {
-    commandTree.listen('/quit', doQuit, {
-      usage: usage('quit')
-    })
-
     // register a window close command handler
     commandTree.listen('/window/close', () => {
       const remote = require('electron').remote
@@ -44,7 +40,6 @@ export default (commandTree: Registrar) => {
     })
   }
 
-  // just for fun, make /exit a synonym for /quit
   commandTree.listen('/exit', doQuit, {
     usage: usage('exit')
   })


### PR DESCRIPTION
BREAKING CHANGE: this PR removes the `quit` command

Fixes #7487

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
