### PR TITLE
fix(plugins/plugin-s3): S3Mounts widget has high overhead on startup

### DIFF
--- a/plugins/plugin-s3/components/src/S3Mounts.tsx
+++ b/plugins/plugin-s3/components/src/S3Mounts.tsx
@@ -18,11 +18,9 @@ import React from 'react'
 import commonPathPrefix from 'common-path-prefix'
 import { TableComposable, Tbody, Tr, Td } from '@patternfly/react-table'
 
-import { Ansi, Icons, ViewLevel, Markdown, TextWithIconWidget, Tooltip } from '@kui-shell/plugin-client-common'
-
-import { wireToStandardEvents, unwireToStandardEvents, i18n, encodeComponent } from '@kui-shell/core'
-
+import { i18n, encodeComponent } from '@kui-shell/core'
 import { eventBus, Mount, getCurrentMounts } from '@kui-shell/plugin-s3'
+import { Ansi, Icons, ViewLevel, Markdown, TextWithIconWidget, Tooltip } from '@kui-shell/plugin-client-common'
 
 import '../web/scss/S3Mounts.scss'
 
@@ -92,15 +90,14 @@ export default class S3Mounts extends React.PureComponent<Props, State> {
    *
    */
   public componentDidMount() {
-    this.handler()
     eventBus.on('/s3/configuration/update', this.handler)
-    wireToStandardEvents(this.handler)
+    // wireToStandardEvents(this.handler)
   }
 
   /** Make sure to unsubscribe! */
   public componentWillUnmount() {
     eventBus.off('/s3/configuration/update', this.handler)
-    unwireToStandardEvents(this.handler)
+    // unwireToStandardEvents(this.handler)
   }
 
   /** @return the header for the Popover component */


### PR DESCRIPTION
Fixes #7576

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
