### PR TITLE
fix(plugins/plugin-client-default): compilation error

### DIFF
--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -111,7 +111,7 @@ export default function renderMain(props: KuiProps) {
         <S3Mounts />
       </ContextWidgets>
 
-      {!isPopup() && <SpaceFiller />}
+      {!isPopup && <SpaceFiller />}
 
       <MeterWidgets className="kui--hide-in-narrower-windows">
         {/* <ClusterUtilization /> */}


### PR DESCRIPTION
Fixes #7546 

When I merged PRs into master, git seemed to mess up rebasing https://github.com/kubernetes-sigs/kui/commit/0b95d9cdd216424206f57347e5de1d0821e21e53, due to duplicate variable names.

I first merged the S3 plugin PR, which removed the import of isPopup from plugin-client-default/index.tsx. https://github.com/kubernetes-sigs/kui/commit/177457f3156bf1e36d1fc671b96982ee6e89aa7f#diff-8d9874cfcd3046ea3d4915be2efb64cb7121331a6352b74ceb0e1db3824088c8L19
Then I merged the "enable split in Popup mode" PR, which uses isPopup() to put spacefiller. https://github.com/kubernetes-sigs/kui/commit/177457f3156bf1e36d1fc671b96982ee6e89aa7f#diff-8d9874cfcd3046ea3d4915be2efb64cb7121331a6352b74ceb0e1db3824088c8L19

I should get merge conflict when merging the second PR, but GitHub doesn't show Merge Conflict probably because index.tsx has another variable called isPopup?

Anyways, this PR fixed the compilation issue.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
