### PR TITLE
fix(plugins/plugin-kubectl): kubectl create ns failures do not display as errors in Kui

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/create.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/create.ts
@@ -15,7 +15,7 @@
  */
 
 import Debug from 'debug'
-import { Arguments, Table, isTable, is404or409 } from '@kui-shell/core'
+import { Arguments, CodedError, Table, isTable, is404or409 } from '@kui-shell/core'
 
 import { fetchFile } from '../../../lib/util/fetch-file'
 import { Explained, getKindAndVersion } from '../../kubectl/explain'
@@ -98,7 +98,9 @@ export default async function createDirect(
       if (ok.length === 0) {
         // all errors? then tell the user about them (no need to re-invoke the CLI)
         if (errors.length > 0 && errors.every(is404or409)) {
-          return errors.map(_ => _.message).join('\n')
+          const error: CodedError = new Error(errors.map(_ => _.message).join('\n'))
+          error.code = errors[0].code
+          throw error
         }
         // otherwise: intentional fall-through, returning void; let
         // kubectl CLI handle the errors for now

--- a/plugins/plugin-kubectl/src/controller/kubectl/create.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/create.ts
@@ -15,7 +15,7 @@
  */
 
 import Debug from 'debug'
-import { Registrar, Arguments } from '@kui-shell/core'
+import { Registrar, Arguments, is404or409 } from '@kui-shell/core'
 
 import defaultFlags from './flags'
 import { isDryRun, isEntityFormat, KubeOptions, formatOf } from './options'
@@ -52,7 +52,7 @@ export const doCreate = (verb: 'create' | 'apply', command = 'kubectl') => async
           debug('createDirect falling through to CLI impl')
         }
       } catch (err) {
-        if (err.code === 404) {
+        if (is404or409(err)) {
           throw err
         } else {
           console.error('Error in direct create. Falling back to CLI create.', err.code, err)

--- a/plugins/plugin-kubectl/src/test/k8s2/get-pod.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/get-pod.ts
@@ -67,6 +67,12 @@ commands.forEach(command => {
     allocateNS(this, ns)
 
     /** error handling starts */
+    it('should error out when creating an existing namespace', () => {
+      return CLI.command(`${command} create ns ${ns}`, this.app)
+        .then(ReplExpect.error(409))
+        .catch(Common.oops(this, true))
+    })
+
     it('should command not found when kubectl is not specified', () => {
       return CLI.command('get pods', this.app)
         .then(ReplExpect.error(127))


### PR DESCRIPTION
Fixes #7755 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
