### PR TITLE
10.5.2

### DIFF
--- a/packages/core/src/models/TabLayoutModificationResponse.ts
+++ b/packages/core/src/models/TabLayoutModificationResponse.ts
@@ -46,6 +46,9 @@ export type NewSplitRequest = {
 
     /** Only perform the split if the given command returns false */
     ifnot?: string
+
+    /** Swap the positions of the given two splits */
+    swap?: { a: number; b: number }
   }
 }
 

--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { CommentaryResponse, REPL, i18n } from '@kui-shell/core'
+import { CommentaryResponse, REPL, i18n, isReadOnlyClient } from '@kui-shell/core'
 
 import Card from '../spi/Card'
 import Button from '../spi/Button'
@@ -169,7 +169,7 @@ export default class Commentary extends React.PureComponent<Props, State> {
 
   private card() {
     return (
-      <span className="kui--commentary-card" onDoubleClick={this._setEdit}>
+      <span className="kui--commentary-card" onDoubleClick={isReadOnlyClient() ? undefined : this._setEdit}>
         <Card
           {...this.props}
           data-is-editing={this.state.isEdit || undefined}

--- a/plugins/plugin-client-common/src/controller/split.ts
+++ b/plugins/plugin-client-common/src/controller/split.ts
@@ -31,7 +31,17 @@ export function debug(args: Arguments) {
  *
  */
 export default function split(args?: Arguments<CommandLineOptions>): TabLayoutModificationResponse<NewSplitRequest> {
+  if (args.parsedOptions.swap) {
+    if (!Array.isArray(args.parsedOptions.swap) || args.parsedOptions.swap.length !== 2) {
+      console.error('Expected exactly two --swap options', args.parsedOptions.swap)
+      throw new Error('Expected exactly two --swap options')
+    } else if (args.parsedOptions.swap.find(_ => _ === 0)) {
+      throw new Error('Expected --swap options to be 1-indexed')
+    }
+  }
+
   const options: Options = {
+    swap: !args.parsedOptions.swap ? undefined : args.parsedOptions.swap,
     if: args.parsedOptions.if,
     ifnot: args.parsedOptions.ifnot,
     index: args.parsedOptions.index,

--- a/plugins/plugin-client-common/src/plugin.ts
+++ b/plugins/plugin-client-common/src/plugin.ts
@@ -20,7 +20,7 @@ export default async (registrar: Registrar) => {
   if (!isHeadless()) {
     await import(/* webpackMode: "lazy" */ './controller/confirm').then(_ => _.default(registrar))
     await import(/* webpackMode: "lazy" */ './controller/split').then(_ => {
-      registrar.listen('/split', _.default, { flags: { boolean: ['inverse'] } })
+      registrar.listen('/split', _.default, { flags: { boolean: ['inverse'], alias: { split: ['s'] } } })
       registrar.listen('/split-debug', _.debug)
       registrar.listen('/split-count', ({ tab }) => tab.splitCount())
       registrar.listen('/is-split', ({ tab }) => tab.hasSideBySideTerminals())

--- a/plugins/plugin-client-common/web/scss/components/Hint/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Hint/PatternFly.scss
@@ -20,5 +20,9 @@
   @include HintBody {
     font-size: inherit;
     font-family: var(--font-sans-serif);
+
+    a {
+      color: var(--color-base0C);
+    }
   }
 }

--- a/plugins/plugin-core-support/src/test/core-support/link-block.ts
+++ b/plugins/plugin-core-support/src/test/core-support/link-block.ts
@@ -37,7 +37,11 @@ describe('Link blocks', function(this: Common.ISuite) {
 
   it('paste the link to a commentary block, and expect the commentary block show the status of ls', async () => {
     try {
-      await CLI.command('#', this.app).then(ReplExpect.ok)
+      const res = await CLI.command('#', this.app).then(ReplExpect.ok)
+
+      await this.app.client
+        .$(`${Selectors.OUTPUT_N(res.count)} ${Selectors.COMMENTARY_EDITOR}`)
+        .then(_ => _.waitForDisplayed({ timeout: CLI.waitTimeout }))
 
       await this.app.client.execute(() => document.execCommand('paste'))
 


### PR DESCRIPTION
[10.5.2 2d351f693] fix(plugins/plugin-client-common): double clicking on Commentary enters edit mode, even for readOnly clients
 Date: Mon Sep 13 16:29:31 2021 -0400
 2 files changed, 7 insertions(+), 3 deletions(-)

[10.5.2 82836c80f] feat: Add ability to swap the order of splits
 Date: Mon Sep 13 16:32:02 2021 -0400
 4 files changed, 49 insertions(+), 2 deletions(-)

[10.5.2 2e5bfacff] fix(plugins/plugin-client-common): Sequential execution fails if first split has nothing executable
 Date: Mon Sep 13 16:34:42 2021 -0400
 1 file changed, 30 insertions(+), 4 deletions(-)

[10.5.2 48e772336] fix(plugins/plugin-client-common): links in hints in sidecar have low contrast in light themes
 Date: Mon Sep 13 16:40:37 2021 -0400
 1 file changed, 4 insertions(+)