### PR TITLE
10.3.19

### DIFF
--- a/plugins/plugin-bash-like/src/test/bash-like/rerun.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/rerun.ts
@@ -65,6 +65,8 @@ describe(`rerun command ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: C
       await CLI.command('cd /tmp', this.app).then(ReplExpect.okWithAny)
       const cdDirectory = await this.app.client.$(Selectors.OUTPUT_LAST).then(_ => _.getText())
 
+      await CLI.command('sleep 1000', this.app) // test if rerun works when there's an active block
+
       await this.app.client.$(Selectors.PROMPT_N(pwdRes.count)).then(_ => _.moveTo())
       const rerunButton = await this.app.client.$(Selectors.COMMAND_RERUN_BUTTON(pwdRes.count))
       await rerunButton.waitForDisplayed()

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarButton.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarButton.tsx
@@ -18,6 +18,7 @@ import React from 'react'
 import { Button, ResourceWithMetadata, isViewButton, MultiModalResponse, ParsedOptions } from '@kui-shell/core'
 
 import LocationProps from './Location'
+import Tooltip from '../../spi/Tooltip'
 
 type Props = LocationProps & {
   button: Button
@@ -74,18 +75,18 @@ export default class ToolbarButton<T extends ResourceWithMetadata = ResourceWith
     const { button } = this.props
 
     return (
-      <span
-        className={
-          'kui--tab-navigatable kui--notab-when-sidecar-hidden sidecar-bottom-stripe-button-as-button sidecar-bottom-stripe-button' +
-          (button.icon ? ' kui--toolbar-button-with-icon' : '')
-        }
-      >
-        <div role="presentation" onClick={this._buttonOnclick} data-mode={button.mode}>
-          <span role="tab" title={button.label || button.mode}>
-            {button.icon ? button.icon : button.label || button.mode}
-          </span>
-        </div>
-      </span>
+      <Tooltip content={button.label || button.mode}>
+        <span
+          className={
+            'kui--tab-navigatable kui--notab-when-sidecar-hidden sidecar-bottom-stripe-button-as-button sidecar-bottom-stripe-button' +
+            (button.icon ? ' kui--toolbar-button-with-icon' : '')
+          }
+        >
+          <div role="presentation" onClick={this._buttonOnclick} data-mode={button.mode}>
+            <span role="tab">{button.icon ? button.icon : button.label || button.mode}</span>
+          </div>
+        </span>
+      </Tooltip>
     )
   }
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -647,13 +647,6 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
               .concat([Processing(Active(), event, event.evaluatorOptions.isExperimental)])
               .concat(curState.blocks.slice(insertIdx))
           }
-        } else if (isProcessing(curState.blocks[idx])) {
-          // the last block is Processing; this can handle if the user
-          // causes a pexec to be sent to a split that is already
-          // processing
-          return {
-            blocks: curState.blocks.concat(processing(Active()))
-          }
         }
 
         const rerunIdx =
@@ -696,6 +689,13 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
               .slice(0, rerunIdx) // everything before
               .concat(isRerunable(block) ? [Rerun(block, event)] : [])
               .concat(curState.blocks.slice(rerunIdx + 1)) // everything after
+          }
+        } else if (isProcessing(curState.blocks[idx])) {
+          // the last block is Processing; this can handle if the user
+          // causes a pexec to be sent to a split that is already
+          // processing
+          return {
+            blocks: curState.blocks.concat(processing(Active()))
           }
         } else {
           // Transform the last block to Processing

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
@@ -33,9 +33,9 @@ export default class SplitHeader extends React.PureComponent<Props> {
   private closeButton() {
     return (
       <Tooltip markdown={strings('Close this split pane')}>
-        <div className="kui--split-close-button" onClick={this.props.onRemove}>
+        <a href="#" className="kui--split-close-button kui--tab-navigatable" onClick={this.props.onRemove}>
           &#x2A2F;
-        </div>
+        </a>
       </Tooltip>
     )
   }
@@ -43,7 +43,9 @@ export default class SplitHeader extends React.PureComponent<Props> {
   private clearButton() {
     return (
       <Tooltip markdown={strings('Clear this split pane')}>
-        <Icons className="kui--split-clear-button" icon="Clear" onClick={this.props.onClear} />
+        <a href="#" className="kui--tab-navigatable" onClick={this.props.onClear}>
+          <Icons className="kui--split-clear-button" icon="Clear" />
+        </a>
       </Tooltip>
     )
   }

--- a/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
@@ -80,6 +80,7 @@ body[kui-theme-style] {
       svg[data-mode='selected container'] {
         /* need to override some enclosing hover effects from sidecar toolbar */
         fill: currentColor;
+        padding: 0px;
       }
     }
   }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/SplitHeader.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/SplitHeader.scss
@@ -16,34 +16,38 @@
 
 @import 'mixins';
 
-@include SplitHeader {
-  padding: 0.125em 0;
-  padding-left: $input-padding-left;
-  padding-right: $input-padding-right;
+body[kui-theme-style] {
+  @include SplitHeader {
+    padding: 0.125em 0;
+    padding-left: $input-padding-left;
+    padding-right: $input-padding-right;
 
-  opacity: 0.925;
-  background-color: var(--color-sidecar-toolbar-background);
-  & > div {
-    color: var(--color-sidecar-toolbar-foreground);
+    opacity: 0.925;
+    background-color: var(--color-sidecar-toolbar-background);
+
+    & > a,
+    & > div {
+      color: var(--color-sidecar-toolbar-foreground);
+    }
+
+    & > svg {
+      fill: var(--color-sidecar-toolbar-foreground);
+    }
   }
 
-  & > svg {
-    fill: var(--color-sidecar-toolbar-foreground);
+  @include SplitHeaderClose {
+    padding: 2px;
+    &:hover {
+      cursor: pointer;
+      background-color: var(--color-table-border1);
+    }
   }
-}
 
-@include SplitHeaderClose {
-  padding: 2px;
-  &:hover {
-    cursor: pointer;
-    background-color: var(--color-table-border1);
-  }
-}
-
-@include SplitHeaderClear {
-  padding: 2px;
-  &:hover {
-    cursor: pointer;
-    background-color: var(--color-table-border1);
+  @include SplitHeaderClear {
+    padding: 2px;
+    &:hover {
+      cursor: pointer;
+      background-color: var(--color-table-border1);
+    }
   }
 }

--- a/plugins/plugin-kubectl/src/lib/view/modes/logs.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/logs.tsx
@@ -224,6 +224,7 @@ export class Logs extends Terminal<State> {
     return {
       mode: 'kubectl-logs-previous-toggle',
       label: this.state.showingPrevious ? strings('Show Current') : strings('Show Previous'),
+      icon: <Icons icon={this.state.showingPrevious ? 'NextPage' : 'PreviousPage'} />,
       kind: 'view',
       command: () =>
         this.showContainer(undefined, curState => ({


### PR DESCRIPTION
[10.3.19 12ce42178] fix: split close button is not tab navigable
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Jun 8 13:47:20 2021 -0400
 2 files changed, 32 insertions(+), 26 deletions(-)

[10.3.19 eff92c56f] fix: sidecar toolbar buttons use different tooltip style than split close/clear buttons
 Date: Tue Jun 8 14:26:21 2021 -0400
 2 files changed, 14 insertions(+), 12 deletions(-)

[10.3.19 7a298fa2e] fix(plugins/plugin-client-common): icons in dropdown in sidecar toolbar are too small
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Jun 8 14:43:17 2021 -0400
 1 file changed, 1 insertion(+)
Auto-merging plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx

[10.3.19 8d3b793e6] fix(plugins/plugin-client-common): rerunning a block when there is an active block seems to insert a new block
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Jun 8 15:24:30 2021 -0400
 2 files changed, 9 insertions(+), 7 deletions(-)