### PR TITLE
fix(plugins/plugin-kubectl): tables-as-grid display bogus Status in t…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/Grid.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/Grid.tsx
@@ -34,7 +34,12 @@ export type Props<T extends KuiTable = KuiTable> = {
 }
 
 export const findGridableColumn = (response: KuiTable) => {
-  return response.durationColumnIdx >= 0
+  // why the or part? well, if the controller hasn't specified a
+  // colorBy, and we have a durationColumnIdx but *not* a
+  // statusColumnIdx, then use duration as the default
+  const colorByDuration = response.colorBy === 'duration' || response.statusColumnIdx === undefined
+
+  return colorByDuration && response.durationColumnIdx >= 0
     ? response.durationColumnIdx
     : response.statusColumnIdx !== undefined
     ? response.statusColumnIdx


### PR DESCRIPTION
…ooltip if table has a durationColumnIndex

Fixes #7872

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
