### PR TITLE
feat(plugins/plugin-client-common): Editor component should default t…

### DIFF
--- a/packages/test/src/api/util.ts
+++ b/packages/test/src/api/util.ts
@@ -179,6 +179,37 @@ export const expectArray = (expected: Array<string>, failFast = true, subset = f
   }
 }
 
+/** Expand the fold on the given line of a monaco editor */
+export async function clickToExpandMonacoFold(res: AppAndCount, lineIdx: number) {
+  const container =
+    res.splitIndex !== undefined
+      ? `${Selectors.PROMPT_BLOCK_N_FOR_SPLIT(res.count, res.splitIndex)} .kui--tab-content:not([hidden])`
+      : `${Selectors.PROMPT_BLOCK_N(res.count)} .kui--tab-content:not([hidden])`
+
+  console.log('MF1')
+  const selector = `${container} .monaco-editor-wrapper`
+  const wrapper = await res.app.client.$(selector)
+  await wrapper.waitForExist({ timeout: CLI.waitTimeout })
+
+  console.log('MF2')
+  const marginOverlaysSelector = `.margin-view-overlays > div:nth-child(${lineIdx + 1})` // css is 1-indexed
+  const foldingSelector = `${marginOverlaysSelector} .codicon-folding-collapsed`
+  const foldingClickable = await wrapper.$(foldingSelector)
+
+  console.log('MF3')
+  await foldingClickable.waitForExist({ timeout: CLI.waitTimeout })
+
+  console.log('MF4')
+  await foldingClickable.click()
+
+  console.log('MF5')
+  const unfoldingSelector = `${marginOverlaysSelector} .codicon-folding-expanded`
+  const unfoldingClickable = await wrapper.$(unfoldingSelector)
+  await unfoldingClickable.waitForExist({ timeout: CLI.waitTimeout })
+
+  console.log('MF6')
+}
+
 /** get the monaco editor text */
 export const getValueFromMonaco = async (res: AppAndCount, container?: string) => {
   if (!container) {

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -374,6 +374,9 @@ export default class Editor extends React.PureComponent<Props, State> {
       const editor = Monaco.create(state.wrapper, options)
       setTimeout(async () => {
         editor.setValue(await Editor.extractValue(state.content, props.response, props.repl))
+
+        // initial default folding level; see https://github.com/kubernetes-sigs/kui/issues/8008
+        editor.getAction('editor.foldLevel2').run()
       })
 
       const onZoom = () => {

--- a/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.css
+++ b/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.css
@@ -152,5 +152,5 @@ body[kui-theme-style] .monaco-editor .cursor {
 }
 
 body[kui-theme-style] .monaco-editor .folded-background {
-  background-color: var(--color-table-border3);
+  background-color: var(--color-base03);
 }

--- a/plugins/plugin-kubectl/src/test/k8s4/edit.ts
+++ b/plugins/plugin-kubectl/src/test/k8s4/edit.ts
@@ -162,11 +162,15 @@ commands.forEach(command => {
     const parseError = modifyWithError.bind(undefined, 'parse error', Keys.End, 'could not find expected')
 
     /** modify pod {name} so as to add a label of key=value */
-    const modify = (name: string, key = 'foo', value = 'bar') => {
-      it('should modify the content', async () => {
+    const modify = (name: string, key = 'foo', value = 'bar', needsUnfold = true) => {
+      it(`should modify the content by adding label ${key}=${value}`, async () => {
         try {
           const actualText = await Util.getValueFromMonaco(res)
           const labelsLineIdx = actualText.split(/\n/).indexOf('  labels:')
+
+          if (needsUnfold) {
+            await Util.clickToExpandMonacoFold(res, labelsLineIdx)
+          }
 
           // +2 here because nth-child is indexed from 1, and we want the line after that
           const lineSelector = `${Selectors.SIDECAR(res.count)} .view-lines > .view-line:nth-child(${labelsLineIdx +
@@ -252,7 +256,7 @@ commands.forEach(command => {
       modify(name, 'clickfoo1', 'clickbar1')
       modify(name, 'clickfoo2', 'clickbar2') // after success, should re-modify the resource in the current tab successfully
       validationError(true) // do unsupported edits in the current tab, validate the error alert, and then undo the changes
-      modify(name, 'clickfoo3', 'clickbar3') // after error, should re-modify the resource in the current tab successfully
+      modify(name, 'clickfoo3', 'clickbar3', false) // after error, should re-modify the resource in the current tab successfully
 
       it('should switch to summary tab, expect no alerts and not editable', async () => {
         try {
@@ -316,7 +320,7 @@ commands.forEach(command => {
     modify(nginx)
     modify(nginx, 'foo1', 'bar1') // successfully re-modify the resource in the current tab
     validationError(true) // do unsupported edits in the current tab, and then undo the changes
-    modify(nginx, 'foo2', 'bar2') // after error, successfully re-modify the resource in the current tab
+    modify(nginx, 'foo2', 'bar2', false) // after error, successfully re-modify the resource in the current tab
     parseError() // after sucess, do unsupported edits
 
     it('should refresh', () => Common.refresh(this))


### PR DESCRIPTION
…o a fold depth of 2

Fixes #8008

<img width="619" alt="Screen Shot 2021-09-16 at 4 09 22 PM" src="https://user-images.githubusercontent.com/4741620/133679069-61ee6649-d55e-49c2-a23e-b5c9f1383547.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
