### PR TITLE
fix(plugins/plugin-kubectl): involved object button shows up in the w…

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/modes/involved-object.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/involved-object.ts
@@ -48,6 +48,7 @@ const mode: ModeRegistration<KubeResourceWithInvolvedObject> = {
   mode: {
     mode: 'involvedObject',
     label: strings('Show Involved Object'),
+    showRelatedResource: true,
     command,
     kind: 'drilldown'
   }


### PR DESCRIPTION
…rong place

Fixes #8013

<img width="618" alt="Screen Shot 2021-09-16 at 4 16 53 PM" src="https://user-images.githubusercontent.com/4741620/133680001-98be042d-92c4-47b3-b4ea-2b82d3d078e7.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
