### PR TITLE
fix(plugins/plugin-kubectl): click-drilling down from cluster-scoped resources can yield `-n undefined` in the command execution

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -676,7 +676,8 @@ export function toKuiTable(
   const drilldownFormat = '-o yaml'
 
   const onclickFor = (row: MetaTable['rows'][0], name: string) => {
-    const drilldownNamespace = !/namespace/i.test(drilldownKind) ? `-n ${row.object.metadata.namespace}` : ''
+    const drilldownNamespace =
+      !/namespace/i.test(drilldownKind) && row.object.metadata.namespace ? `-n ${row.object.metadata.namespace}` : ''
     return withKubeconfigFrom(
       args,
       `${drilldownCommand} ${drilldownVerb} ${drilldownKind} ${encodeComponent(


### PR DESCRIPTION
Fixes #7728 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
