### PR TITLE
fix(plugins/plugin-kubectl): Deployment Summary Ready shows "undefined/N" if there are no pods ready yet

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/modes/Summary/impl/Deployment.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/Summary/impl/Deployment.ts
@@ -32,7 +32,7 @@ import { Deployment } from '../../../../model/resource'
 function ready(deployment: Deployment) {
   const { readyReplicas, replicas } = deployment.status
 
-  const numerator = readyReplicas
+  const numerator = readyReplicas || 0
   const denominator = replicas
   return `${numerator}/${denominator}`
 }


### PR DESCRIPTION
Fixes #7762 
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
