### PR TITLE
10.5.9

### DIFF
--- a/packages/webpack/headless-webpack.config.js
+++ b/packages/webpack/headless-webpack.config.js
@@ -61,8 +61,9 @@ console.log('outputPath', outputPath)
 const plugins = []
 
 // ignore these bits for headless
-plugins.push(new IgnorePlugin({ contextRegExp: /\/tests\// }))
-plugins.push(new IgnorePlugin({ contextRegExp: /\/@kui-shell\/build/ }))
+const allFiles = /.*/
+plugins.push(new IgnorePlugin({ resourceRegExp: allFiles, contextRegExp: /\/tests\// }))
+plugins.push(new IgnorePlugin({ resourceRegExp: allFiles, contextRegExp: /\/@kui-shell\/build/ }))
 ;[
   /^d3$/,
   /^elkjs\/lib\/elk.bundled.js$/,

--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -188,7 +188,7 @@ export class Kui extends React.PureComponent<Props, State> {
     return (
       <Alert
         hideCloseButton
-        className="kui--terminal-alert kui--connection-lost"
+        className="kui--terminal-alert kui--connection-lost top-pad left-pad right-pad"
         alert={{
           type: 'error',
           title: strings('Lost connection to your cluster'),
@@ -217,7 +217,10 @@ export class Kui extends React.PureComponent<Props, State> {
 
   private defaultLoadingError() {
     return err => (
-      <Alert alert={{ type: 'error', title: strings('Error connecting to your cluster'), body: err.toString() }} />
+      <Alert
+        className="top-pad"
+        alert={{ type: 'error', title: strings('Error connecting to your cluster'), body: err.toString() }}
+      />
     )
   }
 

--- a/plugins/plugin-client-common/src/components/Client/SessionInitStatus.ts
+++ b/plugins/plugin-client-common/src/components/Client/SessionInitStatus.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Kubernetes Authors
+ * Copyright 2020 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-.kui--toolbar-alert {
-  white-space: normal;
+type SessionInitStatus = 'NotYet' | 'InProgress' | 'Reinit' | 'Done' | 'Error'
 
-  h4 {
-    margin: 0;
-    font-size: inherit;
-  }
-}
+export default SessionInitStatus

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -376,9 +376,7 @@ export default class Editor extends React.PureComponent<Props, State> {
         editor.setValue(await Editor.extractValue(state.content, props.response, props.repl))
 
         // initial default folding level; see https://github.com/kubernetes-sigs/kui/issues/8008
-        console.error('!!!!!!F1')
         editor.getAction('editor.foldLevel2').run()
-        console.error('!!!!!!F2')
       })
 
       const onZoom = () => {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -50,6 +50,7 @@ import getSize from './getSize'
 import SplitHeader from './SplitHeader'
 import { NotebookImpl, isNotebookImpl, snapshot, FlightRecorder, tabAlignment } from './Snapshot'
 import KuiConfiguration from '../../Client/KuiConfiguration'
+import SessionInitStatus from '../../Client/SessionInitStatus'
 import { onCopy, onCut, onPaste } from './ClipboardTransfer'
 import {
   Active,
@@ -121,6 +122,9 @@ type Props = TerminalOptions & {
 
   /** Toggle attribute on Tab DOM */
   toggleAttribute(attr: string): void
+
+  /** Status of the proxy session (for client-server architectures of Kui) */
+  sessionInit: SessionInitStatus
 }
 
 interface State {
@@ -350,7 +354,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
     const scrollback = this.scrollback()
     const welcomeMax = this.props.config.showWelcomeMax
 
-    if (this.props.config.loadingDone && welcomeMax !== undefined) {
+    if (this.props.sessionInit === 'Done' && this.props.config.loadingDone && welcomeMax !== undefined) {
       const welcomed = parseInt(localStorage.getItem(NUM_WELCOMED)) || 0
 
       if ((welcomeMax === -1 || welcomed < welcomeMax) && this.props.config.loadingDone) {
@@ -1539,7 +1543,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
   public render() {
     return (
-      <div className="repl" id="main-repl">
+      <div className="repl" id="main-repl" data-session-init-status={this.props.sessionInit}>
         <div className="repl-inner zoomable kui--terminal-split-container" data-split-count={this.state.splits.length}>
           {this.state.splits.map((scrollback, sbidx) => this.split(scrollback, sbidx))}
         </div>

--- a/plugins/plugin-client-common/src/components/spi/Loading/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Loading/impl/PatternFly.tsx
@@ -22,7 +22,7 @@ import Props from '../model'
 export default class PatternFlyLoading extends React.PureComponent<Props> {
   public render() {
     return (
-      <div className="flex-layout flex-align-center flex-align-top big-top-pad">
+      <div className="flex-layout flex-align-top big-top-pad">
         <Spinner size="lg" className="fade-in left-pad" />
         <span className={this.props.className + ' left-pad'}>{this.props.description}</span>
       </div>

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Announcement.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Announcement.scss
@@ -22,3 +22,7 @@
     background-color: var(--color-repl-background);
   }
 }
+
+.repl:not([data-session-init-status='Done']) .kui--session-init-done {
+  display: none;
+}


### PR DESCRIPTION
[10.5.9 99a8e5abe] fix(packages/webpack): update headless webpack config to new IgnorePlugin schema enforcement
 Date: Tue Sep 21 11:45:51 2021 -0400
 1 file changed, 3 insertions(+), 2 deletions(-)

[10.5.9 b9565bc62] fix(plugins/plugin-client-common): when proxy disconnects, all terminal state is lost
 Date: Tue Sep 21 11:26:48 2021 -0400
 6 files changed, 67 insertions(+), 37 deletions(-)
 create mode 100644 plugins/plugin-client-common/src/components/Client/SessionInitStatus.ts

[10.5.9 c1ae2cc85] fix(plugins/plugin-client-common): Loading for proxied clients is now centered
 Date: Tue Sep 21 12:16:36 2021 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)