### PR TITLE
fix(plugins/plugin-client-common): StatusStripe widgets have double borders

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -144,7 +144,13 @@ $z-index: var(--pf-global--ZIndex--xs);
 
   .kui--status-stripe-context {
     font-size: $font-size;
-    border-right: $element-border;
+
+    &:first-child {
+      border-right: $element-border;
+    }
+    & + .kui--status-stripe-context .kui--status-stripe-element {
+      border-left: none;
+    }
 
     .kui--status-stripe-element {
       padding-left: calc(#{$element-padding} * 0.875 / 0.75);


### PR DESCRIPTION
Fixes #7544

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
