### PR TITLE
10.5.11

### DIFF
--- a/plugins/plugin-carbon-themes/web/scss/carbon-gray10.scss
+++ b/plugins/plugin-carbon-themes/web/scss/carbon-gray10.scss
@@ -23,6 +23,7 @@
 @import '@kui-shell/plugin-client-common/web/scss/components/StatusStripe/mixins';
 
 body[kui-theme='Carbon Gray10'] {
+  @include PlexFonts;
   @include charts-light;
   @include colors-light;
   @include InvertedColorsForTerminal;

--- a/plugins/plugin-carbon-themes/web/scss/carbon-gray90.scss
+++ b/plugins/plugin-carbon-themes/web/scss/carbon-gray90.scss
@@ -26,6 +26,7 @@
 
 /* color variables */
 body[kui-theme='Carbon Gray90'][kui-theme-style] {
+  @include PlexFonts;
   @include charts-dark;
   @include colors-dark;
 

--- a/plugins/plugin-carbon-themes/web/scss/colors.scss
+++ b/plugins/plugin-carbon-themes/web/scss/colors.scss
@@ -108,6 +108,8 @@
   --color-yellow-sidecar: #fdd13a;
   --color-green-sidecar: #56d679;
 
+  --color-stripe-01: var(--color-base00);
+
   --color-brand-01: #0062ff;
   --color-brand-02: #171717;
   --color-brand-03: #0062ff;
@@ -122,6 +124,7 @@
 
   --color-table-border1: var(--color-base01);
   --color-table-border2: #8f8b8b;
+  --color-table-border3: #a8a8a8;
 
   --color-background-03: var(--color-ui-03);
 

--- a/plugins/plugin-carbon-themes/web/scss/mono.scss
+++ b/plugins/plugin-carbon-themes/web/scss/mono.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Kubernetes Authors
+ * Copyright 2021 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-@import 'mono';
-@import 'sans';
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap');
 
-@mixin PlexFonts {
-  @include PlexMonospace;
-  @include PlexSansSerif;
+@mixin PlexMonospace {
+  --font-monospace: 'IBM Plex Mono', Liberation Mono, consolas, SFMono-Regular, menlo, monaco, Courier New, monospace;
 }

--- a/plugins/plugin-carbon-themes/web/scss/sans.scss
+++ b/plugins/plugin-carbon-themes/web/scss/sans.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Kubernetes Authors
+ * Copyright 2021 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-@import 'mono';
-@import 'sans';
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100;0,400;0,700;1,400;1,700&display=swap');
 
-@mixin PlexFonts {
-  @include PlexMonospace;
-  @include PlexSansSerif;
+@mixin PlexSansSerif {
+  --font-sans-serif: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }

--- a/plugins/plugin-s3/src/vfs/index.ts
+++ b/plugins/plugin-s3/src/vfs/index.ts
@@ -548,9 +548,15 @@ class S3VFSResponder extends S3VFS implements VFS {
     fileName: string,
     dstIsFolder: boolean
   ) {
-    const endPoint = /^http/.test(this.options.endPoint) ? this.options.endPoint : `https://${this.options.endPoint}`
+    // note how we use the bucketName.endpoint style of urls
+    // see https://github.com/kubernetes-sigs/kui/issues/8046
+    const proto = this.options.endPoint.match(/(^https?:\/\/)/)
+    const endPoint = (proto
+      ? `${proto[1]}${bucketName}.${this.options.endPoint}`
+      : `https://${bucketName}.${this.options.endPoint}`
+    ).replace(/\.$/, '')
     const folder = dstIsFolder ? fileName : dirname(fileName)
-    const dstDir = !folder ? bucketName : join(bucketName, folder)
+    const dstDir = folder || ''
     if (srcs.find(_ => /index.html$/.test(_.path)) || /index.html$/.test(fileName)) {
       const path = join(dstDir, 'index.html')
       return strings('Published website as', `${endPoint}/${path}`)


### PR DESCRIPTION
[10.5.11 96f7f60da] feat(plugins/plugin-s3): when copying to a public s3 bucket, use the bucket url, not the generic one
 Date: Wed Sep 22 12:04:36 2021 -0400
 1 file changed, 8 insertions(+), 2 deletions(-)

[10.5.11 e799e6533] feat(plugins/plugin-carbon-themes): use plex fonts via google font CDN
 Date: Wed Sep 22 13:00:21 2021 -0400
 6 files changed, 54 insertions(+), 4 deletions(-)
 create mode 100644 plugins/plugin-carbon-themes/web/scss/mono.scss
 create mode 100644 plugins/plugin-carbon-themes/web/scss/sans.scss