### PR TITLE
fix: improve color contrast of links in inverted splits

### DIFF
--- a/plugins/plugin-carbon-themes/web/scss/inverted.scss
+++ b/plugins/plugin-carbon-themes/web/scss/inverted.scss
@@ -82,5 +82,8 @@
   @include ScrollbackInvertedColors {
     @include carbon-inverted;
     @include Reset;
+    --color-brand-01: #97c1ff;
+    --color-brand-02: var(--color-base07);
+    --color-brand-03: #0062ff;
   }
 }

--- a/plugins/plugin-patternfly4-themes/web/scss/dark.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/dark.scss
@@ -79,6 +79,7 @@
   --color-sidecar-toolbar-background: var(--pf-global--palette--black-300);
 
   --color-text-02: var(--color-base05);
+  --color-brand-01: var(--pf-global--palette--cyan-100);
   --color-brand-02: var(--color-base07);
   --active-tab-color: var(--pf-global--active-color--300);
 


### PR DESCRIPTION
Fixes #8086

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
