### PR TITLE
fix: ls should not use Markdown for cells (slow)

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -251,7 +251,6 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): Table {
   return {
     header,
     body,
-    markdown: true,
     noSort: true,
     defaultPresentation,
     allowedPresentations,

--- a/plugins/plugin-core-support/src/notebooks/vfs/index.ts
+++ b/plugins/plugin-core-support/src/notebooks/vfs/index.ts
@@ -137,10 +137,7 @@ export class NotebookVFS implements VFS {
   private enumerate({ entries }: { entries: Entry[] }) {
     return entries.map((mount: Entry) => {
       const name = basename(mount.mountPath)
-      const nameForDisplay =
-        isLeaf(mount) && mount.data.metadata
-          ? mount.data.metadata.description || mount.data.metadata.name || name
-          : name
+      const nameForDisplay = isLeaf(mount) && mount.data.metadata ? mount.data.metadata.name || name : name
       const isDir = !isLeaf(mount)
 
       return {


### PR DESCRIPTION
This PR also disables use of a notebook's description (which may contain markdown). I think this was the sole use of Markdown in tables.

Fixes #7667

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
