### PR TITLE
fix(plugins/plugin-kubectl): CurrentContext/CurrentNamespace widgets …

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -107,7 +107,8 @@ $z-index: var(--pf-global--ZIndex--xs);
             background-color: var(--color-yellow);
           }
           &[data-view='info'] {
-            background-color: var(--color-brand-01);
+            font-style: italic;
+            background-color: var(--color-base04);
           }
           color: var(--color-base00);
         }


### PR DESCRIPTION
…show nothing while loading

Fixes #7629

### Patternfly4 Light
![Jun-15-2021 11-55-46](https://user-images.githubusercontent.com/4741620/122087628-ed1f2680-cdd2-11eb-9cb0-892b7e51df90.gif)

### Patternfly4 Dark
![Jun-15-2021 11-58-23](https://user-images.githubusercontent.com/4741620/122087641-ef818080-cdd2-11eb-9658-ddb6ae698b38.gif)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
