### PR TITLE
fix(plugins/plugin-client-common): double clicking on Commentary ente…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { CommentaryResponse, REPL, i18n } from '@kui-shell/core'
+import { CommentaryResponse, REPL, i18n, isReadOnlyClient } from '@kui-shell/core'
 
 import Card from '../spi/Card'
 import Button from '../spi/Button'
@@ -169,7 +169,7 @@ export default class Commentary extends React.PureComponent<Props, State> {
 
   private card() {
     return (
-      <span className="kui--commentary-card" onDoubleClick={this._setEdit}>
+      <span className="kui--commentary-card" onDoubleClick={isReadOnlyClient() ? undefined : this._setEdit}>
         <Card
           {...this.props}
           data-is-editing={this.state.isEdit || undefined}

--- a/plugins/plugin-core-support/src/test/core-support/link-block.ts
+++ b/plugins/plugin-core-support/src/test/core-support/link-block.ts
@@ -37,7 +37,11 @@ describe('Link blocks', function(this: Common.ISuite) {
 
   it('paste the link to a commentary block, and expect the commentary block show the status of ls', async () => {
     try {
-      await CLI.command('#', this.app).then(ReplExpect.ok)
+      const res = await CLI.command('#', this.app).then(ReplExpect.ok)
+
+      await this.app.client
+        .$(`${Selectors.OUTPUT_N(res.count)} ${Selectors.COMMENTARY_EDITOR}`)
+        .then(_ => _.waitForDisplayed({ timeout: CLI.waitTimeout }))
 
       await this.app.client.execute(() => document.execCommand('paste'))
 


### PR DESCRIPTION
…rs edit mode, even for readOnly clients

Fixes #7977

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
