### PR TITLE
feat: add client option `hideReplayOutput` to hide output when replay…

### DIFF
--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -64,3 +64,13 @@ export function isExecutableClient(): boolean {
     return true
   }
 }
+
+export function hideReplayOutput(): boolean {
+  try {
+    const { hideReplayOutput } = require('@kui-shell/client/config.d/client.json')
+    return hideReplayOutput
+  } catch (err) {
+    debug('Client did not define a hideReplayOutput status, assuming no')
+    return false
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -306,6 +306,6 @@ export {
 export { default as teeToFile } from './util/tee'
 
 // Client API
-export { isOfflineClient, isReadOnlyClient, isExecutableClient } from './api/client'
+export { isOfflineClient, isReadOnlyClient, isExecutableClient, hideReplayOutput } from './api/client'
 
 export * from './api/window-events'

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -17,6 +17,7 @@
 import React from 'react'
 
 import {
+  hideReplayOutput,
   i18n,
   isAbortableResponse,
   isCodedError,
@@ -352,8 +353,20 @@ export default class Output extends React.PureComponent<Props, State> {
         ? this.state.assertHasContent
         : this.isShowingSomethingInTerminal(this.props.model)
 
+    const hideOutput =
+      hideReplayOutput() &&
+      isFinished(this.props.model) &&
+      !isCancelled(this.props.model) &&
+      !isEmpty(this.props.model) &&
+      !isCommentaryResponse(this.props.model.response) &&
+      this.props.model.isReplay
+
     return (
-      <div className={'repl-output ' + (hasContent ? ' repl-result-has-content' : '')}>
+      <div
+        className={
+          'repl-output ' + (hasContent ? ' repl-result-has-content' : '') + (hideOutput ? ' repl-result-hide' : '')
+        }
+      >
         {!this.props.isPartOfMiniSplit && hasContent && this.ctx()}
         <div className="result-vertical">
           {this.stream()}

--- a/plugins/plugin-client-common/web/css/static/repl.scss
+++ b/plugins/plugin-client-common/web/css/static/repl.scss
@@ -109,6 +109,9 @@
 .repl-block.valid-response .repl-output {
   display: flex;
   /* align-items: flex-start; */
+  &.repl-result-hide {
+    display: none;
+  }
 }
 .repl-result-spinner {
   font-size: 0.875rem;


### PR DESCRIPTION
Fixes #7634 

This PR adds a client option `hideReplayOutput` to hide any `non-comentary` output when replaying a notebook. Note: when user reruns a command in the replayed notebook, the output will not be hidden.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
