### PR TITLE
10.3.18

### DIFF
--- a/packages/test/src/api/mmr.ts
+++ b/packages/test/src/api/mmr.ts
@@ -212,11 +212,10 @@ export class TestMMR {
    * modes() executes `command` in REPL and expects `modes` are showin in Sidecar
    * @param { MMRExpectMode[] } expectModes is the expected modes shown as Sidecar Tabs
    * @param { MMRExpectMode } defaultMode is the expected default Sidecar Tab
-   * @param  options includes: testWindowButtons
-   * @param { boolean } testWindowButtons indicates whether modes() will test the sidecar window buttons as well
+   *
    *
    */
-  public modes(expectModes: MMRExpectMode[], defaultMode: MMRExpectMode, options?: { testWindowButtons?: boolean }) {
+  public modes(expectModes: MMRExpectMode[], defaultMode: MMRExpectMode) {
     const { command, testName } = this.param
 
     describe(`mmr modes ${testName || command || ''} ${process.env.MOCHA_RUN_TARGET ||
@@ -373,41 +372,9 @@ export class TestMMR {
           }
         })
 
-      const backToOpen = () => {
-        it(`should resume the sidecar from maximized to open`, async () => {
-          try {
-            const button = await this.app.client.$(Selectors.SIDECAR_MAXIMIZE_BUTTON(cmdIdx))
-            await button.waitForDisplayed()
-            await button.click()
-            await SidecarExpect.open({ app: this.app, count: cmdIdx })
-          } catch (err) {
-            await Common.oops(this, true)
-          }
-        })
-      }
-
       showModes()
       cycleTheTabs()
       cycleTheTabs()
-
-      if (options && options.testWindowButtons === true) {
-        const maximize = () =>
-          it('should maximize the sidecar', async () => {
-            try {
-              const button = await this.app.client.$(Selectors.SIDECAR_MAXIMIZE_BUTTON(cmdIdx))
-              await button.waitForDisplayed()
-              await button.click()
-              await SidecarExpect.fullscreen({ app: this.app, count: cmdIdx })
-            } catch (err) {
-              await Common.oops(this, true)(err)
-            }
-          })
-
-        showModes()
-        maximize()
-        backToOpen()
-        showModes()
-      }
     })
   }
 

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -52,7 +52,6 @@ export const _SIDECAR = '.kui--sidecar'
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 export const SIDECAR_BASE = (N: number, splitIndex = 1) => `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} ${_SIDECAR}`
 export const SIDECAR = (N: number, splitIndex = 1) => `${SIDECAR_BASE(N, splitIndex)}.visible:not(.minimized)`
-export const SIDECAR_FULLSCREEN = (N: number, splitIndex = 1) => `${SIDECAR(N, splitIndex)}.maximized`
 export const SIDECAR_WITH_FAILURE = (N: number, splitIndex = 1) =>
   `${SIDECAR_BASE(N, splitIndex)}.visible.activation-success-false`
 export const SIDECAR_ACTIVATION_TITLE = (N: number, splitIndex = 1) =>
@@ -135,8 +134,6 @@ export const SIDECAR_FORWARD_BUTTON = (N: number, splitIndex = 1) =>
 export const SIDECAR_FORWARD_BUTTON_DISABLED = (N: number, splitIndex = 1) =>
   `${SIDECAR_HEADER_NAVIGATION(N, splitIndex)} .disabled .kui--sidecar--titlebar-navigation--forward`
 
-export const SIDECAR_MAXIMIZE_BUTTON = (N: number, splitIndex = 1) =>
-  `${SIDECAR(N, splitIndex)} .toggle-sidecar-maximization-button a` // maximize button in the bottom stripe
 export const SIDECAR_CLOSE_BUTTON = (N: number, splitIndex = 1) =>
   `${SIDECAR(N, splitIndex)} .sidecar-bottom-stripe-close a` // close button in the bottom stripe
 export const SIDECAR_RESUME_FROM_CLOSE_BUTTON = (N: number, splitIndex = 1) =>

--- a/packages/test/src/api/sidecar-expect.ts
+++ b/packages/test/src/api/sidecar-expect.ts
@@ -48,14 +48,6 @@ export const openWithFailure = async (res: AppAndCount) => {
     .then(() => res)
 }
 
-/** expect open fullscreen */
-export const fullscreen = async (res: AppAndCount) => {
-  return res.app.client
-    .$(Selectors.SIDECAR_FULLSCREEN(res.count, res.splitIndex))
-    .then(_ => _.waitForDisplayed({ timeout: waitTimeout }))
-    .then(() => res)
-}
-
 /** fully closed, not just minimized */
 export const fullyClosed = async (res: AppAndCount) => {
   return res.app.client

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/BaseSidecarV2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/BaseSidecarV2.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { KResponse, Tab as KuiTab, ParsedOptions, eventChannelUnsafe, isPopup } from '@kui-shell/core'
+import { KResponse, Tab as KuiTab, ParsedOptions, isPopup } from '@kui-shell/core'
 
 import Width from './width'
 import LocationProps from './Location'
@@ -118,12 +118,6 @@ export default class BaseSidecar<R extends KResponse, S extends State> extends R
     return 'visible' + (this.state.isMaximized ? ' maximized' : '')
   }
 
-  private onScreenshot() {
-    setTimeout(() => {
-      eventChannelUnsafe.emit('/screenshot/element', this.dom.current)
-    })
-  }
-
   protected title(
     props?: Omit<
       TitleBarProps,
@@ -135,12 +129,8 @@ export default class BaseSidecar<R extends KResponse, S extends State> extends R
         {...props}
         notCloseable
         repl={this.props.tab.REPL}
-        width={this.state.isMaximized ? Width.Maximized : this.defaultWidth()}
-        fixedWidth={this.isFixedWidth()}
-        onMaximize={this.onMaximize.bind(this)}
-        onRestore={this.onRestore.bind(this)}
+        width={this.defaultWidth()}
         onClose={this.onClose.bind(this)}
-        willScreenshot={this.onScreenshot.bind(this)}
       />
     )
   }

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/TitleBar.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/TitleBar.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { REPL, inBrowser } from '@kui-shell/core'
+import { REPL } from '@kui-shell/core'
 
 import Width from './width'
 import Icons from '../../spi/Icons'
@@ -31,14 +31,10 @@ export interface Props {
   notCloseable?: boolean
 
   repl: REPL
-  fixedWidth: boolean
   width: Width
 
   onClickNamespace?: () => void
-  onMaximize: () => void
-  onRestore: () => void
   onClose: () => void
-  willScreenshot: () => void
 
   back?: { enabled: boolean; onClick: () => void }
   forward?: { enabled?: boolean; onClick: () => void }
@@ -49,78 +45,11 @@ export interface Props {
  * ---------------------------------
  * | Kind | Namespace    S | M m x |
  * ---------------------------------
- *  S: Screenshot button
- *  M: Maximize/Restore button [!props.fixedWith]
- *  m: Minimize button [!props.fixedWith]
- *  x: Close button
  *
  *  Kind: props.kind
  *  Namespace: props.namespace
  */
 export default class Window extends React.PureComponent<Props> {
-  private toggleMaximization() {
-    try {
-      if (this.props.width !== Width.Maximized) {
-        this.props.onMaximize()
-      } else {
-        this.props.onRestore()
-      }
-    } catch (err) {
-      console.error(err)
-    }
-  }
-
-  private readonly _toggleMaximization = this.toggleMaximization.bind(this)
-
-  private readonly _preventDefault = (evt: React.MouseEvent) => evt.preventDefault()
-
-  private screenshotButton() {
-    return (
-      <div className="sidecar-bottom-stripe-button">
-        <span className="kui--sidecar-screenshot-button">
-          <div aria-label="Screenshot">
-            <a
-              href="#"
-              className="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden"
-              tabIndex={-1}
-              onMouseDown={this._preventDefault}
-              onClick={this.props.willScreenshot}
-            >
-              <Icons icon="Screenshot" />
-            </a>
-          </div>
-        </span>
-      </div>
-    )
-  }
-
-  private maximizeButton() {
-    if (this.props.width !== Width.Closed && !this.props.fixedWidth) {
-      const max = this.props.width === Width.Maximized
-      const className = max ? 'unmaximize-button-label' : 'maximize-button-label'
-      const icon = max ? <Icons icon="WindowMinimize" /> : <Icons icon="WindowMaximize" />
-      const aria = max ? 'Restore' : 'Maximize'
-
-      return (
-        <div className="sidecar-bottom-stripe-button sidecar-bottom-stripe-maximize toggle-sidecar-maximization-button">
-          <span className={className}>
-            <div aria-label={aria}>
-              <a
-                href="#"
-                className="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden"
-                tabIndex={-1}
-                onMouseDown={this._preventDefault}
-                onClick={this._toggleMaximization}
-              >
-                {icon}
-              </a>
-            </div>
-          </span>
-        </div>
-      )
-    }
-  }
-
   private quitButton() {
     return (
       <div className="sidecar-bottom-stripe-button sidecar-bottom-stripe-quit">
@@ -215,11 +144,7 @@ export default class Window extends React.PureComponent<Props> {
         <div className="sidecar-bottom-stripe-left-bits"></div>
 
         <div className="sidecar-bottom-stripe-right-bits">
-          <div className="sidecar-window-buttons">
-            {!inBrowser() && this.screenshotButton()}
-            {this.maximizeButton()}
-            {!this.props.notCloseable && this.quitButton()}
-          </div>
+          <div className="sidecar-window-buttons">{!this.props.notCloseable && this.quitButton()}</div>
         </div>
       </div>
     )

--- a/plugins/plugin-client-common/web/css/static/ToolbarButton.scss
+++ b/plugins/plugin-client-common/web/css/static/ToolbarButton.scss
@@ -5,6 +5,7 @@
   svg,
   .bx--tooltip__trigger svg {
     fill: currentColor;
+    padding: 2px;
   }
 
   &:hover {

--- a/plugins/plugin-client-common/web/css/static/sidecar-main.css
+++ b/plugins/plugin-client-common/web/css/static/sidecar-main.css
@@ -178,7 +178,6 @@ $toolbar-height: 1.5rem;
   .sidecar-bottom-stripe-button {
     display: flex;
     line-height: 1.5em;
-    padding: 3px;
 
     & > div {
       display: flex;

--- a/plugins/plugin-client-test/src/test/api1/mmr-mode-via-registration.ts
+++ b/plugins/plugin-client-test/src/test/api1/mmr-mode-via-registration.ts
@@ -92,7 +92,7 @@ testRegistrationWithModes.badges([
   { title: 'badge2', css: 'red-background' },
   { title: 'badge3', css: 'green-background' }
 ])
-testRegistrationWithModes.modes(modes.concat(modesFromRegistration), modes[0], { testWindowButtons: true })
+testRegistrationWithModes.modes(modes.concat(modesFromRegistration), modes[0])
 testRegistrationWithModes.toolbarButtons(buttonFromRegistration)
 
 testRegistrationOnly.modes(modesFromRegistration, modesFromRegistration[0])
@@ -101,6 +101,6 @@ testRegistrationOnly.toolbarButtons(buttonFromRegistration)
 // iterate back and forth between these two, to make sure there is no
 // erroneous state transfer across the mode models
 testRegistrationOnlyWithShow.modes(modesFromRegistration, modesFromRegistration[1])
-testRegistrationWithModes.modes(modes.concat(modesFromRegistration), modes[0], { testWindowButtons: true })
+testRegistrationWithModes.modes(modes.concat(modesFromRegistration), modes[0])
 testRegistrationOnlyWithShow.modes(modesFromRegistration, modesFromRegistration[1])
-testRegistrationWithModes.modes(modes.concat(modesFromRegistration), modes[0], { testWindowButtons: true })
+testRegistrationWithModes.modes(modes.concat(modesFromRegistration), modes[0])

--- a/plugins/plugin-client-test/src/test/api1/mmr-mode.ts
+++ b/plugins/plugin-client-test/src/test/api1/mmr-mode.ts
@@ -157,7 +157,7 @@ testReact.toolbarText({
 
 testDiff.diffPlainText('diff', 'barrrrrrrrr')
 testDefault.name({ heroName: true })
-testDefault.modes(expectModes, expectModes[0], { testWindowButtons: true })
+testDefault.modes(expectModes, expectModes[0])
 testDefault2.modes(expectModes2, expectModes2[0])
 testDefault3.modes(expectModes3, expectModes3[0])
 testDefault4.modes(expectModes4, expectModes4[0])

--- a/plugins/plugin-kubectl/src/test/k8s2/get-pod.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/get-pod.ts
@@ -264,36 +264,9 @@ commands.forEach(command => {
       }
     })
 
-    let clickRes: ReplExpect.AppAndCount
     it(`should list pods via ${command} then click`, async () => {
       try {
-        clickRes = await openSidecarByList(this, `${command} get pods ${inNamespace}`, 'nginx')
-      } catch (err) {
-        return Common.oops(this, true)(err)
-      }
-    })
-
-    it('should click on the sidecar maximize button', async () => {
-      try {
-        await this.app.client
-          .$(Selectors.SIDECAR_MAXIMIZE_BUTTON(clickRes.count, clickRes.splitIndex))
-          .then(_ => _.click())
-        await this.app.client
-          .$(Selectors.SIDECAR_FULLSCREEN(clickRes.count, clickRes.splitIndex))
-          .then(_ => _.waitForExist())
-      } catch (err) {
-        return Common.oops(this, true)(err)
-      }
-    })
-
-    it('should click on the sidecar maximize button to restore split screen', async () => {
-      try {
-        await this.app.client
-          .$(Selectors.SIDECAR_MAXIMIZE_BUTTON(clickRes.count, clickRes.splitIndex))
-          .then(_ => _.click())
-        await this.app.client
-          .$(Selectors.SIDECAR_FULLSCREEN(clickRes.count, clickRes.splitIndex))
-          .then(_ => _.waitForExist({ timeout: 20000, reverse: true }))
+        await openSidecarByList(this, `${command} get pods ${inNamespace}`, 'nginx')
       } catch (err) {
         return Common.oops(this, true)(err)
       }


### PR DESCRIPTION
[10.3.18 fe83b5287] design: remove sidecar Titlebar buttons
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Jun 8 10:36:01 2021 -0400
 8 files changed, 11 insertions(+), 167 deletions(-)

[10.3.18 6580d4d78] design: SplitHeader buttons should match in size with Sidecar toolbar buttons
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Jun 8 12:02:16 2021 -0400
 2 files changed, 1 insertion(+), 1 deletion(-)
