### PR TITLE
fix(plugins/plugin-kubectl): Kubernetes Context widget does not alway…

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/TextWithIconWidget.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/TextWithIconWidget.tsx
@@ -21,7 +21,7 @@ import { Props as PopoverProps } from '../../spi/Popover'
 const Popover = React.lazy(() => import('../../spi/Popover'))
 
 /** variants of how the information should be presented */
-export type ViewLevel = 'removed' | 'hidden' | 'normal' | 'obscured' | 'ok' | 'warn' | 'error' | 'info'
+export type ViewLevel = 'loading' | 'removed' | 'hidden' | 'normal' | 'obscured' | 'ok' | 'warn' | 'error' | 'info'
 
 /** End-user options */
 export interface Options {

--- a/plugins/plugin-client-common/src/index.ts
+++ b/plugins/plugin-client-common/src/index.ts
@@ -40,6 +40,7 @@ export { default as ContextWidgets } from './components/Client/StatusStripe/Cont
 export {
   ViewLevel,
   default as TextWithIconWidget,
+  Props as TextWithIconWidgetProps,
   Options as TextWithIconWidgetOptions
 } from './components/Client/StatusStripe/TextWithIconWidget'
 export { default as Settings } from './components/Client/StatusStripe/Settings'

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -95,6 +95,7 @@ $z-index: var(--pf-global--ZIndex--xs);
     }
     &:not(.kui--status-stripe-tag-element) {
       &[data-view='warn'],
+      &[data-view='loading'],
       &[data-view='info'] {
         filter: grayscale(0.15) brightness(0.9);
         &:hover {
@@ -107,6 +108,9 @@ $z-index: var(--pf-global--ZIndex--xs);
             background-color: var(--color-yellow);
           }
           &[data-view='info'] {
+            background-color: var(--color-base04);
+          }
+          &[data-view='loading'] {
             font-style: italic;
             background-color: var(--color-base04);
           }

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -58,7 +58,7 @@ export default class CurrentNamespace extends React.PureComponent<Props, State> 
     this.state = {
       currentNamespace: strings('Loading...'),
       allNamespaces: [],
-      viewLevel: 'info'
+      viewLevel: 'loading'
     }
   }
 
@@ -239,7 +239,6 @@ export default class CurrentNamespace extends React.PureComponent<Props, State> 
           key={this.state.currentNamespace /* pf 4.152.4 regression? "This is the current" does not show on change */}
           variant="typeahead"
           maxHeight="11rem"
-          className="small-top-pad"
           selected={this.state.currentNamespace}
           options={options}
           groups={groups}


### PR DESCRIPTION
…s correctly show "This is your current context"

Fixes #7996

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
