### PR TITLE
10.3.15

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -204,6 +204,10 @@ export function hasOriginalUUID(block: BlockModel | WithOriginalExecUUID): block
   return typeof (block as WithOriginalExecUUID).originalExecUUID === 'string'
 }
 
+export function hasBeenRerun(block: BlockModel): boolean {
+  return hasOriginalUUID(block)
+}
+
 /** Transform to Processing */
 export function Processing(
   block: BlockModel,

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -205,7 +205,7 @@ export function hasOriginalUUID(block: BlockModel | WithOriginalExecUUID): block
 }
 
 export function hasBeenRerun(block: BlockModel): boolean {
-  return hasOriginalUUID(block)
+  return hasOriginalUUID(block) && hasUUID(block) && block.originalExecUUID !== block.execUUID
 }
 
 /** Transform to Processing */

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -45,6 +45,7 @@ import {
   FinishedBlock,
   hasUUID,
   hasCommand,
+  hasBeenRerun,
   isBeingRerun,
   isFinished,
   isProcessing,
@@ -171,7 +172,8 @@ export default class Output extends React.PureComponent<Props, State> {
   }
 
   private onRender(assertHasContent: boolean): void {
-    if (this.props.onRender) {
+    if (this.props.onRender && !this.props.isBeingRerun && !hasBeenRerun(this.props.model)) {
+      // we don't want reruns to trigger any scrolling behavior
       this.props.onRender()
     }
     this.setState({ assertHasContent })

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -143,6 +143,7 @@ type ScrollbackState = ScrollbackOptions & {
   onFocus: (evt: React.FocusEvent) => void
   onOutputRender: () => void
   navigateTo: (dir: 'first' | 'last' | 'previous' | 'next') => void
+  setActiveBlock: (c: Block) => void
   willFocusBlock: (evt: React.SyntheticEvent) => void
   willRemoveBlock: (evt: React.SyntheticEvent, idx?: number) => void
   willUpdateCommand: (idx: number, command: string) => void
@@ -403,6 +404,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       onFocus: undefined,
       onOutputRender: undefined,
       navigateTo: undefined,
+      setActiveBlock: undefined,
       willFocusBlock: undefined,
       willRemoveBlock: undefined,
       willUpdateCommand: undefined
@@ -460,6 +462,13 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
           showThisIdxInMiniSplit: newIdx
         }
       })
+    }
+
+    /** Update the active block */
+    state.setActiveBlock = (c: Block) => {
+      if (c && c.props && c.props.model && isActive(c.props.model)) {
+        state._activeBlock = c
+      }
     }
 
     /**
@@ -1327,7 +1336,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
                     isWidthConstrained={isWidthConstrained}
                     onOutputRender={scrollback.onOutputRender}
                     navigateTo={scrollback.navigateTo}
-                    ref={idx !== this.findActiveBlock(scrollback) ? undefined : c => (scrollback._activeBlock = c)}
+                    ref={scrollback.setActiveBlock}
                   />
                 )
               })

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
@@ -19,14 +19,31 @@
 @import 'mixins';
 @import './Block';
 
+$split-padding: 0.5em;
+$split-gutter-gap: 6px;
+$split-gutter-color: var(--color-stripe-01);
+$split-bgcolor: var(--color-repl-background);
+
 @include SplitContainer {
   display: grid;
-  grid-gap: 6px;
   overflow: hidden;
-  background-color: var(--color-stripe-01);
+  grid-gap: $split-gutter-gap;
+  background-color: $split-gutter-color;
 }
 
 @include Scrollback {
-  padding: 0.5em 0;
-  background-color: var(--color-repl-background);
+  /* support for inner scrolling on ScrollbackBlockList */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  background-color: $split-bgcolor;
+}
+
+@include ScrollbackBlockList {
+  /* these two rules given us inner scrolling on ScrollbackBlockList */
+  flex: 1;
+  overflow: auto;
+
+  padding: $split-padding 0;
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/SplitHeader.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/SplitHeader.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Kubernetes Authors
+ * Copyright 2021 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-@import 'Announcement';
-@import 'Commentary';
-@import 'Experimental';
-@import 'Layout';
-@import 'MiniSplit';
-@import 'Scrollback';
-@import 'SourceRef';
-@import 'Spinner';
-@import 'SplitHeader';
+@import 'mixins';
+
+@include SplitHeader {
+  opacity: 0.925;
+  padding: 0.125em 0;
+  padding-right: $input-padding-right;
+  background-color: var(--color-stripe-01);
+}
+
+@include SplitHeaderClose {
+  padding: 3px;
+  &:hover {
+    cursor: pointer;
+    background-color: var(--color-table-border1);
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -45,6 +45,12 @@ $action-hover-delay: 210ms;
   }
 }
 
+@mixin ScrollbackBlockList {
+  .kui--scrollback-block-list {
+    @content;
+  }
+}
+
 @mixin NotFocusedSplit {
   @include Scrollback {
     &:not([data-is-focused]):not([data-is-minisplit]) {
@@ -325,5 +331,17 @@ $action-hover-delay: 210ms;
     &[data-split-count='#{$N}'] {
       @content;
     }
+  }
+}
+
+/** header for split */
+@mixin SplitHeader {
+  .kui--split-header {
+    @content;
+  }
+}
+@mixin SplitHeaderClose {
+  .kui--split-close-button {
+    @content;
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
@@ -203,6 +203,16 @@ $tab-label-font-size: 0.875rem;
     &:not(.kui--tab--active) .kui--tab-close:hover {
       background: var(--color-table-border3);
     }
+
+    /* This overrides the .kui--tab:after rule we have from Sidecar */
+    &:after {
+      display: none;
+    }
+  }
+
+  /* This makes some separation between the selected tab border and the SplitHeader */
+  .pf-c-nav.pf-m-horizontal .pf-c-nav__link::before {
+    bottom: 1px;
   }
 
   .kui--top-tab-buttons {


### PR DESCRIPTION
[10.3.15 6c7029648] fix(plugins/plugin-client-common): when rerunning blocks, output always scrolls to bottom
 Date: Fri Jun 4 13:16:02 2021 -0400
 3 files changed, 17 insertions(+), 2 deletions(-)

[10.3.15 50392f494] regression: when rerunning blocks, output always scrolls to bottom (part b)
 Date: Fri Jun 4 15:41:30 2021 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)

[10.3.15 3309b923b] feat(plugins/plugin-client-common): ability to close a split via UI gesture
 Date: Fri Jun 4 15:06:10 2021 -0400
 6 files changed, 193 insertions(+), 89 deletions(-)
 create mode 100644 plugins/plugin-client-common/web/scss/components/Terminal/SplitHeader.scss