### PR TITLE
fix: CurrentContext and CurrentNamespace widgets double-fetch onLoad

### DIFF
--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -241,7 +241,6 @@ export default class CurrentContext extends React.PureComponent<Props, State> {
    *
    */
   public componentDidMount() {
-    this.handler()
     eventBus.on('/tab/new', this.handler)
     eventBus.on('/tab/switch/request/done', this.handlerNotCallingKubectl)
 

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -129,7 +129,6 @@ export default class CurrentNamespace extends React.PureComponent<Props, State> 
    *
    */
   public componentDidMount() {
-    this.handler()
     eventBus.on('/tab/new', this.handler)
     eventBus.on('/tab/switch/request/done', this.handlerNotCallingKubectl)
 


### PR DESCRIPTION
Two things are going on here:

1) In CurrentContext and CurrentNamespace, we issue the calls to fetch the info twice, once on mount of each widget, and once the initial Tab is mounted; we only need the latter

2) The way plugin-kubectl caches current context and current namespace is a bit racy on initial page load. We cache the strings, rather than the Promise of the strings. This can lead to double fetching if two initial requests come in close succession. It turns out that both of these widgets ask for the current namespace, hence we run into this race.

These fixes should also resolve a Content Layout Shift glitch that you can either observe visually, or via the Performance tab in chrome/electron.

Fixes #7624

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
