### PR TITLE
fix: width of vi not correct after closing splits

### DIFF
--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -61,10 +61,12 @@ interface Size {
   cols: number
 }
 let resizeGeneration = 0
+function bumpGeneration() {
+  resizeGeneration++
+}
 if (window) {
-  window.addEventListener('resize', () => {
-    resizeGeneration++
-  })
+  window.addEventListener('resize', bumpGeneration)
+  eventChannelUnsafe.on('/zoom', bumpGeneration)
 }
 function getCachedSize(tab: Tab): Size {
   const cachedSize: Size = tab['_kui_pty_cachedSize']

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -1075,6 +1075,8 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
         return { splits, focusedIdx }
       }
     })
+
+    setTimeout(() => eventChannelUnsafe.emit('/zoom'))
   }
 
   /**


### PR DESCRIPTION
Fixes #7600

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
