### PR TITLE
fix: kubectl apply -f does not support multi-file applies

### DIFF
--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -290,6 +290,7 @@ export type CommandTreeResolution<T extends KResponse, O extends ParsedOptions> 
 
 export interface YargsParserFlags {
   configuration?: Partial<Yargs.Configuration>
+  array?: string[]
   boolean?: string[]
   string?: string[]
   narg?: Record<string, number>

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -282,6 +282,7 @@ class InProcessExecutor implements Executor {
           {}
       ),
       string: commandFlags.string || [],
+      array: commandFlags.array || [],
       boolean: (commandFlags.boolean || []).concat(optionalBooleans || []),
       alias: Object.assign({}, commandFlags.alias || {}, optionalAliases || {}),
       narg: Object.assign(

--- a/plugins/plugin-kubectl/src/controller/client/direct/status.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/status.ts
@@ -161,7 +161,7 @@ export default async function watchMulti(
   groups: Group[],
   finalState?: FinalState,
   drilldownCommand = getCommandFromArgs(args),
-  file?: string,
+  file?: string | string[],
   isWatchRequest = true
 ): Promise<void | string[] | Table | (Table & Watchable)> {
   if (groups.length === 0) {
@@ -242,7 +242,7 @@ export default async function watchMulti(
 
     // HETEROGENEOUS CASE
     // we need to assemble a unifiedTable facade
-    const title = file ? basename(file) : undefined
+    const title = file ? (typeof file === 'string' ? basename(file) : file.map(_ => basename(_)).join(',')) : undefined
     const breadcrumbs = groups.every(_ => _.namespace === groups[0].namespace)
       ? [{ label: groups[0].namespace }]
       : undefined

--- a/plugins/plugin-kubectl/src/controller/kubectl/diff.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/diff.ts
@@ -44,6 +44,9 @@ const doDiff = (command: string) =>
       try {
         const { REPL } = args
         const filepath = getFileFromArgv(args)
+        if (typeof filepath !== 'string') {
+          throw new Error('multi-file diff currently unsupported')
+        }
         const fullpath = findFile(expandHomeDir(filepath))
         const name = basename(filepath)
         const enclosingDirectory = dirname(filepath)

--- a/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
@@ -46,14 +46,17 @@ export function flags(booleans: string[] = []): CommandOptions {
     flags: {
       configuration: {
         // disable yargs-parser being clever with -lapp=name
-        'short-option-groups': false,
+        'short-option-groups': false
 
         // disable -n foo -n bar from being parsed as -n foo,bar
-        'duplicate-arguments-array': false
+        // ugh, we need this for multi-file applies
+        // 'duplicate-arguments-array': false
       },
       // Notes on narg: to prevent yargs-parser from processing "--watch true" into watch:true
+      // see https://github.com/kubernetes-sigs/kui/issues/7841
       narg: { w: 0, watch: 0, 'watch-only': 0 },
       string: ['_'], // enforce positional arguments to be parsed as string
+      array: ['f', 'file'],
       boolean: booleans.concat(defaultBooleans)
     },
     noCoreRedirect: true

--- a/plugins/plugin-kubectl/src/controller/kubectl/status.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/status.ts
@@ -72,7 +72,7 @@ type Resources = { resourcesToWaitFor: ResourceRef[] } & Partial<Pick<WithSource
  *
  */
 async function getResourcesReferencedByFile(
-  file: string,
+  file: string | string[],
   args: Arguments<Options>,
   namespaceFromCommandLine: string
 ): Promise<Resources> {

--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -238,7 +238,7 @@ export const formatTable = async <O extends KubeOptions>(
   const drilldownFormat =
     (drilldownCommand === 'kubectl' || drilldownCommand === 'oc') && drilldownVerb === 'get' ? '-o yaml' : ''
 
-  const ns = options.n || options.namespace
+  const ns = getNamespaceAsExpressed(args)
   const drilldownNamespace = ns ? `-n ${encodeComponent(ns)}` : ''
 
   const kindColumnIdx = preTable[0].findIndex(({ key }) => key === 'KIND')

--- a/plugins/plugin-kubectl/src/test/k8s1/apply-multi-file.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/apply-multi-file.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect, SidecarExpect, Selectors } from '@kui-shell/test'
+import {
+  openSidecarByList,
+  remotePodYaml,
+  remotePodYaml2,
+  waitForRed,
+  createNS,
+  allocateNS,
+  deleteNS
+} from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+
+const synonyms = ['kubectl']
+const dashFs = ['-f']
+const resources = ['nginx', 'nginx2']
+
+describe(`kubectl apply multi-file ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const ns: string = createNS()
+  const inNamespace = `-n ${ns}`
+
+  allocateNS(this, ns)
+
+  // repeat the tests for kubectl, k, etc. i.e. any built-in
+  // synonyms/aliases we have for "kubectl"
+  synonyms.forEach(kubectl => {
+    dashFs.forEach(dashF => {
+      const files = `${dashF} ${remotePodYaml} ${dashF} ${remotePodYaml2}`
+
+      resources.forEach(resource => {
+        it(`should create two sample pods from URL via "${kubectl} apply ${dashF}" for test: ${this.title}`, async () => {
+          return openSidecarByList(this, `${kubectl} apply ${files} ${inNamespace}`, resource)
+            .then(SidecarExpect.yaml({ Status: 'Running' }))
+            .catch(Common.oops(this, true))
+        })
+      })
+
+      it(`should delete the sample pods from URL via ${kubectl}`, async () => {
+        try {
+          const res = await CLI.command(`${kubectl} delete ${files} ${inNamespace}`, this.app)
+          await Promise.all(
+            resources.map(resource =>
+              ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME(resource) })(res).then(selector =>
+                waitForRed(this.app, selector)
+              )
+            )
+          )
+        } catch (err) {
+          Common.oops(this, true)(err)
+        }
+      })
+    })
+  })
+
+  deleteNS(this, ns)
+})

--- a/plugins/plugin-kubectl/tests/lib/k8s/utils.d.ts
+++ b/plugins/plugin-kubectl/tests/lib/k8s/utils.d.ts
@@ -76,7 +76,7 @@ declare function deletePodByName (ctx: Common.ISuite, pod: string, ns: string, c
  * Keep poking the given kind till no more such entities exist
  *
  */
-declare function waitTillNone (kind: string, theCli?: headless, name?: string, okToSurvive?: string, inNamespace?: string): (app: Application) => Promise<void>
+declare function waitTillNone (kind: string, theCli?: headless, name?: string | string[], okToSurvive?: string, inNamespace?: string): (app: Application) => Promise<void>
 
 /**
  * Wait till the given resource is Terminating
@@ -129,3 +129,6 @@ declare function waitForTerminalText(this: Common.ISuite, res: ReplExpect.AppAnd
 
 /** URL of remote pod yaml */
 declare const remotePodYaml: string
+
+/** URL of second remote pod yaml */
+declare const remotePodYaml2: string

--- a/plugins/plugin-kubectl/tests/lib/k8s/utils.js
+++ b/plugins/plugin-kubectl/tests/lib/k8s/utils.js
@@ -159,9 +159,13 @@ exports.waitTillNone = (kind, theCli = makeCLI('kubectl'), name = '', okToSurviv
   new Promise(resolve => {
     // fetch the entities
     const fetch = async () => {
-      const response = await theCli.command(`get "${kind}" ${name} ${inNamespace}`, app, {
-        errOk: 1
-      })
+      const response = await theCli.command(
+        `get "${kind}" ${typeof name === 'string' ? name : name.join(' ')} ${inNamespace}`,
+        app,
+        {
+          errOk: 1
+        }
+      )
       return response
     }
 
@@ -306,3 +310,7 @@ exports.waitForTerminalText = async function(res, checker) {
 /** URL of remote pod yaml */
 exports.remotePodYaml =
   'https://raw.githubusercontent.com/IBM/kui/master/plugins/plugin-kubectl/tests/data/k8s/headless/pod.yaml'
+
+/** URL of remote pod yaml */
+exports.remotePodYaml2 =
+  'https://raw.githubusercontent.com/IBM/kui/master/plugins/plugin-kubectl/tests/data/k8s/headless/pod2.yaml'


### PR DESCRIPTION
Fixes #7841

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
