### PR TITLE
kui-babel only works if clients have their plugins in a top-level dir…

### DIFF
--- a/packages/builder/bin/babel.sh
+++ b/packages/builder/bin/babel.sh
@@ -37,7 +37,7 @@ function babel {
 }
 
 declare -a LIST=()
-for i in {packages,plugins}/*; do
+for i in {packages,node_modules/@kui-shell/plugin-*,node_modules/@kui-shell/client}; do
     if [ -d $i/mdist ]; then
         cmd=$(babel $i)
         LIST+=("$cmd")


### PR DESCRIPTION
…ectory named "plugins/"

part of #7510

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
