### PR TITLE
feat: Update AnimalApp to show the use of a notebook hosted in the cl…

### DIFF
--- a/docs/example/AnimalApp/plugins/plugin-client-default/notebooks/animalapp.json
+++ b/docs/example/AnimalApp/plugins/plugin-client-default/notebooks/animalapp.json
@@ -1,0 +1,119 @@
+{
+  "apiVersion": "kui-shell/v1",
+  "kind": "Notebook",
+  "metadata": {
+    "name": "Welcome to AnimalApp"
+  },
+  "spec": {
+    "splits": [
+      {
+        "uuid": "1_c57e811f-2da8-557e-a402-9f0950407675",
+        "blocks": [
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Welcome to AnimalApp\n\nThis is a test of notebooks."
+              }
+            },
+            "historyIdx": 9,
+            "cwd": "~/git/whisk/nickm/kui/docs/example/AnimalApp",
+            "command": "# # Welcome to AnimalApp\\n\\nThis is a test of notebooks.",
+            "startEvent": {
+              "route": "/#",
+              "startTime": 1623183901175,
+              "command": "# # Welcome to AnimalApp\\n\\nThis is a test of notebooks.",
+              "pipeStages": {
+                "prefix": "",
+                "stages": [["#"]],
+                "redirect": ""
+              },
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--base-url",
+                      "alias": "-b",
+                      "docs": "Base URL for images"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "noCoreRedirect": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "19531506-cf4b-4813-adde-84333b93dd44",
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "19531506-cf4b-4813-adde-84333b93dd44",
+                "history": 9,
+                "env": {}
+              }
+            },
+            "completeEvent": {
+              "execType": 0,
+              "completeTime": 1623183901211,
+              "command": "# # Welcome to AnimalApp\\n\\nThis is a test of notebooks.",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "pipeStages": {
+                "prefix": "",
+                "stages": [["#"]],
+                "redirect": ""
+              },
+              "execUUID": "19531506-cf4b-4813-adde-84333b93dd44",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "noCoreRedirect": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "19531506-cf4b-4813-adde-84333b93dd44",
+                "history": 9,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Welcome to AnimalApp\n\nThis is a test of notebooks."
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 9
+            },
+            "isExperimental": false,
+            "isReplay": true,
+            "execUUID": "19531506-cf4b-4813-adde-84333b93dd44",
+            "originalExecUUID": "19531506-cf4b-4813-adde-84333b93dd44",
+            "startTime": 1623183901175,
+            "outputOnly": true,
+            "state": "valid-response"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/example/AnimalApp/plugins/plugin-client-default/src/index.tsx
+++ b/docs/example/AnimalApp/plugins/plugin-client-default/src/index.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react'
 
-import { i18n, inBrowser } from '@kui-shell/core'
+import { inBrowser } from '@kui-shell/core'
 import { Kui, KuiProps, ContextWidgets, MeterWidgets, CurrentWorkingDirectory } from '@kui-shell/plugin-client-common'
 
 import { CurrentGitBranch } from '@kui-shell/plugin-git'
@@ -26,15 +26,13 @@ import { Screenshot, Search } from '@kui-shell/plugin-electron-components'
 
 import { productName } from '@kui-shell/client/config.d/name.json'
 
-const strings = i18n('plugin-client-default')
-
 /**
  * We will set this bit when the user dismisses the Welcome to Kui
  * tab, so as to avoid opening it again and bothering that user for
  * every new Kui window.
  *
  */
-const welcomeBit = 'plugin-client-default.welcome-was-dismissed'
+// const welcomeBit = 'plugin-client-default.welcome-was-dismissed'
 
 /**
  * Format our body, with extra status stripe widgets
@@ -43,8 +41,6 @@ const welcomeBit = 'plugin-client-default.welcome-was-dismissed'
  *
  */
 export default function renderMain(props: KuiProps) {
-  const title = strings('Welcome to Kui')
-
   return (
     <Kui
       productName={productName}
@@ -54,22 +50,9 @@ export default function renderMain(props: KuiProps) {
       toplevel={!inBrowser() && <Search />}
       commandLine={
         props.commandLine || [
-          'tab',
-          'new',
-          '--cmdline',
-          'replay /kui/welcome.json',
-          '-q', // qexec
-          '--bg', // open in background
-          '--title',
-          title,
-          '--status-stripe-type',
-          'blue',
-          '--status-stripe-message',
-          title,
-          '--if',
-          `kuiconfig not set ${welcomeBit}`,
-          '--onClose',
-          `kuiconfig set ${welcomeBit}`
+          'replay',
+          '/kui/animalapp.json'
+          // '--close-current-tab' // with this, AnimalApp opens showing only the animalapp.json notebook
         ]
       }
     >

--- a/docs/example/AnimalApp/plugins/plugin-client-default/src/preload.ts
+++ b/docs/example/AnimalApp/plugins/plugin-client-default/src/preload.ts
@@ -19,11 +19,6 @@
  *
  */
 export default async () => {
-  // coming soon, in kui 9.0.0
-  /* const { notebookVFS } = await import('@kui-shell/plugin-core-support')
-  notebookVFS.cp(
-    undefined,
-    ['plugin://plugin-client-common/notebooks/welcome.json'],
-    '/kui'
-  ) */
+  const { notebookVFS } = await import('@kui-shell/plugin-core-support')
+  notebookVFS.cp(undefined, ['plugin://client/notebooks/animalapp.json'], '/kui')
 }


### PR DESCRIPTION
…ient plugin

Fixes #7578

with and without the `--close-current-tab` option:

<img width="1118" alt="Screen Shot 2021-06-08 at 4 30 09 PM" src="https://user-images.githubusercontent.com/4741620/121253744-7ab0c280-c877-11eb-99c7-3a5cdf6264df.png">

<img width="729" alt="Screen Shot 2021-06-08 at 4 28 38 PM" src="https://user-images.githubusercontent.com/4741620/121253739-78e6ff00-c877-11eb-95ba-ed183b4218e6.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
