### PR TITLE
fix(plugins/plugin-client-common): improvements to hover and click be…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -724,11 +724,9 @@ export default class Input extends InputProvider {
       const replayed = isReplay(this.props.model)
       const completed = this.props.model.startTime && isWithCompleteEvent(this.props.model)
       const showingDate = !replayed && completed && !this.props.isWidthConstrained
-      const duration =
-        !replayed &&
-        isWithCompleteEvent(this.props.model) &&
-        this.props.model.completeEvent.completeTime &&
-        prettyPrintDuration(this.props.model.completeEvent.completeTime - this.props.model.startTime)
+
+      const now = isWithCompleteEvent(this.props.model) ? this.props.model.completeEvent.completeTime : Date.now()
+      const duration = !replayed && now && prettyPrintDuration(Math.max(0, now - this.props.model.startTime))
       const noParen = !showingDate || !duration
       const openParen = noParen ? '' : '('
       const closeParen = noParen ? '' : ')'

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -164,6 +164,7 @@ export default class Block extends React.PureComponent<Props, State> {
     if (isFinished(this.props.model) || isProcessing(this.props.model)) {
       return (
         <Output
+          key={isEmpty(this.props.model) ? undefined : this.props.model.execUUID}
           uuid={this.props.uuid}
           tab={this.props.tab}
           idx={this.props.idx}

--- a/plugins/plugin-client-common/src/test/editor/edit-remove-block.ts
+++ b/plugins/plugin-client-common/src/test/editor/edit-remove-block.ts
@@ -56,7 +56,7 @@ describe(`remove command output verify editor content is preserved ${process.env
 
   it('should open editor and type something', async () => {
     try {
-      res2 = await CLI.command(`edit "${filepath}"}`, this.app).then(SidecarExpect.open)
+      res2 = await CLI.command(`edit "${filepath}"`, this.app).then(SidecarExpect.open)
 
       await setValue(res2, typeThis)
       await expectText(res2, typeThis)

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -204,8 +204,7 @@
     }
 
     .kui--block-action:hover {
-      background-color: var(--color-table-border2);
-      mix-blend-mode: difference;
+      background-color: var(--color-base02);
     }
 
     .repl-input,

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
@@ -46,14 +46,16 @@ $input-padding: 1em;
     @include BlockActions {
       position: unset;
       background-color: transparent;
+
+      &[data-has-been-rerun] {
+        @include BlockAction {
+          color: var(--color-gray);
+        }
+      }
     }
     @include BlockAction {
       font-size: 1.375em;
       color: var(--color-green);
-
-      &:hover {
-        filter: brightness(1.25);
-      }
     }
   }
 }


### PR DESCRIPTION
…havior for block action buttons

- improved hover effect (stop using mix-blend-mode)
- restore function of "two face icon" so that checkmark is now visible upon click
- in notebook replay mode, use gray color for already-rerun blocks

Fixes #7971

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
