### PR TITLE
design: SplitHeader buttons should match in size with Sidecar toolbar buttons

### DIFF
--- a/plugins/plugin-client-common/web/css/static/ToolbarButton.scss
+++ b/plugins/plugin-client-common/web/css/static/ToolbarButton.scss
@@ -5,6 +5,7 @@
   svg,
   .bx--tooltip__trigger svg {
     fill: currentColor;
+    padding: 2px;
   }
 
   &:hover {

--- a/plugins/plugin-client-common/web/css/static/sidecar-main.css
+++ b/plugins/plugin-client-common/web/css/static/sidecar-main.css
@@ -178,7 +178,6 @@ $toolbar-height: 1.5rem;
   .sidecar-bottom-stripe-button {
     display: flex;
     line-height: 1.5em;
-    padding: 3px;
 
     & > div {
       display: flex;


### PR DESCRIPTION
Fixes #7563 
![Screen Shot 2021-06-08 at 12 04 10 PM](https://user-images.githubusercontent.com/21212160/121219398-a620b680-c851-11eb-8227-8c539e73aacd.png)





<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
