### PR TITLE
fix(plugins/plugin-client-common): don't show block borders for not-f…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -18,6 +18,8 @@
 @import 'mixins';
 @import '../Sidecar/mixins';
 
+@import 'BlockBorder';
+
 .repl-input,
 .repl-input-sourceref,
 .repl-output {
@@ -91,24 +93,6 @@
     position: relative;
     margin: 0.1875em 0;
 
-    &:before {
-      background-color: var(--color-table-border2);
-      border-left: none;
-      border-right: none;
-      border-radius: 1px;
-      opacity: 0.625;
-      content: '';
-      left: 1px;
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      width: $block-band-width;
-      box-shadow: -1px 0 rgba(100, 100, 100, 0.7);
-    }
-    &.error:before {
-      opacity: 1;
-      background-color: var(--color-red);
-    }
     &:hover .repl-output .repl-context:after {
       border-color: var(--color-base03);
     }
@@ -145,45 +129,18 @@
   li:focus.repl-block,
   li:hover.repl-block[data-is-focused],
   .repl-block[data-is-focused] {
-    &:before {
-      opacity: 1;
-    }
-    &:before {
-      background-color: $focus-color;
-    }
     .repl-input .repl-context {
       opacity: 1;
     }
   }
-  li:not(:focus):hover.repl-block {
-    &,
-    &[data-is-output-only] {
-      &:before {
-        background-color: $focus-color;
-      }
-    }
-
-    &.error {
-      &:before {
-        background-color: hsl(0, 100%, 70%);
-      }
-    }
-  }
   li:not(:focus) {
     &.repl-block {
-      &[data-is-output-only]:before {
-        background-color: transparent;
-      }
       .repl-context:hover,
       .repl-input-element:hover {
         cursor: pointer;
       }
     }
   }
-
-  /*@include ActiveBlock {
-    padding: 0.875em 0;
-  }*/
 
   @include Block {
     display: flex;

--- a/plugins/plugin-client-common/web/scss/components/Terminal/BlockBorder.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/BlockBorder.scss
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import 'mixins';
+
+@include Block {
+  @include BlockBorder {
+    background-color: transparent;
+    border-left: none;
+    border-right: none;
+    border-radius: 2px;
+    opacity: 0.5;
+    content: '';
+    left: 2px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: $block-border-width;
+  }
+}
+@include ActiveBlock {
+  @include BlockBorder {
+    background-color: $focus-color;
+  }
+
+  &:focus,
+  &[data-is-focused] {
+    @include BlockBorder {
+      opacity: 1;
+      background-color: $focus-color;
+    }
+  }
+}
+@include Block {
+  &:focus,
+  &[data-is-focused] {
+    @include BlockBorder {
+      opacity: 1;
+      background-color: var(--color-table-border3);
+    }
+  }
+}
+@include ErrorBlock {
+  @include BlockBorder {
+    opacity: 0.625;
+    background-color: var(--color-red);
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -33,11 +33,11 @@ $input-bg-inverted: var(--color-base02);
 $input-border: 1px solid rgba(150, 150, 150, 0.2);
 $input-border-editing: var(--color-brand-03);
 
-/** This is the left-hand band that defines each block region */
-$block-band-width: 0.375em;
+/** This is the left-hand border that defines each block region */
+$block-border-width: 0.4375em;
 
-$input-padding-left: 1em;
-$input-padding-right: $input-padding-left - $block-band-width;
+$input-padding-left: 1.25em;
+$input-padding-right: $input-padding-left;
 $repl-context-min-width: 2em;
 $repl-context-margin-right: 0.5em;
 
@@ -160,6 +160,20 @@ $action-hover-delay: 210ms;
 @mixin DisappearOnHover {
   opacity: 0; /* rather than display: none to avoid reflow on hover */
   transition-delay: $action-hover-delay;
+}
+
+@mixin BlockBorder {
+  &:before {
+    @content;
+  }
+}
+
+@mixin ErrorBlock {
+  @include Block {
+    &.error {
+      @content;
+    }
+  }
 }
 
 @mixin ActiveBlock {


### PR DESCRIPTION
…ocused finished blocks

Fixes #7905

## After
<img width="893" alt="Screen Shot 2021-09-02 at 3 35 28 PM" src="https://user-images.githubusercontent.com/4741620/131905385-88dc4a81-0178-4486-8944-ba54dc7556dc.png">

## Before

(from the last published Kui, 10.4.12)

<img width="893" alt="Screen Shot 2021-09-02 at 3 26 09 PM" src="https://user-images.githubusercontent.com/4741620/131904440-d816b053-da00-4848-9337-abf2e0abaa7e.png">



<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
