### PR TITLE
chore: load-time tuning

### DIFF
--- a/packages/core/src/plugins/preloader.ts
+++ b/packages/core/src/plugins/preloader.ts
@@ -82,7 +82,9 @@ export default async (prescan: PrescanModel) => {
             : module.route === 'client'
             ? require(/* webpackMode: "lazy" */ '@kui-shell/client/' + 'mdist/preload')
             : await import(
-                /* webpackMode: "lazy" */ '@kui-shell/plugin-' + webpackPath(module.route) + '/mdist/preload'
+                /* webpackChunkName: "kui-plugin" */ /* webpackMode: "lazy" */ '@kui-shell/plugin-' +
+                  webpackPath(module.route) +
+                  '/mdist/preload'
               )
         debug('preloading capabilities.2 %s', module.path)
         const registration: CapabilityRegistration = registrationRef.registerCapability

--- a/packages/core/src/plugins/resolver.ts
+++ b/packages/core/src/plugins/resolver.ts
@@ -85,10 +85,14 @@ const prequire = async (
                 ? await import(/* webpackIgnore: true */ mainPath(module.path))
                 : module.route === 'client'
                 ? await import(
-                    /* webpackMode: "lazy" */ '@kui-shell/clien' + webpackPath(module.route).slice(5) + '/mdist/plugin'
+                    /* webpackChunkName: "client-plugin" */ /* webpackMode: "lazy" */ '@kui-shell/clien' +
+                      webpackPath(module.route).slice(5) +
+                      '/mdist/plugin'
                   )
                 : await import(
-                    /* webpackMode: "lazy" */ '@kui-shell/plugin-' + webpackPath(module.route) + '/mdist/plugin'
+                    /* webpackChunkName: "kui-plugins" */ /* webpackMode: "lazy" */ '@kui-shell/plugin-' +
+                      webpackPath(module.route) +
+                      '/mdist/plugin'
                   )
             const registration: PluginRegistration = registrationRef.default || registrationRef
             const combinedOptions = Object.assign({ usage: prescan.usage, docs: prescan.docs }, options)

--- a/packages/core/templates/index.ejs
+++ b/packages/core/templates/index.ejs
@@ -51,6 +51,7 @@
         autoCorrect="off"
         autoCapitalize="off"
         spellCheck="false"
+        style="position: absolute; left: -1000px; top: -1000px;"
       ></textarea>
 
       <div id="restart-needed-warning" style="display: none">

--- a/packages/test/src/api/util.ts
+++ b/packages/test/src/api/util.ts
@@ -283,13 +283,18 @@ export async function tabCount(app: Application): Promise<number> {
 }
 
 /** Close all except the first tab */
-export function closeAllExceptFirstTab(this: Common.ISuite) {
+export function closeAllExceptFirstTab(this: Common.ISuite, expectedInitialNTabs = 2) {
   it('should close all but first tab', async () => {
     try {
-      let nInitialTabs = await tabCount(this.app)
+      await this.app.client.waitUntil(async () => {
+        const currentCount = await tabCount(this.app)
+        return currentCount === expectedInitialNTabs
+      })
 
-      while (nInitialTabs > 1) {
-        const N = nInitialTabs--
+      let nTabs = await tabCount(this.app)
+
+      while (nTabs > 1) {
+        const N = nTabs--
 
         await this.app.client.$(Selectors.TOP_TAB_CLOSE_N(N)).then(_ => _.click())
 

--- a/plugins/plugin-client-common/src/components/spi/Card/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Card/impl/PatternFly.tsx
@@ -31,7 +31,7 @@ import {
 
 import Props from '../model'
 import { DropDownAction } from '../../DropDown'
-import Markdown from '../../../Content/Markdown'
+const Markdown = React.lazy(() => import('../../../Content/Markdown'))
 
 import '../../../../../web/scss/components/Card/PatternFly.scss'
 

--- a/plugins/plugin-client-common/src/components/spi/Select/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Select/impl/PatternFly.tsx
@@ -54,9 +54,13 @@ export default class PatternFlySelect extends React.PureComponent<Props, State> 
     }))
   }
 
-  private onClick(option: SelectOptions) {
+  private async onClick(option: SelectOptions) {
     if (option.command) {
-      pexecInCurrentTab(option.command)
+      if (typeof option.command === 'string') {
+        pexecInCurrentTab(option.command)
+      } else {
+        pexecInCurrentTab(await option.command())
+      }
     }
   }
 

--- a/plugins/plugin-client-common/src/components/spi/Select/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/Select/model.ts
@@ -15,7 +15,7 @@
  */
 export type SelectOptions = {
   label: string
-  command?: string
+  command?: string | (() => Promise<string>)
   description?: React.ReactNode
   isSelected?: boolean
   isDisabled?: boolean

--- a/plugins/plugin-client-common/src/components/spi/Tooltip/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Tooltip/impl/PatternFly.tsx
@@ -15,10 +15,11 @@
  */
 
 import React from 'react'
+import { Tooltip } from '@patternfly/react-core'
+
 import Props, { isMarkdownProps, isReferenceProps } from '../model'
 
-import Markdown from '../../../Content/Markdown'
-import { Tooltip } from '@patternfly/react-core'
+const Markdown = React.lazy(() => import('../../../Content/Markdown'))
 
 import '../../../../../web/scss/components/Tooltip/PatternFly.scss'
 

--- a/plugins/plugin-client-common/src/index.ts
+++ b/plugins/plugin-client-common/src/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import React from 'react'
+
 /**
  * Here we arrange the CSS for base functionality of Kui. Order is
  * preserved in the resulting <link> tags.
@@ -44,27 +46,30 @@ export {
   Options as TextWithIconWidgetOptions
 } from './components/Client/StatusStripe/TextWithIconWidget'
 export { default as Settings } from './components/Client/StatusStripe/Settings'
-export { default as TagWidget } from './components/Client/StatusStripe/TagWidget'
+export const TagWidget = React.lazy(() => import('./components/Client/StatusStripe/TagWidget'))
 export { default as DropdownWidget } from './components/Client/StatusStripe/DropdownWidget'
 export { default as KuiContext } from './components/Client/context'
 
 // Content components
-export { default as Ansi } from './components/Content/Scalar/Ansi'
+export const Ansi = React.lazy(() => import('./components/Content/Scalar/Ansi'))
 export { default as Loading } from './components/spi/Loading'
-export { default as Markdown } from './components/Content/Markdown'
+export const Markdown = React.lazy(() => import('./components/Content/Markdown'))
 export { default as HTMLDom } from './components/Content/Scalar/HTMLDom'
 
 // sidecar components
-export { default as TopNavSidecar } from './components/Views/Sidecar/TopNavSidecarV2'
-export { default as LeftNavSidecar } from './components/Views/Sidecar/LeftNavSidecarV2'
+export const TopNavSidecar = React.lazy(() => import('./components/Views/Sidecar/TopNavSidecarV2'))
+export const LeftNavSidecar = React.lazy(() => import('./components/Views/Sidecar/LeftNavSidecarV2'))
 
 // SPI
-export { default as Alert } from './components/spi/Alert'
-export { default as Button } from './components/spi/Button'
-export { default as Card } from './components/spi/Card'
-export { default as Popover } from './components/spi/Popover'
-export { default as Select } from './components/spi/Select'
-export { default as Tag } from './components/spi/Tag'
+export const Alert = React.lazy(() => import('./components/spi/Alert'))
+export const Button = React.lazy(() => import('./components/spi/Button'))
+export const Card = React.lazy(() => import('./components/spi/Card'))
+export const Popover = React.lazy(() => import('./components/spi/Popover'))
+export const Select = React.lazy(() => import('./components/spi/Select'))
+export const Tag = React.lazy(() => import('./components/spi/Tag'))
+export const Icons = React.lazy(() => import('./components/spi/Icons'))
+export const DropDown = React.lazy(() => import('./components/spi/DropDown'))
+export { Action as DropDownAction } from './components/spi/DropDown/model'
 export { default as Tooltip } from './components/spi/Tooltip'
 
 // Input components
@@ -77,10 +82,6 @@ export { default as defaultOnKeyDown } from './components/Views/Terminal/Block/O
 export { default as defaultOnKeyPress } from './components/Views/Terminal/Block/OnKeyPress'
 export { onKeyUp as defaultOnKeyUp } from './components/Views/Terminal/Block/ActiveISearch'
 export { default as FancyPipeline } from './components/Views/Terminal/Block/FancyPipeline'
-
-// spi
-export { default as Icons } from './components/spi/Icons'
-export { default as DropDown, DropDownAction } from './components/spi/DropDown'
 
 declare let __KUI_RUNNING_KUI_TEST: boolean
 export function inDebugMode() {

--- a/plugins/plugin-client-common/web/css/static/grid.scss
+++ b/plugins/plugin-client-common/web/css/static/grid.scss
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @mixin kui-rows {
   flex: 1;
   display: flex;

--- a/plugins/plugin-client-common/web/css/static/ui.css
+++ b/plugins/plugin-client-common/web/css/static/ui.css
@@ -75,12 +75,6 @@ body[kui-theme-style] a.plain-anchor {
 }
 
 /* REPL */
-#invisible-global-input {
-  /* element that handles text input while a command is being executed */
-  position: absolute;
-  left: -1000px;
-  top: -1000px;
-}
 body.still-loading .repl {
   opacity: 0;
 }

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react'
 
-import { i18n, inBrowser } from '@kui-shell/core'
+import { inBrowser } from '@kui-shell/core'
 import {
   Kui,
   KuiProps,
@@ -26,14 +26,18 @@ import {
   SpaceFiller
 } from '@kui-shell/plugin-client-common'
 
-import { CurrentGitBranch } from '@kui-shell/plugin-git'
-import { ProxyOfflineIndicator } from '@kui-shell/plugin-proxy-support'
 import { CurrentContext, CurrentNamespace } from '@kui-shell/plugin-kubectl/components'
-import { Search, UpdateChecker } from '@kui-shell/plugin-electron-components'
+
+const Search = React.lazy(() => import('@kui-shell/plugin-electron-components').then(_ => ({ default: _.Search })))
+const CurrentGitBranch = React.lazy(() => import('@kui-shell/plugin-git').then(_ => ({ default: _.CurrentGitBranch })))
+const UpdateChecker = React.lazy(() =>
+  import('@kui-shell/plugin-electron-components').then(_ => ({ default: _.UpdateChecker }))
+)
+const ProxyOfflineIndicator = React.lazy(() =>
+  import('@kui-shell/plugin-proxy-support').then(_ => ({ default: _.ProxyOfflineIndicator }))
+)
 
 import { productName } from '@kui-shell/client/config.d/name.json'
-
-const strings = i18n('plugin-client-default')
 
 /**
  * We will set this bit when the user dismisses the Welcome to Kui
@@ -55,7 +59,7 @@ function isExecuting(props: KuiProps, ...cmds: string[]) {
  *
  */
 export default function renderMain(props: KuiProps) {
-  const title = strings('Welcome to Kui')
+  const title = 'Welcome to Kui'
 
   // Important: don't use popup for commands that need tabs,
   // e.g. replaying notebooks, since `replay` currently needs tabs,

--- a/plugins/plugin-core-support/src/test/core-support/tab-management.ts
+++ b/plugins/plugin-core-support/src/test/core-support/tab-management.ts
@@ -125,6 +125,7 @@ describe('core new tab conditional', function(this: Common.ISuite) {
 describe('core new tab onClose', function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
+  Util.closeAllExceptFirstTab.bind(this)()
 
   const closers = [
     // Variant 1: execute `tab close` command
@@ -161,7 +162,7 @@ describe('core new tab onClose', function(this: Common.ISuite) {
     const key = 'foo-' + idx
     const value = '999999-' + idx
 
-    Util.closeAllExceptFirstTab.bind(this)()
+    // Util.closeAllExceptFirstTab.bind(this)(1)
     it(`should successfully open a new tab with onClose handler ${key}=${value}`, async () => {
       try {
         await CLI.command(`tab new --onClose "kuiconfig set ${key} ${value}"`, this.app)

--- a/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
@@ -294,6 +294,7 @@ describe('split an active split', function(this: Common.ISuite) {
 describe('split close and reopen', function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
+  Util.closeAllExceptFirstTab.bind(this)()
 
   const expectBlockCount = ReplExpect.blockCount.bind(this)
   const splitTheTerminalViaButton = splitViaButton.bind(this)
@@ -307,7 +308,7 @@ describe('split close and reopen', function(this: Common.ISuite) {
       await Common.refresh(this)
       await new Promise(resolve => setTimeout(resolve, 2000))
     })
-    Util.closeAllExceptFirstTab.bind(this)()
+    Util.closeAllExceptFirstTab.bind(this)(1)
     count(1)
     splitTheTerminalViaButton(2)
     count(2)

--- a/plugins/plugin-kubectl/src/test/k8s2/get-pod-multi-tab.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/get-pod-multi-tab.ts
@@ -104,7 +104,7 @@ commands.forEach(command => {
     createPod(ns2)
 
     it('should refresh', () => Common.refresh(this))
-    Util.closeAllExceptFirstTab.bind(this)()
+    Util.closeAllExceptFirstTab.bind(this)(1)
 
     let res1: ReplExpect.AppAndCount
     let res2: ReplExpect.AppAndCount


### PR DESCRIPTION
- defers loading of notebook data
- defers loading of plugin-kubectl
- defer some of the components in plugin-client-default

This should shave about 200-300ms off page load time for electron clients (maybe a 20% improvement). The main target for this is initial page load time for browser-based clients (the uncached case). This PR should reduce the payload size of the initial bundle fetch by 2-3MB (for uncompressed bundles).

Fixes #8070
Closes #8068

BREAKING CHANGE: this alters the loading cycle in a way that may break sensitive tests, mostly by making cert
ain actions a bit more asynchronous. The only possible breakage, I believe, is in test, and very few of those. If you have a test that calls `Util.closeAllExceptFirstTab` from kui-shell/test more than once in a given mocha `describe`, the second and subsequent ones will need to be altered to pass a parameter `closeAllExceptFirstTab(1)`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
