### PR TITLE
fix(plugins/plugin-client-common): split close button lacks tooltip

### DIFF
--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -41,6 +41,7 @@
   "Duration": "Duration: {0}",
   "Cold Start": "Cold start delay: {0}. {1}",
   "Close this tab": "Close this tab {0}",
+  "Close this split": "Close this split",
   "Click to show more detail": "Click to show more detail",
   "You clicked to show the": "You clicked to show the",
   "Drilling down to show the": "Drilling down to show the",

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
@@ -15,8 +15,12 @@
  */
 
 import React from 'react'
+import { i18n } from '@kui-shell/core'
 
+import Tooltip from '../../spi/Tooltip'
 import '../../../../web/scss/components/Terminal/SplitHeader.scss'
+
+const strings = i18n('plugin-client-common')
 
 interface Props {
   onRemove(): void
@@ -24,13 +28,21 @@ interface Props {
 
 /** Render a header for the given split */
 export default class SplitHeader extends React.PureComponent<Props> {
+  private closeButton() {
+    return (
+      <Tooltip markdown={strings('Close this split')}>
+        <div className="kui--split-close-button" onClick={this.props.onRemove}>
+          &#x2A2F;
+        </div>
+      </Tooltip>
+    )
+  }
+
   public render() {
     return (
       <div className="kui--split-header flex-layout kui--inverted-color-context">
         <div className="flex-fill" />
-        <div className="kui--split-close-button" onClick={this.props.onRemove}>
-          &#x2A2F;
-        </div>
+        {this.closeButton()}
       </div>
     )
   }


### PR DESCRIPTION
Fixes #7549

<img width="157" alt="Screen Shot 2021-06-07 at 12 22 24 PM" src="https://user-images.githubusercontent.com/4741620/121056085-d69e1d00-c78b-11eb-937a-e7b08daa884e.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
