### PR TITLE
fix(plugins/plugin-client-common): FancyPipeline errors out when rerunning snapshot blocks saved before pipestage was introduced

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -341,14 +341,6 @@ export function isWithCompleteEvent(block: BlockModel): block is CompleteBlock {
   return (isOk(block) || isOops(block) || isEmpty(block)) && block.completeEvent !== undefined
 }
 
-/** @return whether the block has pipeStages information; older snapshots may not */
-export function hasPipeStages(block: BlockModel) {
-  return (
-    (hasStartEvent(block) && block.startEvent.pipeStages !== undefined) ||
-    (isWithCompleteEvent(block) && block.completeEvent.pipeStages !== undefined)
-  )
-}
-
 /** @return whether the block is from replay */
 export function isReplay(block: BlockModel): boolean {
   return (isProcessing(block) || isWithCompleteEvent(block)) && block.isReplay

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -37,7 +37,6 @@ import {
   isFinished,
   hasCommand,
   isEmpty,
-  hasPipeStages,
   hasStartEvent,
   isWithCompleteEvent,
   isReplay,
@@ -678,9 +677,9 @@ export default class Input extends InputProvider {
    *
    */
   private fancyValue(value: string) {
-    if (isWithCompleteEvent(this.props.model) && hasPipeStages(this.props.model)) {
+    if (isWithCompleteEvent(this.props.model) && this.props.model.completeEvent.pipeStages !== undefined) {
       return <FancyPipeline REPL={this.props.tab.REPL} {...this.props.model.completeEvent.pipeStages} />
-    } else if (hasStartEvent(this.props.model) && hasPipeStages(this.props.model)) {
+    } else if (hasStartEvent(this.props.model) && this.props.model.startEvent.pipeStages !== undefined) {
       return <FancyPipeline REPL={this.props.tab.REPL} {...this.props.model.startEvent.pipeStages} />
     } else {
       return <span className="repl-input-element flex-fill">{value}</span>


### PR DESCRIPTION
Fixes #7662 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
