### PR TITLE
fix(plugins/plugin-client-common): Change block rerun action button f…

### DIFF
--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -194,7 +194,7 @@ export const BLOCK_DOWN_BUTTON = (N: number) => `${PROMPT_BLOCK_N(N)} .kui--bloc
 export const BLOCK_SECTION_BUTTON = (N: number) => `${PROMPT_BLOCK_N(N)} .kui--block-action [icon="Section"]`
 export const COMMAND_COPY_BUTTON = (N: number) => `${PROMPT_BLOCK_N(N)} .kui--block-action [icon="Copy"]`
 export const COMMAND_COPY_DONE_BUTTON = (N: number) => `${PROMPT_BLOCK_N(N)} .kui--block-action [icon="Checkmark"]`
-export const COMMAND_RERUN_BUTTON = (N: number) => `${PROMPT_BLOCK_N(N)} .kui--block-action [icon="Retry"]`
+export const COMMAND_RERUN_BUTTON = (N: number) => `${PROMPT_BLOCK_N(N)} .kui--block-action [icon="Play"]`
 export const PROMPT_LAST = `${PROMPT_BLOCK_LAST} .repl-input-element`
 export const PROMPT_FINAL = `${PROMPT_BLOCK_FINAL} .repl-input-element`
 export const OUTPUT_LAST = `${PROMPT_BLOCK_LAST} .repl-result`

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
@@ -64,7 +64,7 @@ export default class Actions extends React.PureComponent<Props> {
         }
       }
 
-      return <Action icon="Retry" onClick={handler} title={strings('Re-execute this command')} />
+      return <Action icon="Play" onClick={handler} title={strings('Re-execute this command')} />
     }
   }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -196,28 +196,27 @@
       }
     }
     @include BlockActions {
-      align-items: center;
       display: flex;
       opacity: 0;
       border-radius: 1px;
       background-color: var(--color-base03);
 
+      transition-property: opacity;
+      transition-delay: $action-hover-delay;
+      transition-duration: 140ms;
+
       position: absolute;
       top: 0; /* this with bottom:0 gives 1) vertical center; 2) occluding of repl-input-element content */
       bottom: 0;
       right: 0;
-
-      padding-left: 0.5em;
-      transition-property: opacity;
-      transition-delay: $action-hover-delay;
-      transition-duration: 140ms;
     }
 
     .kui--block-action {
       align-items: center;
+      justify-content: center;
       display: flex;
-      margin-right: $action-padding;
       padding: $action-padding;
+      width: $action-width;
       color: var(--color-text-01);
 
       /* This is a bit of a hack for TwoFaceIcon, to work around the Checkmark being narrower than other icons in Carbon */
@@ -238,8 +237,6 @@
     }
 
     .kui-block-actions-others:not(:empty) {
-      padding-right: $action-padding;
-      margin-right: $action-padding;
       display: flex;
       border-right: 1px solid var(--color-table-border1);
     }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -21,8 +21,9 @@ $inset: 0.375em;
 $right-element-font-size-factor: 0.75;
 $right-element-font-size: $right-element-font-size-factor + rem;
 
-/** Padding for action buttons */
+/** Sizing for Block action buttons */
 $action-padding: 3px;
+$action-width: 2em;
 
 /** Color to indicate focused block */
 $focus-color: var(--color-brand-01);


### PR DESCRIPTION
…rom Retry icon to Play icon

This PR also improves the padding/spacing/hover effect of the Block Action buttons.

Fixes #7696

# After
<img width="130" alt="Screen Shot 2021-06-23 at 12 22 57 PM" src="https://user-images.githubusercontent.com/4741620/123133500-cb025580-d41d-11eb-89e3-73f47a6f1430.png">

# Before

<img width="120" alt="Screen Shot 2021-06-23 at 12 24 00 PM" src="https://user-images.githubusercontent.com/4741620/123133674-f84f0380-d41d-11eb-98c3-71bb644ea2f9.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
