### PR TITLE
fix(plugins/plugin-kubectl): `kubectl get all` fails with resource type error

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/explain.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/explain.ts
@@ -293,7 +293,11 @@ async function fetch(command: string, args: Arguments, kindAsProvidedByUser: str
       }
     }
   } catch (err) {
-    if (!/does not exist/i.test(err.message) && !/couldn't find resource/i.test(err.message)) {
+    if (
+      !/does not exist/i.test(err.message) &&
+      !/couldn't find resource/i.test(err.message) &&
+      !/resource type/i.test(err.message)
+    ) {
       console.error(`error explaining kind ${kindAsProvidedByUser}`, args, err)
       throw err
     } else {

--- a/plugins/plugin-kubectl/src/test/k8s2/get-pod.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/get-pod.ts
@@ -249,6 +249,15 @@ commands.forEach(command => {
         .catch(Common.oops(this, true))
     })
 
+    it(`should get the pod with ${command} get all ${inNamespace}`, () => {
+      return CLI.command(`${command} get all ${inNamespace}`, this.app)
+        .then(
+          ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME('nginx') })
+        )
+        .then((selector: string) => waitForGreen(this.app, selector))
+        .catch(Common.oops(this, true))
+    })
+
     it(`should toggle between grid and list mode`, async () => {
       try {
         const res = await CLI.command(`${command} get pods ${inNamespace}`, this.app)


### PR DESCRIPTION
Fixes #7735 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
