### PR TITLE
10.5.6

### DIFF
--- a/packages/test/src/api/util.ts
+++ b/packages/test/src/api/util.ts
@@ -179,6 +179,37 @@ export const expectArray = (expected: Array<string>, failFast = true, subset = f
   }
 }
 
+/** Expand the fold on the given line of a monaco editor */
+export async function clickToExpandMonacoFold(res: AppAndCount, lineIdx: number) {
+  const container =
+    res.splitIndex !== undefined
+      ? `${Selectors.PROMPT_BLOCK_N_FOR_SPLIT(res.count, res.splitIndex)} .kui--tab-content:not([hidden])`
+      : `${Selectors.PROMPT_BLOCK_N(res.count)} .kui--tab-content:not([hidden])`
+
+  console.log('MF1')
+  const selector = `${container} .monaco-editor-wrapper`
+  const wrapper = await res.app.client.$(selector)
+  await wrapper.waitForExist({ timeout: CLI.waitTimeout })
+
+  console.log('MF2')
+  const marginOverlaysSelector = `.margin-view-overlays > div:nth-child(${lineIdx + 1})` // css is 1-indexed
+  const foldingSelector = `${marginOverlaysSelector} .codicon-folding-collapsed`
+  const foldingClickable = await wrapper.$(foldingSelector)
+
+  console.log('MF3')
+  await foldingClickable.waitForExist({ timeout: CLI.waitTimeout })
+
+  console.log('MF4')
+  await foldingClickable.click()
+
+  console.log('MF5')
+  const unfoldingSelector = `${marginOverlaysSelector} .codicon-folding-expanded`
+  const unfoldingClickable = await wrapper.$(unfoldingSelector)
+  await unfoldingClickable.waitForExist({ timeout: CLI.waitTimeout })
+
+  console.log('MF6')
+}
+
 /** get the monaco editor text */
 export const getValueFromMonaco = async (res: AppAndCount, container?: string) => {
   if (!container) {

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -374,6 +374,9 @@ export default class Editor extends React.PureComponent<Props, State> {
       const editor = Monaco.create(state.wrapper, options)
       setTimeout(async () => {
         editor.setValue(await Editor.extractValue(state.content, props.response, props.repl))
+
+        // initial default folding level; see https://github.com/kubernetes-sigs/kui/issues/8008
+        editor.getAction('editor.foldLevel2').run()
       })
 
       const onZoom = () => {

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -382,37 +382,32 @@ export default class Editor extends React.PureComponent<Props, State> {
       eventChannelUnsafe.on('/zoom', onZoom)
       cleaners.push(() => eventChannelUnsafe.off('/zoom', onZoom))
 
-      if (props.sizeToFit) {
-        const sizeToFit = (
-          width?: number,
-          height = Math.min(0.4 * window.innerHeight, Math.max(250, editor.getContentHeight()))
-        ) => {
-          // if we know 1) the height of the content won't change, and
-          // 2) we are running in "simple" mode (this is mostly the case
-          // for inline editor components, as opposed to editor
-          // components that are intended to fill the full view), then:
-          // size the height to fit the content
-          state.wrapper.style.flexBasis = height + 'px'
-        }
+      const sizeToFit = !props.sizeToFit
+        ? () => true
+        : (width?: number, height = Math.min(0.4 * window.innerHeight, Math.max(250, editor.getContentHeight()))) => {
+            // if we know 1) the height of the content won't change, and
+            // 2) we are running in "simple" mode (this is mostly the case
+            // for inline editor components, as opposed to editor
+            // components that are intended to fill the full view), then:
+            // size the height to fit the content
+            state.wrapper.style.flexBasis = height + 'px'
+          }
+
+      sizeToFit()
+
+      const observer = new ResizeObserver(entries => {
+        sizeToFit(entries[0].contentRect.width, entries[0].contentRect.height)
+        editor.layout()
+      })
+      observer.observe(state.wrapper)
+      cleaners.push(() => observer.disconnect())
+
+      const onTabLayoutChange = () => {
         sizeToFit()
-
-        const observer = new ResizeObserver(entries => {
-          sizeToFit(entries[0].contentRect.width, entries[0].contentRect.height)
-          editor.layout()
-        })
-        observer.observe(state.wrapper)
-        cleaners.push(() => observer.disconnect())
-
-        const onTabLayoutChange = () => sizeToFit()
-        eventBus.onTabLayoutChange(props.tabUUID, onTabLayoutChange)
-        cleaners.push(() => eventBus.offTabLayoutChange(props.tabUUID, onTabLayoutChange))
-      } else {
-        const onTabLayoutChange = () => {
-          editor.layout()
-        }
-        eventBus.onTabLayoutChange(props.tabUUID, onTabLayoutChange)
-        cleaners.push(() => eventBus.offTabLayoutChange(props.tabUUID, onTabLayoutChange))
+        editor.layout()
       }
+      eventBus.onTabLayoutChange(props.tabUUID, onTabLayoutChange)
+      cleaners.push(() => eventBus.offTabLayoutChange(props.tabUUID, onTabLayoutChange))
 
       editor['clearDecorations'] = () => {
         // debug('clearing decorations', editor['__cloudshell_decorations'])

--- a/plugins/plugin-client-common/src/components/Content/Table/Bar.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/Bar.tsx
@@ -64,7 +64,7 @@ export default class Bar extends React.PureComponent<Props> {
             key={idx}
             title={title}
             data-overlay={idx}
-            style={{ marginLeft: str(offset), width: str(width) }}
+            style={{ marginLeft: str(offset + this.props.left), width: str(width) }}
             className={'kui--bar' + (this.props.onClick ? ' clickable' : '')}
           />
         ))}

--- a/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.css
+++ b/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.css
@@ -152,5 +152,5 @@ body[kui-theme-style] .monaco-editor .cursor {
 }
 
 body[kui-theme-style] .monaco-editor .folded-background {
-  background-color: var(--color-table-border3);
+  background-color: var(--color-base03);
 }

--- a/plugins/plugin-client-common/web/scss/components/Sidecar/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidecar/PatternFly.scss
@@ -38,3 +38,9 @@
 @include SidecarTopTabSelectedBorder {
   border-color: var(--color-base0C);
 }
+
+/** See https://github.com/kubernetes-sigs/kui/issues/8007 */
+@include SidecarTopTab {
+  flex: 1;
+  display: flex;
+}

--- a/plugins/plugin-client-common/web/scss/components/Sidecar/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidecar/PatternFly.scss
@@ -44,3 +44,20 @@
   flex: 1;
   display: flex;
 }
+
+/** See https://github.com/kubernetes-sigs/kui/issues/8017 */
+@include SidecarTopTabs {
+  .pf-c-tabs__scroll-button {
+    color: var(--color-text-02);
+    background-color: var(--color-sidecar-header);
+
+    &[disabled] {
+      color: var(--color-base04);
+    }
+
+    &:before {
+      /* this is for the right/left border of the bottom; PF seems to assume some other framing that we don't have */
+      display: none;
+    }
+  }
+}

--- a/plugins/plugin-kubectl/src/lib/model/resource.ts
+++ b/plugins/plugin-kubectl/src/lib/model/resource.ts
@@ -70,6 +70,7 @@ export interface WithOwnerReferences {
   }[]
 }
 
+/** Resource Version */
 interface WithResourceVersion {
   resourceVersion: string
 }
@@ -90,6 +91,42 @@ export function sameResourceVersion(a: MultiModalResponse<KubeResource>, b: Mult
     hasResourceVersion(a) &&
     hasResourceVersion(b) &&
     a.metadata.resourceVersion === b.metadata.resourceVersion
+  )
+}
+
+/** Managed Fields */
+interface ManagedFields<T extends string> {
+  fieldsType: T
+}
+interface ManagedFieldsV1 extends ManagedFields<'FieldsV1'> {
+  fieldsV1: Record<string, any>
+}
+
+interface WithManagedFields<Fields extends ManagedFields<string> = ManagedFieldsV1> {
+  managedFields: (Fields & {
+    manager: string
+    operation: string
+    apiVersion: string
+    time: string
+  })[]
+}
+
+export type KubeResourceWithManagedFields<Fields extends ManagedFields<string> = ManagedFieldsV1> = KubeResource<
+  {},
+  KubeMetadata & Required<WithManagedFields<Fields>>
+>
+
+export function hasManagedFields(resource: KubeResource): resource is KubeResourceWithManagedFields {
+  const { managedFields } = (resource as KubeResourceWithManagedFields).metadata
+
+  return (
+    Array.isArray(managedFields) &&
+    managedFields.length > 0 &&
+    typeof managedFields[0].manager === 'string' &&
+    typeof managedFields[0].operation === 'string' &&
+    typeof managedFields[0].apiVersion === 'string' &&
+    typeof managedFields[0].time === 'string' &&
+    typeof managedFields[0].fieldsType === 'string'
   )
 }
 

--- a/plugins/plugin-kubectl/src/lib/view/modes/Annotations.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/Annotations.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { i18n, ModeRegistration } from '@kui-shell/core'
+import { KubeResource, isKubeResource } from '../../model/resource'
+
+const strings = i18n('plugin-kubectl')
+
+/**
+ * Extract the managed fields
+ *
+ */
+async function content(_, resource: KubeResource) {
+  const { dump } = await import('js-yaml')
+
+  return {
+    contentType: 'yaml',
+    content: dump(resource.metadata.annotations)
+  }
+}
+
+/**
+ * Add a Managed Fields sidecar tab
+ *
+ */
+const mode: ModeRegistration<KubeResource> = {
+  when: isKubeResource,
+  mode: {
+    mode: 'annotations',
+    label: strings('Annotations'),
+    content
+  }
+}
+
+export default mode

--- a/plugins/plugin-kubectl/src/lib/view/modes/Labels.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/Labels.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { i18n, ModeRegistration } from '@kui-shell/core'
+import { KubeResource, isKubeResource } from '../../model/resource'
+
+const strings = i18n('plugin-kubectl')
+
+/**
+ * Extract the managed fields
+ *
+ */
+async function content(_, resource: KubeResource) {
+  const { dump } = await import('js-yaml')
+
+  return {
+    contentType: 'yaml',
+    content: dump(resource.metadata.labels)
+  }
+}
+
+/**
+ * Add a Managed Fields sidecar tab
+ *
+ */
+const mode: ModeRegistration<KubeResource> = {
+  when: isKubeResource,
+  mode: {
+    mode: 'labels',
+    label: strings('Labels'),
+    content
+  }
+}
+
+export default mode

--- a/plugins/plugin-kubectl/src/lib/view/modes/ManagedFields.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/ManagedFields.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Not currently in use, but of possible future value */
+
+import { i18n, ModeRegistration } from '@kui-shell/core'
+import { hasManagedFields, KubeResourceWithManagedFields } from '../../model/resource'
+
+const strings = i18n('plugin-kubectl')
+
+/**
+ * Extract the managed fields
+ *
+ */
+async function content(_, resource: KubeResourceWithManagedFields) {
+  const { dump } = await import('js-yaml')
+
+  return {
+    contentType: 'yaml',
+    content: dump(resource.metadata.managedFields)
+  }
+}
+
+/**
+ * Add a Managed Fields sidecar tab
+ *
+ */
+const mode: ModeRegistration<KubeResourceWithManagedFields> = {
+  when: hasManagedFields,
+  mode: {
+    mode: 'managedFields',
+    label: strings('Managed Fields'),
+    content
+  }
+}
+
+export default mode

--- a/plugins/plugin-kubectl/src/lib/view/modes/involved-object.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/involved-object.ts
@@ -48,6 +48,7 @@ const mode: ModeRegistration<KubeResourceWithInvolvedObject> = {
   mode: {
     mode: 'involvedObject',
     label: strings('Show Involved Object'),
+    showRelatedResource: true,
     command,
     kind: 'drilldown'
   }

--- a/plugins/plugin-kubectl/src/non-headless-preload.ts
+++ b/plugins/plugin-kubectl/src/non-headless-preload.ts
@@ -34,6 +34,9 @@ import involvedObjectMode from './lib/view/modes/involved-object'
 import showCRDResources from './lib/view/modes/show-crd-managed-resources'
 import EditButton from './lib/view/modes/EditButton'
 import { eventsMode, eventsBadge } from './lib/view/modes/Events'
+// import managedFieldsMode from './lib/view/modes/ManagedFields'
+import annotationsMode from './lib/view/modes/Annotations'
+import labelsMode from './lib/view/modes/Labels'
 
 import tabCompletionProvider from './lib/tab-completion'
 
@@ -50,11 +53,14 @@ export default async (registrar: PreloadRegistrar) => {
     crdSummaryMode,
     configmapSummaryMode,
     namespaceSummaryMode,
+    annotationsMode,
+    labelsMode,
     eventsMode,
     logsMode,
     ExecIntoPad,
     lastAppliedMode,
     EditButton,
+    // managedFieldsMode,
     showCRDResources,
     showOwnerButton,
     showNodeButton,

--- a/plugins/plugin-kubectl/src/test/k8s4/edit.ts
+++ b/plugins/plugin-kubectl/src/test/k8s4/edit.ts
@@ -162,11 +162,15 @@ commands.forEach(command => {
     const parseError = modifyWithError.bind(undefined, 'parse error', Keys.End, 'could not find expected')
 
     /** modify pod {name} so as to add a label of key=value */
-    const modify = (name: string, key = 'foo', value = 'bar') => {
-      it('should modify the content', async () => {
+    const modify = (name: string, key = 'foo', value = 'bar', needsUnfold = true) => {
+      it(`should modify the content by adding label ${key}=${value}`, async () => {
         try {
           const actualText = await Util.getValueFromMonaco(res)
           const labelsLineIdx = actualText.split(/\n/).indexOf('  labels:')
+
+          if (needsUnfold) {
+            await Util.clickToExpandMonacoFold(res, labelsLineIdx)
+          }
 
           // +2 here because nth-child is indexed from 1, and we want the line after that
           const lineSelector = `${Selectors.SIDECAR(res.count)} .view-lines > .view-line:nth-child(${labelsLineIdx +
@@ -252,7 +256,7 @@ commands.forEach(command => {
       modify(name, 'clickfoo1', 'clickbar1')
       modify(name, 'clickfoo2', 'clickbar2') // after success, should re-modify the resource in the current tab successfully
       validationError(true) // do unsupported edits in the current tab, validate the error alert, and then undo the changes
-      modify(name, 'clickfoo3', 'clickbar3') // after error, should re-modify the resource in the current tab successfully
+      modify(name, 'clickfoo3', 'clickbar3', false) // after error, should re-modify the resource in the current tab successfully
 
       it('should switch to summary tab, expect no alerts and not editable', async () => {
         try {
@@ -316,7 +320,7 @@ commands.forEach(command => {
     modify(nginx)
     modify(nginx, 'foo1', 'bar1') // successfully re-modify the resource in the current tab
     validationError(true) // do unsupported edits in the current tab, and then undo the changes
-    modify(nginx, 'foo2', 'bar2') // after error, successfully re-modify the resource in the current tab
+    modify(nginx, 'foo2', 'bar2', false) // after error, successfully re-modify the resource in the current tab
     parseError() // after sucess, do unsupported edits
 
     it('should refresh', () => Common.refresh(this))


### PR DESCRIPTION
[10.5.6 52953344e] feat(plugins/plugin-kubectl): Add Annotations and Labels tabs for kube resources
 Date: Thu Sep 16 15:56:51 2021 -0400
 5 files changed, 189 insertions(+)
 create mode 100644 plugins/plugin-kubectl/src/lib/view/modes/Annotations.ts
 create mode 100644 plugins/plugin-kubectl/src/lib/view/modes/Labels.ts
 create mode 100644 plugins/plugin-kubectl/src/lib/view/modes/ManagedFields.ts

[10.5.6 70e056d29] fix(plugins/plugin-client-common): Editor component does not respond to sidecar resizing
 Date: Thu Sep 16 15:59:55 2021 -0400
 2 files changed, 30 insertions(+), 29 deletions(-)

[10.5.6 582f73aa2] feat(plugins/plugin-client-common): Editor component should default to a fold depth of 2
 Date: Thu Sep 16 16:02:11 2021 -0400
 4 files changed, 43 insertions(+), 5 deletions(-)

[10.5.6 fe4930c9a] fix(plugins/plugin-kubectl): involved object button shows up in the wrong place
 Date: Thu Sep 16 16:04:31 2021 -0400
 1 file changed, 1 insertion(+)

[10.5.6 974cf038f] fix(plugins/plugin-client-common): SequenceDiagram bars sometimes lack left-offset
 Date: Thu Sep 16 16:06:13 2021 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)

[10.5.6 b92d13dec] fix(plugins/plugin-client-common): sidecar tab overflow buttons have low contrast
 Date: Thu Sep 16 19:18:56 2021 -0400
 1 file changed, 17 insertions(+)