### PR TITLE
fix(plugins/plugin-bash-like): export command enforces parameters inc…

### DIFF
--- a/plugins/plugin-bash-like/src/lib/cmds/export.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/export.ts
@@ -41,7 +41,6 @@ const exportCommand = async (args: Arguments) => {
 
 const usage = {
   command: 'export',
-  strict: 'export',
   docs: 'Export a variable or function to the environment of all the child processes running in the current shell',
   required: [{ name: 'key=value', docs: 'an assignment of key to value' }]
 }


### PR DESCRIPTION
…orrectly

It was enforcing parameters even for $() subprocess executions. Probably safe for now just to disable strict enforcement of `export` options.

Fixes #7791

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
