### PR TITLE
fix: sidecar toolbar buttons use different tooltip style than split c…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarButton.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarButton.tsx
@@ -18,6 +18,7 @@ import React from 'react'
 import { Button, ResourceWithMetadata, isViewButton, MultiModalResponse, ParsedOptions } from '@kui-shell/core'
 
 import LocationProps from './Location'
+import Tooltip from '../../spi/Tooltip'
 
 type Props = LocationProps & {
   button: Button
@@ -74,18 +75,18 @@ export default class ToolbarButton<T extends ResourceWithMetadata = ResourceWith
     const { button } = this.props
 
     return (
-      <span
-        className={
-          'kui--tab-navigatable kui--notab-when-sidecar-hidden sidecar-bottom-stripe-button-as-button sidecar-bottom-stripe-button' +
-          (button.icon ? ' kui--toolbar-button-with-icon' : '')
-        }
-      >
-        <div role="presentation" onClick={this._buttonOnclick} data-mode={button.mode}>
-          <span role="tab" title={button.label || button.mode}>
-            {button.icon ? button.icon : button.label || button.mode}
-          </span>
-        </div>
-      </span>
+      <Tooltip content={button.label || button.mode}>
+        <span
+          className={
+            'kui--tab-navigatable kui--notab-when-sidecar-hidden sidecar-bottom-stripe-button-as-button sidecar-bottom-stripe-button' +
+            (button.icon ? ' kui--toolbar-button-with-icon' : '')
+          }
+        >
+          <div role="presentation" onClick={this._buttonOnclick} data-mode={button.mode}>
+            <span role="tab">{button.icon ? button.icon : button.label || button.mode}</span>
+          </div>
+        </span>
+      </Tooltip>
     )
   }
 }

--- a/plugins/plugin-kubectl/src/lib/view/modes/logs.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/logs.tsx
@@ -224,6 +224,7 @@ export class Logs extends Terminal<State> {
     return {
       mode: 'kubectl-logs-previous-toggle',
       label: this.state.showingPrevious ? strings('Show Current') : strings('Show Previous'),
+      icon: <Icons icon={this.state.showingPrevious ? 'NextPage' : 'PreviousPage'} />,
       kind: 'view',
       command: () =>
         this.showContainer(undefined, curState => ({


### PR DESCRIPTION
…lose/clear buttons

This also updates the "Show Previous" kubernetes pod logs button to use an icon rather than text. This helps to give us a more consistent look and spacing.

Fixes #7568

<img width="627" alt="Screen Shot 2021-06-08 at 2 27 39 PM" src="https://user-images.githubusercontent.com/4741620/121238100-ba6eae80-c865-11eb-8f69-1cc42de73887.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
