### PR TITLE
fix(plugins/plugin-client-common): hideReplayOutput doesn't always wo…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -22,6 +22,8 @@ import {
   KResponse,
   ScalarResponse,
   UsageError,
+  hideReplayOutput,
+  isCommentaryResponse,
   isCommentarySectionBreak,
   isXtermErrorResponse,
   cwd as kuiCwd
@@ -374,4 +376,17 @@ export function Rerun(
     originalExecUUID: (hasOriginalUUID(block) && block.originalExecUUID) || block.execUUID,
     startTime: newStartTime
   })
+}
+
+/** this implements support for not showing the Output blocks when replaying a notebook */
+export function hideOutput(model: BlockModel): boolean {
+  return (
+    hideReplayOutput() && // client asked us not to show replay output in notebooks
+    isReplay(model) && // we are showing a notebook
+    !hasBeenRerun(model) && // user has yet to re-execute the block in this notebook
+    isFinished(model) &&
+    !isCancelled(model) &&
+    !isEmpty(model) &&
+    !isCommentaryResponse(model.response)
+  )
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -17,7 +17,6 @@
 import React from 'react'
 
 import {
-  hideReplayOutput,
   i18n,
   isAbortableResponse,
   isCodedError,
@@ -353,20 +352,8 @@ export default class Output extends React.PureComponent<Props, State> {
         ? this.state.assertHasContent
         : this.isShowingSomethingInTerminal(this.props.model)
 
-    const hideOutput =
-      hideReplayOutput() &&
-      isFinished(this.props.model) &&
-      !isCancelled(this.props.model) &&
-      !isEmpty(this.props.model) &&
-      !isCommentaryResponse(this.props.model.response) &&
-      this.props.model.isReplay
-
     return (
-      <div
-        className={
-          'repl-output ' + (hasContent ? ' repl-result-has-content' : '') + (hideOutput ? ' repl-result-hide' : '')
-        }
-      >
+      <div className={'repl-output ' + (hasContent ? ' repl-result-has-content' : '')}>
         {!this.props.isPartOfMiniSplit && hasContent && this.ctx()}
         <div className="result-vertical">
           {this.stream()}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -29,6 +29,7 @@ import {
   isOutputOnly,
   isProcessing,
   isAnnouncement,
+  hideOutput,
   hasUUID
 } from './BlockModel'
 
@@ -224,10 +225,12 @@ export default class Block extends React.PureComponent<Props, State> {
    *
    */
   public render() {
+    const hideOut = hideOutput(this.props.model)
+
     return (
       (!this.props.noActiveInput || !isActive(this.props.model)) && (
         <li
-          className={'repl-block kui--maximize-candidate ' + this.props.model.state.toString()}
+          className={'repl-block ' + (hideOut ? '' : this.props.model.state.toString())}
           data-is-executale={this.props.isExecutable}
           data-is-section-break={this.props.isSectionBreak}
           data-in-sections={this.props.sectionIdx !== undefined || undefined}
@@ -252,7 +255,7 @@ export default class Block extends React.PureComponent<Props, State> {
           ) : (
             <React.Fragment>
               {this.input()}
-              {this.output()}
+              {!hideOut && this.output()}
             </React.Fragment>
           )}
         </li>

--- a/plugins/plugin-client-common/web/css/static/repl.scss
+++ b/plugins/plugin-client-common/web/css/static/repl.scss
@@ -109,9 +109,6 @@
 .repl-block.valid-response .repl-output {
   display: flex;
   /* align-items: flex-start; */
-  &.repl-result-hide {
-    display: none;
-  }
 }
 .repl-result-spinner {
   font-size: 0.875rem;


### PR DESCRIPTION
…rk as expected

This PR shifts the "hide output" logic from `<Output>` to `<Block>`. Instead of using css, we do not even render the Output component at all, in these scenarios.

FIxes #7711

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
