### PR TITLE
fix(plugins/plugin-kubectl): work around jsonpath npm's inability to …

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/custom-columns.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/custom-columns.ts
@@ -57,7 +57,9 @@ function parse(spec: string): CustomColumns {
         if (key && query) {
           return {
             key,
-            query: jsonpath.parse('$' + query) // the jsonpath npm needs a leading "$"
+            query: jsonpath.parse('$' + query.replace(/\.(\w+-\w+)/g, (_, p1) => `["${p1}"]`))
+            // the jsonpath npm needs a leading "$", and does not handle -
+            // see https://github.com/dchester/jsonpath/issues/90
           }
         }
       }

--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -753,8 +753,10 @@ export function toKuiTable(
   if (sortBy) {
     const sortByDate = /Time/.test(sortBy)
 
-    // the jsonpath npm needs a leading "$"
-    const qquery = jsonpath.parse('$' + sortBy)
+    // The jsonpath npm needs a leading "$". also, re: the replace:
+    // jsonpath does not handle dashes!
+    // https://github.com/dchester/jsonpath/issues/90
+    const qquery = jsonpath.parse('$' + sortBy.replace(/\.\w+-\w+/g, _ => `["${_}"]`))
     const query = (qquery as any) as string // bad typing in @types/jsonpath
 
     body.sort((a, b) => {


### PR DESCRIPTION
…handle dashes in query strings

Fixes #7870

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
