### PR TITLE
[WIP]fix(plugins/plugin-kubectl): Kui fetches wrong content when KUBECONFIG env var is set in the tab

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,7 +121,7 @@ jobs:
         NEEDS_K8S: true
         NEEDS_OC: true
         NEEDS_TOP: true
-      run: ./tools/travis/install.sh && npx concurrently -n K8S3,K8S4 'npm run test1 k8s3' 'npm run test2 k8s4' && npx concurrently -n K8S2 'npm run test1 k8s2'
+      run: ./tools/travis/install.sh && npx concurrently -n K8S 'npm run test1 k8s' && npx concurrently -n K8S3,K8S4 'npm run test1 k8s3' 'npm run test2 k8s4' && npx concurrently -n K8S2 'npm run test1 k8s2'
 
   k8s-chaos:
     runs-on: ubuntu-latest

--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -104,8 +104,8 @@ class WriteEventBus extends EventBusBase {
     setTimeout(() => this.eventBus.emit(`/tab/layout/change/${tabUUID}`, evt))
   }
 
-  public emitEnvUpdate(key: string, value: string) {
-    this.eventBus.emit(`/env/update/${key}`, value)
+  public emitEnvUpdate(key: string, value: string, tab: Tab) {
+    this.eventBus.emit(`/env/update/${key}`, { value, tab })
   }
 
   private emitCommandEvent(
@@ -224,7 +224,7 @@ class ReadEventBus extends WriteEventBus {
     this.eventBus.off(`/tab/layout/change/${tabUUID}`, listener)
   }
 
-  public onEnvUpdate(key: string, listener: (value: string) => void): void {
+  public onEnvUpdate(key: string, listener: (args: { value: string; tab: Tab }) => void): void {
     this.eventBus.on(`/env/update/${key}`, listener)
   }
 

--- a/packages/core/src/core/symbol-table.ts
+++ b/packages/core/src/core/symbol-table.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Tab, getTabId } from '../webapp/tab'
+import { Tab, getPrimaryTabId } from '../webapp/tab'
 import sessionStore from '../models/sessionStore'
 
 /**
@@ -29,12 +29,12 @@ export class SymbolTable {
   }
 
   public read(tab: Tab): Record<string, string> {
-    return this.getSymbolTable()[getTabId(tab)] || {}
+    return this.getSymbolTable()[getPrimaryTabId(tab)] || {}
   }
 
   public write(tab: Tab, curDic: Record<string, string>) {
     const storage = this.getSymbolTable()
-    storage[getTabId(tab)] = curDic
+    storage[getPrimaryTabId(tab)] = curDic
     sessionStore().setItem(this.symbolTableSessionStorageKey, JSON.stringify(storage))
   }
 }

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -728,7 +728,24 @@ async function semicolonInvoke(commands: string[], execOptions: ExecOptions): Pr
  *
  */
 export function getImpl(tab: Tab): REPL {
-  const impl = { qexec, rexec, pexec, reexec, click, encodeComponent, split } as REPL
+  const impl = {
+    click,
+    split,
+    encodeComponent,
+    pexec: (command: string, execOptions?: ExecOptions) => {
+      return pexec(command, Object.assign({ tab }, execOptions))
+    },
+    reexec: (command: string, execOptions: ExecOptionsWithUUID) => {
+      return reexec(command, Object.assign({ tab }, execOptions))
+    },
+    rexec: (command: string, execOptions?: ExecOptions) => {
+      return rexec(command, Object.assign({ tab }, execOptions))
+    },
+    qexec: (command: string, b1?: HTMLElement | boolean, b2?: boolean, execOptions?: ExecOptions, b3?: HTMLElement) => {
+      return qexec(command, b1, b2, Object.assign({ tab }, execOptions), b3)
+    }
+  } as REPL
+
   tab.REPL = impl
   return impl
 }

--- a/plugins/plugin-bash-like/src/lib/cmds/export.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/export.ts
@@ -34,7 +34,7 @@ const exportCommand = async (args: Arguments) => {
   curDic[key] = value
 
   SymbolTable.write(tab, curDic)
-  eventBus.emitEnvUpdate(key, value)
+  eventBus.emitEnvUpdate(key, value, args.tab)
 
   return true
 }

--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -118,8 +118,8 @@ export default class CurrentContext extends React.PureComponent<Props, State> {
     return last && now - last < 250
   }
 
-  private async getCurrentContextFromChange() {
-    const tab = getCurrentTab()
+  private async getCurrentContextFromChange(type: string, namespace: string, context: string, _tab: Tab) {
+    const tab = _tab || getCurrentTab()
     const defaultCurrentContext = await getCurrentDefaultContextName(tab)
 
     const allContexts = this.state.allContexts.find(_ => _.metadata.name === defaultCurrentContext)

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -46,6 +46,7 @@ const strings = i18n('plugin-kubectl')
 
 export default class CurrentNamespace extends React.PureComponent<Props, State> {
   private readonly handler = this.reportCurrentNamespace.bind(this)
+  private readonly handlerForTab = this.reportCurrentNamespaceForTab.bind(this)
   private readonly handlerNotCallingKubectl = this.getCurrentNamespaceFromTab.bind(this)
 
   public constructor(props: Props) {
@@ -71,6 +72,10 @@ export default class CurrentNamespace extends React.PureComponent<Props, State> 
     this.last = now
 
     return last && now - last < 250
+  }
+
+  private async reportCurrentNamespaceForTab(type: string, namespace: string, context: string, tab: Tab) {
+    return this.reportCurrentNamespace(tab)
   }
 
   private async reportCurrentNamespace(idx?: Tab | number | string) {
@@ -138,7 +143,7 @@ export default class CurrentNamespace extends React.PureComponent<Props, State> 
     eventBus.on('/tab/switch/request/done', this.handlerNotCallingKubectl)
 
     eventBus.onAnyCommandComplete(this.handler)
-    onKubectlConfigChangeEvents(this.handler)
+    onKubectlConfigChangeEvents(this.handlerForTab)
   }
 
   /** Bye! */
@@ -147,7 +152,7 @@ export default class CurrentNamespace extends React.PureComponent<Props, State> 
     eventBus.off('/tab/switch/request/done', this.handlerNotCallingKubectl)
 
     eventBus.offAnyCommandComplete(this.handler)
-    offKubectlConfigChangeEvents(this.handler)
+    offKubectlConfigChangeEvents(this.handlerForTab)
   }
 
   private listNamespace() {

--- a/plugins/plugin-kubectl/src/controller/client/direct/create.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/create.ts
@@ -71,6 +71,7 @@ export default async function createDirect(
       version === 'v1' &&
       names.length > 0 &&
       !args.parsedOptions.context &&
+      !args.execOptions.env.KUBECONFIG &&
       !args.parsedOptions.kubeconfig
     ) {
       // WARNING: this is namespace-specific for now!

--- a/plugins/plugin-kubectl/src/controller/client/direct/delete.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/delete.ts
@@ -40,6 +40,7 @@ export default async function deleteDirect(args: Arguments<KubeOptions>, _kind?:
     !args.parsedOptions['dry-run'] &&
     !args.parsedOptions['field-selector'] &&
     !args.parsedOptions.context &&
+    !args.execOptions.env.KUBECONFIG &&
     !args.parsedOptions.kubeconfig
   ) {
     const explainedKind = await (_kind ||

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -273,6 +273,7 @@ async function rawGet(
     !args.argvNoOptions.includes('>>') &&
     !requestWithoutKind &&
     !args.parsedOptions.context &&
+    !args.execOptions.env.KUBECONFIG &&
     !args.parsedOptions.kubeconfig
   ) {
     // try talking to the apiServer directly

--- a/plugins/plugin-s3/src/providers/local-minio.ts
+++ b/plugins/plugin-s3/src/providers/local-minio.ts
@@ -50,13 +50,13 @@ let alreadyReportedCannotConnect = false
 
 async function init(repl: REPL, reinit: () => void) {
   if (!listeningAlready) {
-    eventBus.onEnvUpdate('MINIO_ACCESS_KEY', value => {
-      localStorage.setItem(localStorageAccessKey, value)
+    eventBus.onEnvUpdate('MINIO_ACCESS_KEY', args => {
+      localStorage.setItem(localStorageAccessKey, args.value)
       reinit()
     })
 
-    eventBus.onEnvUpdate('MINIO_SECRET_KEY', value => {
-      localStorage.setItem(localStorageSecretKey, value)
+    eventBus.onEnvUpdate('MINIO_SECRET_KEY', args => {
+      localStorage.setItem(localStorageSecretKey, args.value)
       reinit()
     })
   }


### PR DESCRIPTION
Fixes #7759 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
