### PR TITLE
10.3.16

### DIFF
--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -157,6 +157,8 @@ export const SPLITS = `${CURRENT_TAB} .kui--scrollback`
 export const SPLIT_ID = 'data-scrollback-id'
 export const SPLIT_N = (N: number, inverseColors = false) =>
   `${SPLITS}:nth-child(${N})` + (inverseColors ? INVERTED_COLORS : '')
+export const SPLIT_N_HEADER = (N: number) => `${SPLIT_N(N)} .kui--split-header`
+export const SPLIT_N_CLOSE = (N: number) => `${SPLIT_N_HEADER(N)} .kui--split-close-button`
 export const SPLIT_N_FOCUS = (N: number) => `${SPLITS}:nth-child(${N}) ${current(_PROMPT_BLOCK)} ${_PROMPT}`
 export const SPLIT_N_OUTPUT = (N: number) => `${SPLITS}:nth-child(${N}) .repl-output`
 export const CURRENT_PROMPT_BLOCK_FOR_SPLIT = (splitIndex: number) => `${SPLIT_N(splitIndex)} ${current(_PROMPT_BLOCK)}`

--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -41,6 +41,7 @@
   "Duration": "Duration: {0}",
   "Cold Start": "Cold start delay: {0}. {1}",
   "Close this tab": "Close this tab {0}",
+  "Close this split": "Close this split",
   "Click to show more detail": "Click to show more detail",
   "You clicked to show the": "You clicked to show the",
   "Drilling down to show the": "Drilling down to show the",

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/NewTabButton.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/NewTabButton.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { i18n } from '@kui-shell/core'
+import { i18n, inBrowser } from '@kui-shell/core'
 
 import Icons from '../../spi/Icons'
 import Tooltip from '../../spi/Tooltip'
@@ -34,7 +34,7 @@ export default class NewTabButton extends React.PureComponent<Props> {
   private tooltip() {
     return (
       <Tooltip reference={this.ref} position="bottom">
-        {strings('New Tab', ctrlOrMeta('T'))}
+        {strings('New Tab', inBrowser() ? '' : ctrlOrMeta('T'))}
       </Tooltip>
     )
   }

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/SplitTerminalButton.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/SplitTerminalButton.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { i18n, pexecInCurrentTab } from '@kui-shell/core'
+import { i18n, inBrowser, pexecInCurrentTab } from '@kui-shell/core'
 
 import Icons from '../../spi/Icons'
 import KuiContext from '../context'
@@ -36,7 +36,7 @@ export default class SplitTerminalButton extends React.PureComponent {
   private tooltip() {
     return (
       <Tooltip reference={this.ref} position="bottom">
-        {strings('Split the terminal', ctrlOrMeta('Y'))}
+        {strings('Split the terminal', inBrowser() ? '' : ctrlOrMeta('Y'))}
       </Tooltip>
     )
   }

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecarV2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecarV2.tsx
@@ -425,10 +425,9 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, TopNa
         this.props.onRender(false)
       }
       return <div />
-    } else {
-      if (this.props.onRender) {
-        this.props.onRender(true)
-      }
+    } else if (this.props.onRender) {
+      // needs to be async'd; see https://github.com/kubernetes-sigs/kui/issues/7539
+      setTimeout(() => this.props.onRender(true))
     }
 
     const nameBreadCrumbs =

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -45,6 +45,7 @@ import {
 
 import Block from './Block'
 import getSize from './getSize'
+import SplitHeader from './SplitHeader'
 import { NotebookImpl, isNotebookImpl, snapshot, FlightRecorder, tabAlignment } from './Snapshot'
 import KuiConfiguration from '../../Client/KuiConfiguration'
 import { onCopy, onCut, onPaste } from './ClipboardTransfer'
@@ -1324,20 +1325,6 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
     })
   }
 
-  /** Render a header for the given split */
-  private splitHeader(scrollback: ScrollbackState) {
-    return (
-      this.state.splits.length > 1 && (
-        <div className="kui--split-header flex-layout kui--inverted-color-context">
-          <div className="flex-fill" />
-          <div className="kui--split-close-button" onClick={scrollback.remove}>
-            &#x2A2F;
-          </div>
-        </div>
-      )
-    )
-  }
-
   /** Render one split */
   private split(scrollback: ScrollbackState, sbidx: number) {
     const tab = this.tabFor(scrollback)
@@ -1356,7 +1343,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
         onClick={scrollback.onClick}
       >
         <React.Fragment>
-          {this.splitHeader(scrollback)}
+          {this.state.splits.length > 1 && <SplitHeader onRemove={scrollback.remove} />}
           <ul className="kui--scrollback-block-list">{this.blocks(tab, scrollback, sbidx)}</ul>
         </React.Fragment>
       </div>

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 
-@import 'mixins';
+import React from 'react'
 
-@include SplitHeader {
-  padding: 0.125em 0;
-  padding-left: $input-padding-left;
-  padding-right: $input-padding-right;
+import '../../../../web/scss/components/Terminal/SplitHeader.scss'
 
-  opacity: 0.925;
-  background-color: var(--color-sidecar-toolbar-background);
-  & > div {
-    color: var(--color-sidecar-toolbar-foreground);
-  }
+interface Props {
+  onRemove(): void
 }
 
-@include SplitHeaderClose {
-  padding: 3px;
-  &:hover {
-    cursor: pointer;
-    background-color: var(--color-table-border1);
+/** Render a header for the given split */
+export default class SplitHeader extends React.PureComponent<Props> {
+  public render() {
+    return (
+      <div className="kui--split-header flex-layout kui--inverted-color-context">
+        <div className="flex-fill" />
+        <div className="kui--split-close-button" onClick={this.props.onRemove}>
+          &#x2A2F;
+        </div>
+      </div>
+    )
   }
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
@@ -15,8 +15,12 @@
  */
 
 import React from 'react'
+import { i18n } from '@kui-shell/core'
 
+import Tooltip from '../../spi/Tooltip'
 import '../../../../web/scss/components/Terminal/SplitHeader.scss'
+
+const strings = i18n('plugin-client-common')
 
 interface Props {
   onRemove(): void
@@ -24,13 +28,21 @@ interface Props {
 
 /** Render a header for the given split */
 export default class SplitHeader extends React.PureComponent<Props> {
+  private closeButton() {
+    return (
+      <Tooltip markdown={strings('Close this split')}>
+        <div className="kui--split-close-button" onClick={this.props.onRemove}>
+          &#x2A2F;
+        </div>
+      </Tooltip>
+    )
+  }
+
   public render() {
     return (
       <div className="kui--split-header flex-layout kui--inverted-color-context">
         <div className="flex-fill" />
-        <div className="kui--split-close-button" onClick={this.props.onRemove}>
-          &#x2A2F;
-        </div>
+        {this.closeButton()}
       </div>
     )
   }

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -144,7 +144,13 @@ $z-index: var(--pf-global--ZIndex--xs);
 
   .kui--status-stripe-context {
     font-size: $font-size;
-    border-right: $element-border;
+
+    &:first-child {
+      border-right: $element-border;
+    }
+    & + .kui--status-stripe-context .kui--status-stripe-element {
+      border-left: none;
+    }
 
     .kui--status-stripe-element {
       padding-left: calc(#{$element-padding} * 0.875 / 0.75);

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_index.scss
@@ -22,4 +22,3 @@
 @import 'Scrollback';
 @import 'SourceRef';
 @import 'Spinner';
-@import 'SplitHeader';

--- a/plugins/plugin-core-support/src/test/core-support2/split-helpers.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/split-helpers.ts
@@ -104,6 +104,16 @@ export function close(this: Common.ISuite, splitCount: number, inSplit: number) 
       .catch(Common.oops(this, true)))
 }
 
+/** Close the split in the current tab by clicking the close button */
+export function closeViaButton(this: Common.ISuite, splitCount: number, inSplit: number) {
+  it(`should close the split via button in the current tab and expect splitCount=${splitCount}`, () =>
+    this.app.client
+      .$(Selectors.SPLIT_N_CLOSE(inSplit))
+      .then(_ => _.click())
+      .then(() => ReplExpect.splitCount(splitCount)(this.app))
+      .catch(Common.oops(this, true)))
+}
+
 async function clickToFocus(this: Common.ISuite, toSplitIndex: number) {
   console.error('1')
   await this.app.client.$(Selectors.SPLIT_N_FOCUS(toSplitIndex)).then(_ => _.click())


### PR DESCRIPTION
[10.3.16 2f83042dd] test(plugins/plugin-core-support): close split via button
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Fri Jun 4 17:00:21 2021 -0400
 3 files changed, 44 insertions(+), 23 deletions(-)

[10.3.16 79a997bf0] fix(plugins/plugin-client-common): split headers have low contrast in dark themes
 Date: Sun Jun 6 14:09:20 2021 -0400
 4 files changed, 46 insertions(+), 18 deletions(-)
 create mode 100644 plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx

[10.3.16 4aced1ef6] fix(plugins/plugin-client-common): sidecar drilldown can result in react warning in console
 Date: Sun Jun 6 14:11:28 2021 -0400
 1 file changed, 3 insertions(+), 4 deletions(-)

[10.3.16 48b1412d4] fix(plugins/plugin-client-common): StatusStripe widgets may have double borders
 Date: Mon Jun 7 09:00:14 2021 -0400
 1 file changed, 7 insertions(+), 1 deletion(-)

[10.3.16 0cff44395] fix(plugins/plugin-client-common): split close button lacks tooltip
 Date: Mon Jun 7 12:27:21 2021 -0400
 2 files changed, 16 insertions(+), 3 deletions(-)

[10.3.16 b5e1496e8] fix(plugins/plugin-client-common): new tab and new split tooltips suggest incorrect keyboard shortcuts inBrowser
 Date: Mon Jun 7 12:39:10 2021 -0400
 2 files changed, 4 insertions(+), 4 deletions(-)