### PR TITLE
fix: StatusStripe in light themes has low contrast

### DIFF
--- a/plugins/plugin-carbon-themes/web/scss/carbon-gray10.scss
+++ b/plugins/plugin-carbon-themes/web/scss/carbon-gray10.scss
@@ -29,7 +29,7 @@ body[kui-theme='Carbon Gray10'] {
   @include Sidecar {
     @include carbon-inverted;
   }
-  @include StatusStripe {
+  @include StatusStripeWithDefaultColors {
     @include carbon-inverted;
   }
   @include CommentaryEditor {

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/_mixins.scss
@@ -22,6 +22,14 @@ $element-border: 1px solid var(--color-table-border2);
   }
 }
 
+@mixin StatusStripeWithDefaultColors {
+  @include StatusStripe {
+    &[data-type='default'] {
+      @content;
+    }
+  }
+}
+
 @mixin StatusStripeElement {
   .kui--status-stripe-element {
     @content;

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -149,7 +149,7 @@ body[kui-theme='Light'] {
   @include InvertColorsForSidecar;
 
   /** An inverted StatusStripe looks better in this theme */
-  @include StatusStripe {
+  @include StatusStripeWithDefaultColors {
     @include InvertColors;
   }
   @include CommentaryEditor {

--- a/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
@@ -27,7 +27,7 @@ body.kui--patternfly4[kui-theme='PatternFly4 Light'][kui-theme-style] {
   @include charts-light;
 
   /** An inverted StatusStripe looks better in this theme */
-  @include StatusStripe {
+  @include StatusStripeWithDefaultColors {
     @include InvertLightToDark;
   }
   @include CommentaryEditor {


### PR DESCRIPTION
Fixes #7927

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
