### PR TITLE
feat: add readonly and executable client options for replaying notebooks

### DIFF
--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -20,10 +20,47 @@ const debug = Debug('core/api/client')
 /** Is the current client running in offline/disconnected mode? */
 export function isOfflineClient(): boolean {
   try {
-    const { offline } = require('@kui-shell/client/config.d/client.json')
-    return offline
+    const { offline, readonly, executable } = require('@kui-shell/client/config.d/client.json')
+
+    if (offline === undefined && readonly !== undefined && executable !== undefined) {
+      return readonly && !executable
+    } else {
+      return offline
+    }
   } catch (err) {
     debug('Client did not define an offline status, assuming not offline')
     return false
+  }
+}
+
+/** Is the current client running in readonly mode? */
+export function isReadOnlyClient(): boolean {
+  try {
+    const { offline, readonly } = require('@kui-shell/client/config.d/client.json')
+
+    if (offline) {
+      return true
+    } else {
+      return readonly
+    }
+  } catch (err) {
+    debug('Client did not define a readonly status, assuming not readonly')
+    return false
+  }
+}
+
+/** Is the current client running in an executable mode? */
+export function isExecutableClient(): boolean {
+  try {
+    const { offline, executable } = require('@kui-shell/client/config.d/client.json')
+
+    if (offline) {
+      return false
+    } else {
+      return executable === undefined ? true : executable
+    }
+  } catch (err) {
+    debug('Client did not define an executable status, assuming executable')
+    return true
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -306,6 +306,6 @@ export {
 export { default as teeToFile } from './util/tee'
 
 // Client API
-export { isOfflineClient } from './api/client'
+export { isOfflineClient, isReadOnlyClient, isExecutableClient } from './api/client'
 
 export * from './api/window-events'

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { Tab, i18n, isOfflineClient } from '@kui-shell/core'
+import { Tab, i18n, isOfflineClient, isReadOnlyClient, isExecutableClient } from '@kui-shell/core'
 
 import { InputOptions } from './Input'
 import { SupportedIcon } from '../../../spi/Icons'
@@ -123,10 +123,10 @@ export default class Actions extends React.PureComponent<Props> {
       !isOfflineClient() && (
         <div className="kui--block-actions-buttons kui--inverted-color-context">
           <div className="kui-block-actions-others">
-            {this.copyAction()}
-            {this.rerunAction()}
+            {!isReadOnlyClient() && this.copyAction()}
+            {isExecutableClient() && this.rerunAction()}
           </div>
-          {this.removeAction()}
+          {!isReadOnlyClient() && this.removeAction()}
         </div>
       )
     )

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { i18n } from '@kui-shell/core'
+import { i18n, isReadOnlyClient } from '@kui-shell/core'
 
 import Icons from '../../spi/Icons'
 import Tooltip from '../../spi/Tooltip'
@@ -59,11 +59,13 @@ export default class SplitHeader extends React.PureComponent<Props> {
 
   public render() {
     return (
-      <div className="kui--split-header flex-layout kui--inverted-color-context">
-        <div className="flex-fill" />
-        {this.clearButton()}
-        {this.closeButton()}
-      </div>
+      !isReadOnlyClient() && (
+        <div className="kui--split-header flex-layout kui--inverted-color-context">
+          <div className="flex-fill" />
+          {this.clearButton()}
+          {this.closeButton()}
+        </div>
+      )
     )
   }
 }


### PR DESCRIPTION
Fixes #7635 

This PR adds two client options:
- readonly: if true, do not show `splitHeader` and block `copy` and `remove` buttons; default to false
- executable:  if false, do not show the block `rerun` button; default to false

If client specifies `readonly: true` and `executable: false`, Kui will enter `offline` mode. 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
