### PR TITLE
10.3.26

### DIFF
--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -121,7 +121,13 @@ export default class CurrentContext extends React.PureComponent<Props, State> {
   private async getCurrentContextFromChange() {
     const tab = getCurrentTab()
     const defaultCurrentContext = await getCurrentDefaultContextName(tab)
+
+    const allContexts = this.state.allContexts.find(_ => _.metadata.name === defaultCurrentContext)
+      ? this.state.allContexts
+      : await getAllContexts(tab)
+
     this.setState({
+      allContexts,
       currentContext: this.renderName(defaultCurrentContext)
     })
   }

--- a/plugins/plugin-kubectl/oc/src/controller/oc/login.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/oc/login.ts
@@ -19,8 +19,22 @@ import { doExecWithPty, emitKubectlConfigChangeEvent } from '@kui-shell/plugin-k
 
 export default function registerOcLogin(registrar: Registrar) {
   registrar.listen('/oc/login', async args => {
-    const response = await doExecWithPty(args)
+    const command = args.command.replace(/login/, '_login')
+    const response = await args.REPL.qexec(command)
     emitKubectlConfigChangeEvent('SetNamespaceOrContext')
     return response
   })
+
+  registrar.listen(
+    '/oc/_login',
+    async args => {
+      args.command = args.command.replace(/_login/, 'login')
+      args.argvNoOptions[1] = 'login'
+      args.argv[1] = 'login'
+      const response = await doExecWithPty(args, undefined, 'oc')
+      emitKubectlConfigChangeEvent('SetNamespaceOrContext')
+      return response
+    },
+    { requiresLocal: true }
+  )
 }

--- a/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
@@ -108,9 +108,9 @@ export async function doExecWithPty<
   Content = void,
   Response extends KResponse<Content> = KResponse<Content>,
   O extends KubeOptions = KubeOptions
->(args: Arguments<O>, prepare: Prepare<O> = NoPrepare): Promise<string | Response> {
+>(args: Arguments<O>, prepare: Prepare<O> = NoPrepare, exec?: string): Promise<string | Response> {
   if (!reallyNeedsPty(args) && (isHeadless() || (!inBrowser() && args.execOptions.raw))) {
-    return doExecWithStdout(args, prepare)
+    return doExecWithStdout(args, prepare, exec)
   } else {
     //
     // For commands `kubectl (--help/-h)` and `k (--help/-h)`, render usage model;


### PR DESCRIPTION
[10.3.26 ddef31bc7] fix(plugins/plugin-kubectl): oc login does not switch kube proxy in browser clients
 Date: Tue Jun 29 18:25:56 2021 -0400
 2 files changed, 17 insertions(+), 3 deletions(-)

[10.3.26 e5abfc9c4] fix(plugins/plugin-kubectl): CurrentContext does not respond to new contexts
 Date: Tue Jun 29 18:49:24 2021 -0400
 1 file changed, 6 insertions(+)