### PR TITLE
fix: Carbon Gray10 theme has poor contrast for hints

### DIFF
--- a/plugins/plugin-carbon-themes/web/scss/carbon-gray10.scss
+++ b/plugins/plugin-carbon-themes/web/scss/carbon-gray10.scss
@@ -17,6 +17,7 @@
 @import 'fonts';
 @import 'kui--alternate';
 @import 'charts';
+@import 'colors';
 @import 'inverted';
 @import '@kui-shell/plugin-client-common/web/scss/components/Sidecar/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/StatusStripe/mixins';

--- a/plugins/plugin-carbon-themes/web/scss/carbon-gray90.scss
+++ b/plugins/plugin-carbon-themes/web/scss/carbon-gray90.scss
@@ -31,7 +31,8 @@ body[kui-theme='Carbon Gray90'][kui-theme-style] {
 
   @include ScrollbackInvertedColors {
     @include colors-light;
-    @reset;
+    @include Reset;
+    --color-text-02: #565656;
 
     @include Sidecar {
       @include carbon-inverted;

--- a/plugins/plugin-carbon-themes/web/scss/colors.scss
+++ b/plugins/plugin-carbon-themes/web/scss/colors.scss
@@ -19,8 +19,8 @@
 @mixin colors-dark {
   @include kui-patternfly-alignment-dark-for-carbon;
 
-  --color-base00: #262626;
-  --color-base01: #161616;
+  --color-base00: #161616;
+  --color-base01: #262626;
   --color-base02: #393939;
   --color-base03: #525252;
   --color-base04: #8d8d8d;
@@ -68,24 +68,23 @@
   --tab-gray-text-color: #b5b5b5;
   --active-tab-color: #6ea6ff;
 
-  --color-repl-background: var(--color-base00);
+  --color-ui-01: #000000;
 
   --color-prompt-text: #408bfc;
 
+  --color-light-blue: #edf4ff;
   --color-light-red: #ffd7d9;
   --color-light-green: hsla(143, 73%, 43%, 50%);
   --color-light-yellow: hsla(46, 99%, 59%, 50%);
-
-  --color-table-border3: var(--color-base04);
 }
 
 @mixin colors-light {
   @include kui-patternfly-alignment-light-for-carbon;
 
-  --color-base00: #ffffff;
-  --color-base01: #f4f4f4;
-  --color-base02: #e0e0e0;
-  --color-base03: #dcdcdc;
+  --color-base00: #f4f4f4;
+  --color-base01: #e0e0e0;
+  --color-base02: #dcdcdc;
+  --color-base03: #c6c6c6;
   --color-base04: #f2f4f8;
   --color-base05: #50565b;
   --color-base06: #171717;
@@ -113,6 +112,7 @@
   --color-brand-02: #171717;
   --color-brand-03: #0062ff;
 
+  --color-ui-01: #fff;
   --color-ui-05: #171717;
   --color-ui-03: #e0e0e0;
   --color-text-02: #565656;
@@ -122,25 +122,21 @@
 
   --color-table-border1: var(--color-base01);
   --color-table-border2: #8f8b8b;
-  --color-table-border3: var(--color-base02);
 
   --color-background-03: var(--color-ui-03);
 
   --color-sidecar-toolbar-foreground: var(--color-text-01);
 
-  --color-sidecar-header: #282828;
   --color-sidecar-background-01: var(--color-base06);
   --color-sidecar-border: #e4e4e4;
 
   --color-brand-03: #008fff;
   --color-content-divider: #bfc0c2;
 
-  --color-stripe-01: #fff;
-  --color-stripe-02: #f5f7fa;
   --tab-gray-text-color: var(--color-text-01);
   --active-tab-color: #0f62fe;
-  --color-repl-background: #f0f0f0;
 
+  --color-light-blue: #edf4ff;
   --color-light-red: hsla(354, 81%, 51%, 50%);
   --color-light-green: hsla(143, 73%, 43%, 50%);
   --color-light-yellow: hsla(46, 99%, 59%, 50%);

--- a/plugins/plugin-carbon-themes/web/scss/inverted.scss
+++ b/plugins/plugin-carbon-themes/web/scss/inverted.scss
@@ -16,6 +16,7 @@
 
 @import 'charts';
 @import 'colors';
+@import '@kui-shell/plugin-client-common/web/scss/Themes/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins';
 
 /* inverted color scheme */
@@ -57,6 +58,7 @@
   --color-brand-02: var(--color-base07);
   --color-brand-03: var(--color-base0C);
 
+  --color-ui-01: #000;
   --color-repl-background-02: var(--color-base02);
 
   --color-stripe-01: var(--color-base02);
@@ -79,5 +81,6 @@
 @mixin InvertedColorsForTerminal {
   @include ScrollbackInvertedColors {
     @include carbon-inverted;
+    @include Reset;
   }
 }

--- a/plugins/plugin-client-common/web/css/static/ui.css
+++ b/plugins/plugin-client-common/web/css/static/ui.css
@@ -1149,6 +1149,7 @@ body {
   --color-green: var(--color-base0B);
   --color-yellow: var(--color-base0A);
   --color-cyan: var(--color-base0C);
+  --color-light-blue: var(--color-base0D);
   --color-blue: var(--color-base0D);
   --color-magenta: var(--color-base0E);
   --color-white: var(--color-base07);

--- a/plugins/plugin-client-common/web/scss/PatternFly/kui-alignment.scss
+++ b/plugins/plugin-client-common/web/scss/PatternFly/kui-alignment.scss
@@ -15,11 +15,11 @@
  */
 
 @mixin kui-patternfly-alignment-base {
-  --pf-global--palette--blue-50: var(--color-blue);
-  --pf-global--palette--blue-100: var(--color-blue);
-  --pf-global--palette--blue-200: var(--color-blue);
-  --pf-global--palette--blue-300: var(--color-blue);
-  --pf-global--palette--blue-400: var(--color-blue);
+  --pf-global--palette--blue-50: var(--color-light-blue);
+  --pf-global--palette--blue-100: var(--color-light-blue);
+  --pf-global--palette--blue-200: var(--color-light-blue);
+  --pf-global--palette--blue-300: var(--color-light-blue);
+  --pf-global--palette--blue-400: var(--color-light-blue);
   --pf-global--palette--blue-500: var(--color-blue);
   --pf-global--palette--blue-600: var(--color-blue);
   --pf-global--palette--blue-700: var(--color-blue);
@@ -86,19 +86,19 @@
   --pf-global--BackgroundColor--light-100: var(--color-ui-01);
   --pf-global--BackgroundColor--light-200: var(--color-ui-02);
   --pf-global--BackgroundColor--light-300: var(--color-ui-03);
-  --pf-global--BackgroundColor--dark-100: var(--color-base01);
-  --pf-global--BackgroundColor--dark-200: var(--color-ui-03);
-  --pf-global--BackgroundColor--dark-300: var(--color-ui-02);
-  --pf-global--BackgroundColor--dark-400: var(--color-ui-01);
+  --pf-global--BackgroundColor--dark-100: var(--color-ui-01);
+  --pf-global--BackgroundColor--dark-200: var(--color-ui-02);
+  --pf-global--BackgroundColor--dark-300: var(--color-ui-03);
+  --pf-global--BackgroundColor--dark-400: var(--color-ui-04);
   --pf-global--BackgroundColor--dark-transparent-100: rgba(3, 3, 3, 0.62);
   --pf-global--BackgroundColor--dark-transparent-200: rgba(3, 3, 3, 0.32);
   --pf-global--Color--100: var(--color-ui-01);
-  --pf-global--Color--200: var(--color-ui-02);
-  --pf-global--Color--300: var(--color-ui-03);
+  --pf-global--Color--200: var(--color-ui-03);
+  --pf-global--Color--300: var(--color-ui-02);
   --pf-global--Color--400: var(--color-ui-04);
   --pf-global--Color--light-100: var(--color-ui-01);
-  --pf-global--Color--light-200: var(--color-ui-02);
-  --pf-global--Color--light-300: var(--color-ui-03);
+  --pf-global--Color--light-200: var(--color-text-02);
+  --pf-global--Color--light-300: var(--color-ui-02);
   --pf-global--Color--dark-100: var(--color-base06);
   --pf-global--Color--dark-200: var(--color-base05);
   --pf-global--active-color--100: var(--active-tab-color);
@@ -107,7 +107,7 @@
   --pf-global--active-color--400: var(--active-tab-color);
   --pf-global--disabled-color--100: var(--color-base03);
   --pf-global--disabled-color--200: var(--color-base04);
-  --pf-global--disabled-color--300: var(--color-base05);
+  --pf-global--disabled-color--300: var(--color-base02);
   --pf-global--primary-color--100: var(--color-brand-01);
   --pf-global--primary-color--200: var(--color-brand-03);
   --pf-global--primary-color--light-100: var(--color-brand-01);

--- a/plugins/plugin-client-common/web/scss/Themes/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/Themes/_mixins.scss
@@ -60,6 +60,8 @@
   --color-ui-05: var(--color-base04);
   --color-ui-06: var(--color-base02);
 
+  --color-repl-background: var(--color-ui-01);
+
   --color-yellow-sidecar: var(--color-yellow);
   color: var(--color-text-01);
 }

--- a/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
@@ -60,6 +60,7 @@ body[kui-theme-style] {
   .pf-c-dropdown__menu {
     max-height: 30rem;
     overflow-y: auto;
+    color: var(--color-text-01);
     background-color: var(--color-dropdown);
 
     .pf-c-dropdown__menu-item {

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -133,7 +133,6 @@ $z-index: var(--pf-global--ZIndex--xs);
   .kui--status-stripe-button .kui--status-stripe-element:hover {
     &:not(.kui--status-stripe-tag-element) {
       cursor: pointer;
-      color: $fg-type-default;
       background-color: $status-stripe-hover-bg-color;
     }
   }

--- a/plugins/plugin-core-themes/web/scss/dark.scss
+++ b/plugins/plugin-core-themes/web/scss/dark.scss
@@ -41,6 +41,8 @@ body[kui-theme='Dark'] {
   --color-base0E: #ffa0c2; /* MAGENTA: Keywords, Storage, Selector, Markup Italic, Diff Changed */
   --color-base0F: #d0b0ff; /* BROWN: Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?> */
 
+  --color-light-blue: #c8dfff;
+
   --color-base0B-rgb: 61, 187, 97;
   --color-base08-rgb: 251, 75, 83;
 

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -97,6 +97,8 @@
 
 /* color variables */
 body[kui-theme='Light'] {
+  @include kui-patternfly-alignment-light;
+
   --color-base00: #ffffff;
   --color-base01: #f4f4f4;
   --color-base02: #e0e0e0;
@@ -113,6 +115,8 @@ body[kui-theme='Light'] {
   --color-base0D: #0072c3;
   --color-base0E: #d12764;
   --color-base0F: #8a3ffc;
+
+  --color-light-blue: #edf4ff;
 
   --color-base0B-rgb: 29, 189, 90;
   --color-green-rgb: var(--color-base0B-rgb);


### PR DESCRIPTION
This PR also fixes a few related theming issues.

Fixes #7956

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
