### PR TITLE
10.6.3

### DIFF
--- a/packages/core/src/repl/events.ts
+++ b/packages/core/src/repl/events.ts
@@ -29,6 +29,9 @@ export interface CommandStartEvent {
   echo: boolean
   evaluatorOptions: CommandOptions
   pipeStages: CommandLine['pipeStages']
+
+  /** The output will be redirected to a file; do not display any live output */
+  redirectDesired: boolean
 }
 
 export type ResponseType = 'MultiModalResponse' | 'NavResponse' | 'ScalarResponse' | 'Incomplete' | 'Error'

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -370,11 +370,15 @@ class InProcessExecutor implements Executor {
       execOptions.execUUID = execUUID
       const evaluatorOptions = evaluator.options
 
+      // are we asked to redirect the output to a file?
+      const redirectDesired = !noCoreRedirect && !!pipeStages.redirect
+
       this.emitStartEvent({
         tab,
         route: evaluator.route,
         startTime,
         command: commandUntrimmed,
+        redirectDesired,
         pipeStages,
         evaluatorOptions,
         execType,
@@ -451,12 +455,16 @@ class InProcessExecutor implements Executor {
         createOutputStream: execOptions.createOutputStream || (() => this.makeStream(getTabId(tab), execUUID, 'stdout'))
       }
 
+      // COMMAND EXECUTION ABOUT TO COMMENCE. This is where we
+      // actually execute the command line and populate this
+      // `response` variable:
       let response: T | Promise<T> | MixedResponse
-
       const commands = evaluatorOptions.semiExpand === false ? [] : semiSplit(command)
       if (commands.length > 1) {
+        // e.g. "a ; b ; c"
         response = await semicolonInvoke(commands, execOptions)
       } else {
+        // e.g. just "a" or "a > /tmp/foo"
         try {
           response = await Promise.resolve(
             currentEvaluatorImpl.apply<T, O>(commandUntrimmed, execOptions, evaluator, args)
@@ -502,9 +510,14 @@ class InProcessExecutor implements Executor {
         }
       }
 
-      if (!noCoreRedirect && pipeStages.redirect) {
+      // Here is where we handle redirecting the response to a file
+      if (redirectDesired) {
         try {
           await redirectResponse(response, pipeStages.redirect, pipeStages.redirector)
+
+          // mimic "no response", now that we've successfully
+          // redirected the response to a file
+          response = true as T
         } catch (err) {
           response = err
         }

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -374,7 +374,7 @@ class InProcessExecutor implements Executor {
         tab,
         route: evaluator.route,
         startTime,
-        command,
+        command: commandUntrimmed,
         pipeStages,
         evaluatorOptions,
         execType,

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -385,6 +385,11 @@ export function hasStartEvent(block: BlockModel): block is BlockModel & WithComm
   return !isAnnouncement(block) && (isProcessing(block) || isOk(block) || isOops(block))
 }
 
+/** @return whether the output of this command execution be redirected to a file */
+export function isOutputRedirected(block: BlockModel): boolean {
+  return hasStartEvent(block) && block.startEvent.redirectDesired
+}
+
 /** @return whether the block is section break */
 export function isSectionBreak(block: BlockModel): block is CompleteBlock & WithSectionBreak {
   return isOk(block) && block.isSectionBreak

--- a/plugins/plugin-client-common/web/scss/components/Terminal/BlockBorder.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/BlockBorder.scss
@@ -36,26 +36,24 @@
     background-color: $focus-color;
   }
 
-  &:focus,
-  &[data-is-focused] {
+  @include BlockFocusAttributes {
     @include BlockBorder {
       opacity: 1;
       background-color: $focus-color;
     }
   }
 }
-@include Block {
-  &:focus,
-  &[data-is-focused] {
-    @include BlockBorder {
-      opacity: 1;
-      background-color: var(--color-table-border3);
-    }
+@include FocusedBlock {
+  @include BlockBorder {
+    opacity: 1;
+    background-color: var(--color-table-border3);
   }
 }
 @include ErrorBlock {
-  @include BlockBorder {
-    opacity: 0.625;
-    background-color: var(--color-red);
+  @include BlockNotFocusedAttributes {
+    @include BlockBorder {
+      opacity: 0.625;
+      background-color: var(--color-red);
+    }
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -110,6 +110,25 @@ $action-hover-delay: 210ms;
   }
 }
 
+@mixin BlockFocusAttributes {
+  &:focus,
+  &[data-is-focused] {
+    @content;
+  }
+}
+@mixin BlockNotFocusedAttributes {
+  &:not(:focus):not([data-is-focused]) {
+    @content;
+  }
+}
+@mixin FocusedBlock {
+  @include Block {
+    @include BlockFocusAttributes {
+      @content;
+    }
+  }
+}
+
 @mixin SectionBreak {
   @include Block {
     &[data-is-section-break] {


### PR DESCRIPTION
[10.6.3 f56f8f41a] fix(plugins/plugin-client-common): Click to select error block, and left border stays red
 Date: Thu Sep 30 11:48:41 2021 -0400
 2 files changed, 29 insertions(+), 12 deletions(-)

[10.6.3 6807248fc] fix(packages/core): click to edit command line with redirect, and the input edit is missing the redirect part
 Date: Thu Sep 30 11:55:41 2021 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)

[10.6.3 4a6c4673b] fix: redirect to a file also echos the output to the kui terminal
 Date: Thu Sep 30 12:25:59 2021 -0400
 5 files changed, 60 insertions(+), 16 deletions(-)