### PR TITLE
chore: remove splitTerminals feature flag

### DIFF
--- a/docs/example/AnimalApp/plugins/plugin-client-default/src/index.tsx
+++ b/docs/example/AnimalApp/plugins/plugin-client-default/src/index.tsx
@@ -44,7 +44,6 @@ export default function renderMain(props: KuiProps) {
   return (
     <Kui
       productName={productName}
-      splitTerminals
       lightweightTables
       {...props}
       toplevel={!inBrowser() && <Search />}

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/SplitTerminalButton.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/SplitTerminalButton.tsx
@@ -18,7 +18,6 @@ import React from 'react'
 import { i18n, inBrowser, pexecInCurrentTab } from '@kui-shell/core'
 
 import Icons from '../../spi/Icons'
-import KuiContext from '../context'
 import ctrlOrMeta from './ctrlOrMeta'
 import Tooltip from '../../spi/Tooltip'
 
@@ -59,16 +58,10 @@ export default class SplitTerminalButton extends React.PureComponent {
 
   public render() {
     return (
-      <KuiContext.Consumer>
-        {config =>
-          config.splitTerminals && (
-            <React.Fragment>
-              {this.button()}
-              {this.tooltip()}
-            </React.Fragment>
-          )
-        }
-      </KuiContext.Consumer>
+      <React.Fragment>
+        {this.button()}
+        {this.tooltip()}
+      </React.Fragment>
     )
   }
 }

--- a/plugins/plugin-client-common/src/components/Client/props/FeatureFlags.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/FeatureFlags.ts
@@ -26,9 +26,6 @@ type FeatureFlags = {
   /** [Optional] show sidecar name as breadcrumb or hero text, default: 'breadcrumb' */
   sidecarName?: 'breadcrumb' | 'heroText'
 
-  /** [Optional] Enable Split Terminals? */
-  splitTerminals?: boolean
-
   /** [Optional] Show bottom status stripe? [default: true] */
   statusStripe?: boolean
 

--- a/plugins/plugin-client-common/src/components/Content/Table/Grid.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/Grid.tsx
@@ -23,7 +23,6 @@ import { onClickForCell } from './TableCell'
 import DefaultColoring, { Coloring } from './Coloring'
 import tooltipContent, { tooltipProps } from './Tooltip'
 const Markdown = React.lazy(() => import('../Markdown'))
-import KuiConfiguration from '../../Client/KuiConfiguration'
 
 /** parameters to Grid component */
 export type Props<T extends KuiTable = KuiTable> = {
@@ -32,7 +31,6 @@ export type Props<T extends KuiTable = KuiTable> = {
   response: T
   visibleRows: KuiRow[]
   justUpdated: Record<string, boolean> // rowKey index
-  config: KuiConfiguration
 }
 
 export const findGridableColumn = (response: KuiTable) => {
@@ -106,14 +104,7 @@ export default class Grid<P extends Props> extends React.PureComponent<P, State>
           <div key={_.name} data-name={_.name} className={_.css}>
             <span
               className={_.onclick && 'clickable'}
-              onClick={onClickForCell(
-                _,
-                this.props.tab,
-                this.props.repl,
-                _.onclick,
-                this.props.response,
-                this.props.config
-              )}
+              onClick={onClickForCell(_, this.props.tab, this.props.repl, _.onclick, this.props.response)}
             >
               {this.props.response.markdown ? <Markdown nested source={_.name} /> : _.name}
             </span>
@@ -154,8 +145,7 @@ export default class Grid<P extends Props> extends React.PureComponent<P, State>
               tab,
               repl,
               kuiRow.attributes.find(_ => _.onclick),
-              this.props.response,
-              this.props.config
+              this.props.response
             )
           }
 

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -339,7 +339,6 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
         response={this.props.response}
         visibleRows={visibleRows}
         justUpdated={this.justUpdatedMap()}
-        config={this.props.config}
       />
     )
   }
@@ -394,7 +393,7 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
         <TableComposable className="kui--table-like-wrapper" variant={variant} isStickyHeader gridBreakPoint="">
           {header &&
             renderHeader(header, isSortable, this.state.activeSortIdx, this.state.activeSortDir, onSort.bind(this))}
-          {renderBody(response, this.justUpdatedMap(), tab, repl, offset, this.props.config)}
+          {renderBody(response, this.justUpdatedMap(), tab, repl, offset)}
         </TableComposable>
       </div>
     )

--- a/plugins/plugin-client-common/src/components/Content/Table/SequenceDiagram.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/SequenceDiagram.tsx
@@ -494,14 +494,7 @@ export default class SequenceDiagram extends React.PureComponent<Props, State> {
                 : (gap >= 0 ? '+' : '') + prettyPrintDuration(gap)
 
             // drilldown to underlying resource, e.g. Pod for Kubernetes Jobs
-            const onClick = onClickForCell(
-              row,
-              this.props.tab,
-              this.props.repl,
-              row.attributes[0],
-              this.props.response,
-              this.props.config
-            )
+            const onClick = onClickForCell(row, this.props.tab, this.props.repl, row.attributes[0], this.props.response)
 
             // rows that help to define the contents of the interval; e.g. jobName
             const interGroupGapRow =

--- a/plugins/plugin-client-common/src/components/Content/Table/TableBody.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableBody.tsx
@@ -22,7 +22,6 @@ import { EmptyState, EmptyStateVariant, Bullseye, Title, EmptyStateIcon } from '
 import { SearchIcon } from '@patternfly/react-icons'
 
 import renderCell from './TableCell'
-import KuiConfiguration from '../../Client/KuiConfiguration'
 
 const strings = i18n('plugin-client-common')
 
@@ -37,8 +36,7 @@ export default function renderBody(
   justUpdated: Record<string, boolean>, // rowKey index
   tab: Tab,
   repl: REPL,
-  offset: number,
-  config: KuiConfiguration
+  offset: number
 ) {
   const emptyState = () => {
     return (
@@ -62,7 +60,7 @@ export default function renderBody(
         ? emptyState()
         : kuiTable.body.map((kuiRow, ridx) => {
             const updated = justUpdated[kuiRow.rowKey || kuiRow.name]
-            const cell = renderCell(kuiTable, kuiRow, updated, tab, repl, config)
+            const cell = renderCell(kuiTable, kuiRow, updated, tab, repl)
 
             const key = kuiRow.key || (kuiTable.header ? kuiTable.header.key || kuiTable.header.name : undefined)
 

--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -35,7 +35,6 @@ import tooltipContent, { tooltipProps } from './Tooltip'
 const Markdown = React.lazy(() => import('../Markdown'))
 import ErrorCell from './ErrorCell'
 import whenNothingIsSelected from '../../../util/selection'
-import KuiConfiguration from '../../Client/KuiConfiguration'
 
 export type CellOnClickHandler = (evt: React.MouseEvent) => void
 
@@ -52,8 +51,7 @@ export function onClickForCell(
   tab: Tab,
   repl: REPL,
   cell?: KuiCell,
-  opts?: Pick<KuiTable, 'drilldownTo'> & { selectRow?: () => void },
-  config?: KuiConfiguration
+  opts?: Pick<KuiTable, 'drilldownTo'> & { selectRow?: () => void }
 ): CellOnClickHandler {
   const { drilldownTo = 'side-split', selectRow = () => undefined } = opts || {}
 
@@ -81,11 +79,7 @@ export function onClickForCell(
       return whenNothingIsSelected(async (evt: React.MouseEvent) => {
         evt.stopPropagation()
         selectRow()
-        if (
-          config.splitTerminals &&
-          drilldownTo === 'side-split' &&
-          !XOR(evt.metaKey, !!process.env.KUI_SPLIT_DRILLDOWN)
-        ) {
+        if (drilldownTo === 'side-split' && !XOR(evt.metaKey, !!process.env.KUI_SPLIT_DRILLDOWN)) {
           pexecInCurrentTab(`split --ifnot is-split --cmdline "${handler}"`, undefined, false, true)
         } else if (!isHeadless() && drilldownTo === 'new-window') {
           const { ipcRenderer } = await import('electron')
@@ -116,14 +110,7 @@ export function onClickForCell(
  * Render a TableCell part
  *
  */
-export default function renderCell(
-  table: KuiTable,
-  kuiRow: KuiRow,
-  justUpdated: boolean,
-  tab: Tab,
-  repl: REPL,
-  config: KuiConfiguration
-) {
+export default function renderCell(table: KuiTable, kuiRow: KuiRow, justUpdated: boolean, tab: Tab, repl: REPL) {
   return function KuiTableCell(
     key: string,
     value: string,
@@ -186,7 +173,7 @@ export default function renderCell(
           data-value={value}
           data-tag={tag}
           className={outerClassName}
-          onClick={onclick ? onClickForCell(kuiRow, tab, repl, attributes[cidx - 1], table, config) : undefined}
+          onClick={onclick ? onClickForCell(kuiRow, tab, repl, attributes[cidx - 1], table) : undefined}
         >
           {tag === 'badge' && (
             <span

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -333,16 +333,12 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
   }
 
   private allocateUUIDForScrollback() {
-    if (this.props.config.splitTerminals) {
-      // this.props.uuid is the uuid for the whole tab
-      // on top of that, we allocate a "v5" uuid for this scrollback
-      const sbidx = this.scrollbackCounter++
-      const tabPart = this.props.uuid
-      const scrollbackPart = v5(sbidx.toString(), UUID_NAMESPACE)
-      return `${tabPart}_${scrollbackPart}`
-    } else {
-      return this.props.uuid
-    }
+    // this.props.uuid is the uuid for the whole tab
+    // on top of that, we allocate a "v5" uuid for this scrollback
+    const sbidx = this.scrollbackCounter++
+    const tabPart = this.props.uuid
+    const scrollbackPart = v5(sbidx.toString(), UUID_NAMESPACE)
+    return `${tabPart}_${scrollbackPart}`
   }
 
   /** Restore from localStorage for a given tab UUID */

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -75,7 +75,6 @@ export default function renderMain(props: KuiProps) {
   return (
     <Kui
       productName={productName}
-      splitTerminals
       lightweightTables
       {...props}
       isPopup={isPopup}

--- a/plugins/plugin-client-notebook/src/index.tsx
+++ b/plugins/plugin-client-notebook/src/index.tsx
@@ -56,7 +56,6 @@ export default function renderMain(props: KuiProps) {
       productName="Kui"
       noHelp
       noSettings
-      splitTerminals
       lightweightTables
       {...props}
       commandLine={

--- a/plugins/plugin-client-test/src/index.tsx
+++ b/plugins/plugin-client-test/src/index.tsx
@@ -33,7 +33,7 @@ import '../web/css/static/test.scss'
  */
 export default function TestClient(props: KuiProps) {
   return (
-    <Kui {...props} splitTerminals disableTableTitle sidecarName="heroText">
+    <Kui {...props} disableTableTitle sidecarName="heroText">
       <ContextWidgets>
         <CounterWidget idx={0} />
       </ContextWidgets>


### PR DESCRIPTION
Fixes #7593 

BREAKING_CHANGE: the `splitTerminals` property of `<Kui/>` is no longer needed nor supported.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
