### PR TITLE
10.3.25

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Table/badges.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/badges.scss
@@ -79,6 +79,7 @@ $grid-cell-size: 1.25rem;
     &.red-background {
       @include RedBadge;
     }
+    &,
     &.gray-background,
     &.kui--status-unknown {
       @include GrayBadge;

--- a/plugins/plugin-kubectl/src/controller/client/direct/get.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/get.ts
@@ -196,7 +196,7 @@ export async function get(
     try {
       response = (await fetchFile(args.REPL, urls, { headers: { accept: 'application/json' } }))[0]
     } catch (err) {
-      response = tryParseAsStatus(err.message)
+      response = tryParseAsStatus(err.code, err.message)
       if (!isStatus(response)) {
         throw err
       }

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -283,7 +283,7 @@ async function rawGet(
         return response
       }
     } catch (err) {
-      if (err.code !== 500 && err.code !== undefined) {
+      if (err.code !== 500 && err.code !== undefined && !/page not found/.test(err.message)) {
         // expected apiServer error, i.e. Kubernetes Status errors
         throw err
       } else {

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -150,7 +150,11 @@ export async function _needle(
 
     // internal usage: test kui's error handling of apiServer
     if (process.env.TRAVIS_CHAOS_TESTING) {
-      throw new Error('nope')
+      // simulate a condition where kuiproxy is not installed on the apiserver
+      const error: CodedError = new Error('404 page not found')
+      error.code = 404
+      error.statusCode = 404
+      throw error
     }
 
     try {
@@ -231,6 +235,7 @@ async function fetchRemote(repl: REPL, url: string, opts?: FetchOptions<BodyData
 }
 
 export type ReturnedError = {
+  code: number | string
   error: string
 }
 
@@ -264,7 +269,10 @@ export async function fetchFile(
           Object.assign({}, opts, { data: Array.isArray(opts.data) ? opts.data[idx] : opts.data })
         ).catch(err => {
           if (opts && opts.returnErrors) {
-            return { error: err.message || JSON.stringify(err) }
+            return {
+              code: err.code,
+              error: err.message || JSON.stringify(err)
+            }
           } else throw err
         })
       } else {


### PR DESCRIPTION
[10.3.25 ec46bcfa1] fix(plugins/plugin-kubectl): kubectl direct get may pass through kubeproxy 404s to user
 Date: Tue Jun 29 13:41:00 2021 -0400
 4 files changed, 24 insertions(+), 12 deletions(-)

[10.3.25 95b11332b] fix(plugins/plugin-client-common): kubectl Status cell can be empty with splits
 Date: Tue Jun 29 10:32:17 2021 -0400
 1 file changed, 1 insertion(+)