### PR TITLE
fix(plugins/plugin-client-common): SequenceDiagram bars sometimes lac…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/Bar.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/Bar.tsx
@@ -64,7 +64,7 @@ export default class Bar extends React.PureComponent<Props> {
             key={idx}
             title={title}
             data-overlay={idx}
-            style={{ marginLeft: str(offset), width: str(width) }}
+            style={{ marginLeft: str(offset + this.props.left), width: str(width) }}
             className={'kui--bar' + (this.props.onClick ? ' clickable' : '')}
           />
         ))}


### PR DESCRIPTION
…k left-offset

E.g. when displaying a set of 10 separate jobs, we forgot to add the job offset to the overhead bars

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
