### PR TITLE
10.6.6

### DIFF
--- a/packages/core/src/models/DescriptionList.ts
+++ b/packages/core/src/models/DescriptionList.ts
@@ -21,6 +21,9 @@ export default interface DescriptionList {
   kind: 'DescriptionList'
 
   spec: {
+    /** Display as a list of key-value pairs (default), or as a list of labels */
+    as?: 'default' | 'labels'
+
     groups: {
       /** The term being described */
       term: string

--- a/packages/proxy/app/routes/exec.js
+++ b/packages/proxy/app/routes/exec.js
@@ -77,6 +77,14 @@ function main(cmdline, execOptions, server, port, hostname, existingSession, loc
       })
     }
 
+    // pass through process.env.KUI_* to the user
+    // see https://github.com/kubernetes-sigs/kui/issues/8120
+    for (const key in process.env) {
+      if (/^KUI_/.test(key) && !options.env[key]) {
+        options.env[key] = process.env[key]
+      }
+    }
+
     const wsOpen = cmdline === 'bash websocket open'
     if (wsOpen) {
       // N is the random identifier for this connection

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -146,7 +146,11 @@ export default class KuiContent extends React.PureComponent<KuiMMRProps, State> 
         return (
           <div className="flex-fill flex-layout flex-align-stretch">
             <div className="scrollable scrollable-auto scrollable-x flex-fill flex-layout flex-align-stretch">
-              <DescriptionList groups={mode.content.spec.groups} className="left-pad right-pad" />
+              <DescriptionList
+                as={mode.content.spec.as}
+                groups={mode.content.spec.groups}
+                className="left-pad right-pad"
+              />
             </div>
           </div>
         )

--- a/plugins/plugin-client-common/src/components/spi/DescriptionList/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/DescriptionList/impl/PatternFly.tsx
@@ -42,7 +42,7 @@ function columnModifier(maxWidth: number) {
   }
 }
 
-export default function PatternFlyDescriptionList(props: Props) {
+export default function PatternFlyDescriptionList(props: Omit<Props, 'as'>) {
   const maxWidth = props.groups.reduce(
     (max, group) => Math.max(max, group.term.length /*, group.description.toString().length */),
     0

--- a/plugins/plugin-client-common/src/components/spi/DescriptionList/impl/PatternFlyLabelList.tsx
+++ b/plugins/plugin-client-common/src/components/spi/DescriptionList/impl/PatternFlyLabelList.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+import { LabelGroup, Label } from '@patternfly/react-core'
+
+import Props from '../model'
+
+import '../../../../../web/scss/components/DescriptionList/PatternFlyLabelList.scss'
+
+export default function PatternFlyDescriptionList(props: Omit<Props, 'as'>) {
+  return (
+    <div
+      className={[props.className, 'kui--description-list', 'kui--label-list', 'flex-fill', 'padding-content'].join(
+        ' '
+      )}
+    >
+      <LabelGroup className="kui--description-list-group" numLabels={10}>
+        {props.groups.map((group, idx) => (
+          <Label key={idx} className="kui--description-list-term" data-term={group.term}>
+            <span className="map-key">{group.term}</span>
+            <strong className="slightly-deemphasize small-left-pad small-right-pad">|</strong>
+            <span className="map-value">{group.description}</span>
+          </Label>
+        ))}
+      </LabelGroup>
+    </div>
+  )
+}

--- a/plugins/plugin-client-common/src/components/spi/DescriptionList/impl/PatternFlyLabelList.tsx
+++ b/plugins/plugin-client-common/src/components/spi/DescriptionList/impl/PatternFlyLabelList.tsx
@@ -31,7 +31,7 @@ export default function PatternFlyDescriptionList(props: Omit<Props, 'as'>) {
       <LabelGroup className="kui--description-list-group" numLabels={10}>
         {props.groups.map((group, idx) => (
           <Label key={idx} className="kui--description-list-term" data-term={group.term}>
-            <span className="map-key">{group.term}</span>
+            <span className="kui--description-list-label-key">{group.term}</span>
             <strong className="slightly-deemphasize small-left-pad small-right-pad">|</strong>
             <span className="map-value">{group.description}</span>
           </Label>

--- a/plugins/plugin-client-common/src/components/spi/DescriptionList/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/DescriptionList/index.tsx
@@ -17,10 +17,15 @@
 import React from 'react'
 import Props from './model'
 
-const PatternFly4 = React.lazy(() => import('./impl/PatternFly'))
+const PatternFly4DescriptionList = React.lazy(() => import('./impl/PatternFly'))
+const PatternFly4LabelList = React.lazy(() => import('./impl/PatternFlyLabelList'))
 
 export { Props }
 
 export default function DescriptionListSpi(props: Props): React.ReactElement {
-  return <PatternFly4 {...props} />
+  if (!props.as || props.as === 'default') {
+    return <PatternFly4DescriptionList {...props} />
+  } else {
+    return <PatternFly4LabelList {...props} />
+  }
 }

--- a/plugins/plugin-client-common/web/scss/PatternFly/kui-alignment.scss
+++ b/plugins/plugin-client-common/web/scss/PatternFly/kui-alignment.scss
@@ -187,8 +187,8 @@
 @mixin pf-t-dark {
   --pf-global--Color--dark-100: var(--color-base06);
   --pf-global--Color--dark-200: var(--color-base05);
-  --pf-global--Color--100: var(--pf-global--Color--light-100);
-  --pf-global--Color--200: var(--pf-global--Color--light-200);
+  --pf-global--Color--100: var(--pf-global--Color--dark-100);
+  --pf-global--Color--200: var(--pf-global--Color--dark-200);
   --pf-global--BorderColor--100: var(--pf-global--BorderColor--light-100);
   --pf-global--primary-color--100: var(--pf-global--primary-color--light-100);
   --pf-global--link--Color: var(--pf-global--link--Color--light);
@@ -201,7 +201,7 @@
 @mixin kui-patternfly-alignment-dark {
   @include kui-patternfly-alignment-base;
   --pf-global--palette--black-100: var(--color-base00);
-  --pf-global--palette--black-150: var(--color-base00);
+  --pf-global--palette--black-150: var(--color-base01);
   --pf-global--palette--black-200: var(--color-base01);
   --pf-global--palette--black-300: var(--color-base02);
   --pf-global--palette--black-400: var(--color-base02);

--- a/plugins/plugin-client-common/web/scss/components/DescriptionList/PatternFlyLabelList.scss
+++ b/plugins/plugin-client-common/web/scss/components/DescriptionList/PatternFlyLabelList.scss
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { DescriptionList } from '@kui-shell/core'
+@import 'mixins';
 
-export default interface Props {
-  className?: string
-  as: DescriptionList['spec']['as']
-  groups: DescriptionList['spec']['groups']
+@include LabelList {
+  font-size: 0.75rem;
+
+  @include DescriptionListTerm {
+    background-color: var(--color-base02);
+  }
 }

--- a/plugins/plugin-client-common/web/scss/components/DescriptionList/PatternFlyLabelList.scss
+++ b/plugins/plugin-client-common/web/scss/components/DescriptionList/PatternFlyLabelList.scss
@@ -16,10 +16,21 @@
 
 @import 'mixins';
 
+@mixin LabelKey {
+  .kui--description-list-label-key {
+    @content;
+  }
+}
+
 @include LabelList {
   font-size: 0.75rem;
 
   @include DescriptionListTerm {
     background-color: var(--color-base02);
   }
+}
+
+@include LabelKey {
+  font-weight: 500;
+  color: var(--color-base0D);
 }

--- a/plugins/plugin-client-common/web/scss/components/DescriptionList/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/DescriptionList/_mixins.scss
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-import { DescriptionList } from '@kui-shell/core'
+@mixin DescriptionList {
+  .kui--description-list {
+    @content;
+  }
+}
 
-export default interface Props {
-  className?: string
-  as: DescriptionList['spec']['as']
-  groups: DescriptionList['spec']['groups']
+@mixin LabelList {
+  .kui--label-list {
+    @content;
+  }
+}
+
+@mixin DescriptionListTerm {
+  .kui--description-list-term {
+    @content;
+  }
 }

--- a/plugins/plugin-client-common/web/scss/components/DescriptionList/common.scss
+++ b/plugins/plugin-client-common/web/scss/components/DescriptionList/common.scss
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-.kui--description-list {
+@import 'mixins';
+
+@include DescriptionList {
   /* override terminal rule on .repl */
   white-space: normal;
+
+  @include DescriptionListTerm {
+    font-size: inherit;
+  }
 }

--- a/plugins/plugin-kubectl/src/lib/view/modes/Labels.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/Labels.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { i18n, ModeRegistration } from '@kui-shell/core'
+import { i18n, ModeRegistration, DescriptionList } from '@kui-shell/core'
+
 import { KubeResource, hasLabels } from '../../model/resource'
 
 const strings = i18n('plugin-kubectl')
@@ -23,11 +24,12 @@ const strings = i18n('plugin-kubectl')
  * Turn the Labels into a DescriptionList
  *
  */
-function content(_, resource: KubeResource) {
+function content(_, resource: KubeResource): DescriptionList {
   return {
-    apiVersion: 'kui-shell/v1' as const,
-    kind: 'DescriptionList' as const,
+    apiVersion: 'kui-shell/v1',
+    kind: 'DescriptionList',
     spec: {
+      as: 'labels',
       groups: Object.keys(resource.metadata.labels)
         .filter(term => resource.metadata.labels[term].length > 0)
         .sort((a, b) => a.length - b.length)


### PR DESCRIPTION
[10.6.6 74e378b14] feat: use PatternFly LabelGroup for kubernetes Labels tab
 Date: Sun Oct 3 14:37:04 2021 -0400
 11 files changed, 133 insertions(+), 12 deletions(-)
 create mode 100644 plugins/plugin-client-common/src/components/spi/DescriptionList/impl/PatternFlyLabelList.tsx
 create mode 100644 plugins/plugin-client-common/web/scss/components/DescriptionList/PatternFlyLabelList.scss
 create mode 100644 plugins/plugin-client-common/web/scss/components/DescriptionList/_mixins.scss

[10.6.6 20b9fa057] fix(plugins/plugin-client-common): Small tweaks for LabelList variant UI
 Date: Sun Oct 3 18:07:42 2021 -0400
 2 files changed, 12 insertions(+), 1 deletion(-)

[10.6.6 08cb2af16] feat(packages/proxy): pass through KUI_ env vars from proxy container to user
 Date: Mon Oct 4 13:59:32 2021 -0400
 1 file changed, 8 insertions(+)
