### PR TITLE
fix(plugins/plugin-kubectl): kubectl direct get may pass through kube…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/get.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/get.ts
@@ -196,7 +196,7 @@ export async function get(
     try {
       response = (await fetchFile(args.REPL, urls, { headers: { accept: 'application/json' } }))[0]
     } catch (err) {
-      response = tryParseAsStatus(err.message)
+      response = tryParseAsStatus(err.code, err.message)
       if (!isStatus(response)) {
         throw err
       }

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -283,7 +283,7 @@ async function rawGet(
         return response
       }
     } catch (err) {
-      if (err.code !== 500 && err.code !== undefined) {
+      if (err.code !== 500 && err.code !== undefined && !/page not found/.test(err.message)) {
         // expected apiServer error, i.e. Kubernetes Status errors
         throw err
       } else {

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -150,7 +150,11 @@ export async function _needle(
 
     // internal usage: test kui's error handling of apiServer
     if (process.env.TRAVIS_CHAOS_TESTING) {
-      throw new Error('nope')
+      // simulate a condition where kuiproxy is not installed on the apiserver
+      const error: CodedError = new Error('404 page not found')
+      error.code = 404
+      error.statusCode = 404
+      throw error
     }
 
     try {
@@ -231,6 +235,7 @@ async function fetchRemote(repl: REPL, url: string, opts?: FetchOptions<BodyData
 }
 
 export type ReturnedError = {
+  code: number | string
   error: string
 }
 
@@ -264,7 +269,10 @@ export async function fetchFile(
           Object.assign({}, opts, { data: Array.isArray(opts.data) ? opts.data[idx] : opts.data })
         ).catch(err => {
           if (opts && opts.returnErrors) {
-            return { error: err.message || JSON.stringify(err) }
+            return {
+              code: err.code,
+              error: err.message || JSON.stringify(err)
+            }
           } else throw err
         })
       } else {


### PR DESCRIPTION
…proxy 404s to user

This PR improves the error handling paths, to ensure that 1) http status codes are correctly passed through (there were some gaps); and 2) as an extra level of caution, we check for the specific kubeproxy 404 message

Fixes #7731

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
