### PR TITLE
feat: initial /k8s VFS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ env:
   WINDOW_HEIGHT: 1050
   RUNNING_KUI_TEST: true
   KUI_USE_PROXY: true
+  KUI_SFS: true # feature toggle for /k8s vfs
   MINIO_VERSION: minio_20210214040133.0.0
   MINIO_SHA256: d5d9489262b532158a6dfd3f093de685854d83e0caf02ccef2e3d83294cb8eda
 

--- a/packages/core/src/webapp/models/table.ts
+++ b/packages/core/src/webapp/models/table.ts
@@ -84,6 +84,8 @@ export class Row {
 
   onclick?: any // eslint-disable-line @typescript-eslint/no-explicit-any
 
+  drilldownTo?: 'side-split' | 'this-split' | 'new-window'
+
   css?: string
 
   outerCSS?: string
@@ -105,6 +107,8 @@ export class Cell {
   outerCSS?: string
 
   onclick?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  drilldownTo?: 'side-split' | 'this-split' | 'new-window'
 
   key?: string
 

--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -84,7 +84,7 @@ export interface VFS {
 
   /** Remove filepath */
   rm(
-    opts: Pick<Arguments, 'command' | 'REPL' | 'parsedOptions' | 'execOptions'>,
+    opts: Pick<Arguments, 'command' | 'tab' | 'REPL' | 'parsedOptions' | 'execOptions'>,
     filepath: string,
     recursive?: boolean
   ): Promise<string | boolean>

--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -53,7 +53,10 @@ export function onClickForCell(
   cell?: KuiCell,
   opts?: Pick<KuiTable, 'drilldownTo'> & { selectRow?: () => void }
 ): CellOnClickHandler {
-  const { drilldownTo = 'side-split', selectRow = () => undefined } = opts || {}
+  const { selectRow = () => undefined } = opts || {}
+
+  // precedence order of drilldownTo protocol, with a default to drill down to a side split
+  const drilldownTo = (cell && cell.drilldownTo) || row.drilldownTo || (opts && opts.drilldownTo) || 'side-split'
 
   const handler = cell && cell.onclick ? cell.onclick : row.onclick
   if (handler === false) {

--- a/plugins/plugin-kubectl/fs/package.json
+++ b/plugins/plugin-kubectl/fs/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@kui-shell/plugin-kubectl",
+  "version": "1.0.1",
+  "description": "Kubernetes semantic filesystem",
+  "license": "Apache-2.0",
+  "keywords": [
+    "kubernetes",
+    "kubectl",
+    "helm",
+    "cli",
+    "ui",
+    "kui",
+    "plugin"
+  ],
+  "author": "@starpit",
+  "homepage": "https://github.com/IBM/kui#readme",
+  "bugs": {
+    "url": "https://github.com/IBM/kui/issues/new"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/IBM/kui.git"
+  },
+  "main": "dist/index.js",
+  "module": "mdist/index.js",
+  "types": "mdist/index.d.ts",
+  "dependencies": {
+    "@kui-shell/core": "8.0.6",
+    "@IBM/kui": "*",
+    "debug": "4.1.1"
+  },
+  "krew": {
+    "commandPrefix": "kubeui"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "89de9f78e8a1a2bdd29d2e17d7c608ab006c6d32"
+}

--- a/plugins/plugin-kubectl/fs/src/ContextFS.ts
+++ b/plugins/plugin-kubectl/fs/src/ContextFS.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from 'path'
+import { REPL, flatten } from '@kui-shell/core'
+import { VFS } from '@kui-shell/plugin-bash-like/fs'
+import { KubeContext } from '@kui-shell/plugin-kubectl'
+
+import createNamespaceMounts from './namespace-scoped'
+
+/** Where should we situate this `KubeContext` in the directory structure? */
+function pathFor(context: KubeContext) {
+  const { name } = context.metadata
+  const { user } = context.spec
+  const { cluster } = context.spec
+
+  const ibmDotDash = /cloud[.-]ibm[.-]com/
+
+  const A = name.split(/\//)
+  if (A.length === 3 && A[1] === cluster) {
+    // probably namespace/cluster/user; openshift does this?
+    const oscp = join('openshift', A[1], A[2])
+    if (ibmDotDash.test(cluster) || ibmDotDash.test(user)) {
+      return join('ibm', oscp)
+    } else {
+      return oscp
+    }
+  } else if (/codeengine\.cloud\.ibm\.com/.test(cluster)) {
+    return join('ibm', 'codeengine', name)
+  } else if (ibmDotDash.test(cluster) || ibmDotDash.test(user)) {
+    return join('ibm', 'ks', name)
+  } else if (/^(docker-desktop|microk8s|kind-kind)$/.test(name)) {
+    return join('local', name)
+  } else {
+    return name
+  }
+}
+
+/**
+ * Create semantic mounts for a given Kubernetes context
+ *
+ */
+async function initVFSForContext(repl: REPL, context: KubeContext): Promise<VFS[]> {
+  const contextName = context.metadata.name
+  const contextPath = pathFor(context)
+
+  return flatten([await Promise.all([...(await createNamespaceMounts(repl, contextName, contextPath))])])
+}
+
+/**
+ * Create one mount per Kubernetes context
+ *
+ */
+export default async function createContextMounts(repl: REPL): Promise<VFS[]> {
+  const { getAllContexts } = await import('@kui-shell/plugin-kubectl')
+  const contexts = await getAllContexts({ REPL: repl })
+
+  return flatten(await Promise.all(contexts.map(context => initVFSForContext(repl, context))))
+}

--- a/plugins/plugin-kubectl/fs/src/KubeSemanticFilesystem.ts
+++ b/plugins/plugin-kubectl/fs/src/KubeSemanticFilesystem.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO clean this up
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import minimatch from 'minimatch'
+import { basename, dirname, join } from 'path'
+
+import { Arguments } from '@kui-shell/core'
+import { FStat, DirEntry, VFS } from '@kui-shell/plugin-bash-like/fs'
+import { kubectl, KubeItems, KubeResource } from '@kui-shell/plugin-kubectl'
+
+import root from './root'
+import { waitForInitDone } from './preload'
+
+export function direntryForResource(
+  vfs: Pick<VFS, 'mountPath' | 'isLocal'>,
+  resource: KubeResource,
+  isFile: boolean
+): DirEntry {
+  const { name } = resource.metadata
+
+  return {
+    name,
+    nameForDisplay: name,
+    path: join(vfs.mountPath, name),
+    stats: {
+      size: 0,
+      mtimeMs: Array.isArray(resource.status.conditions)
+        ? resource.status.conditions.reduce((max, _) => Math.max(max, new Date(_.lastTransitionTime).getTime()), 0)
+        : new Date(resource.metadata.creationTimestamp).getTime(),
+      uid: 0,
+      gid: 0,
+      mode: 0
+    },
+    dirent: {
+      isFile,
+      isDirectory: !isFile,
+      isSymbolicLink: false,
+      isSpecial: false,
+      isExecutable: false,
+      permissions: '',
+      username: '',
+      mount: { isLocal: vfs.isLocal, mountPath: vfs.mountPath }
+    }
+  }
+}
+
+export default abstract class KubeSemanticFilesystem<R extends KubeResource = KubeResource> implements VFS {
+  public readonly mountPath: string
+  public readonly isLocal = false
+  public readonly isVirtual = true
+
+  protected readonly mountPattern: RegExp
+
+  // eslint-disable-next-line no-useless-constructor
+  public constructor(
+    contextPath: string,
+    private readonly contextName: string,
+    private readonly ns: string,
+    private readonly kind: string,
+    subdir?: string
+  ) {
+    this.mountPath = join(root, contextPath, subdir || '', kind)
+    this.mountPattern = new RegExp(`^${this.mountPath}\\/?`)
+  }
+
+  protected kindFor(filepath: string): string {
+    return basename(dirname(filepath))
+  }
+
+  protected basename(filepath: string): string {
+    return filepath.replace(this.mountPattern, '')
+  }
+
+  protected notAGlob(filepath: string) {
+    return !/[*?{}]/.test(filepath)
+  }
+
+  /** Add any --context/etc. options to the given command line */
+  private withContext(cmdline: string, kube = kubectl) {
+    return `${kube} ${cmdline} --context ${this.contextName} --namespace ${this.ns}`
+  }
+
+  protected async enumerate({ REPL }: Parameters<VFS['ls']>[0], filepaths: string[]): Promise<KubeItems<R>['items']> {
+    const patterns = !filepaths ? undefined : filepaths.map(_ => this.basename(_)).filter(Boolean)
+
+    const { items } = await REPL.qexec<KubeItems<R>>(this.withContext(`get ${this.kind} -o json`))
+    if (items) {
+      return items.filter(_ =>
+        !patterns || patterns.length === 0 ? true : patterns.find(pattern => minimatch(_.metadata.name, pattern))
+      )
+    } else {
+      return []
+    }
+  }
+
+  protected toDirEntries(items: KubeItems<R>['items']): DirEntry[] {
+    return items.map(resource => this.direntryForResource(resource))
+  }
+
+  public async ls(args: Parameters<VFS['ls']>[0], filepaths: string[]) {
+    await waitForInitDone
+    return this.toDirEntries(await this.enumerate(args, filepaths))
+  }
+
+  /** Insert filepath into directory */
+  public cp(_, srcFilepaths: string[], dstFilepath: string): Promise<string> {
+    throw new Error('Unsupported operation')
+  }
+
+  /** Remove filepath */
+  public async rm(args: Parameters<VFS['rm']>[0], filepath: string, recursive?: boolean): ReturnType<VFS['rm']> {
+    if (this.notAGlob(filepath)) {
+      await args.REPL.qexec(this.withContext(`delete ${this.kind} ${this.basename(filepath)}`))
+    } else {
+      const matches = await this.ls({ tab: args.tab, REPL: args.REPL, parsedOptions: {} }, [filepath])
+      await Promise.all(matches.map(glob => this.withContext(`delete ${this.kind} ${this.basename(glob.path)}`)))
+    }
+    return true
+  }
+
+  /** Fetch contents */
+  public async fstat(
+    { REPL }: Pick<Arguments, 'REPL' | 'parsedOptions'>,
+    filepath: string,
+    withData: boolean,
+    enoentOk: boolean
+  ): Promise<FStat> {
+    const name = filepath.slice(this.mountPath.length + 1)
+    return {
+      viewer: this.withContext(`${this.kindFor(filepath)} -o yaml`, 'kvfs-get'),
+      filepath,
+      fullpath: filepath,
+      size: 0,
+      isDirectory: false,
+      data: undefined
+    }
+  }
+
+  /** Fetch content slice */
+  public async fslice(filename: string, offset: number, length: number): Promise<string> {
+    throw new Error('Unsupported operation')
+    return undefined // eslint-disable-line no-unreachable
+  }
+
+  public async fwrite(opts: Pick<Arguments, 'REPL'>, filepath: string, data: string | Buffer) {
+    throw new Error('Unsupported operation')
+  }
+
+  /** Create a directory/bucket */
+  public async mkdir(opts: Pick<Arguments, 'argvNoOptions'>): Promise<void> {
+    throw new Error('Unsupported operation')
+  }
+
+  /** Remove a directory/bucket */
+  public rmdir(): Promise<void> {
+    throw new Error('Unsupported operation')
+  }
+
+  protected get isFile() {
+    return true
+  }
+
+  protected direntryForResource(resource: KubeResource): DirEntry {
+    return direntryForResource(this, resource, this.isFile)
+  }
+}

--- a/plugins/plugin-kubectl/fs/src/namespace-scoped/index.ts
+++ b/plugins/plugin-kubectl/fs/src/namespace-scoped/index.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from 'path'
+import { REPL, flatten } from '@kui-shell/core'
+import { VFS } from '@kui-shell/plugin-bash-like/fs'
+import { getCurrentDefaultNamespace } from '@kui-shell/plugin-kubectl'
+import { isInternalNamespace } from '@kui-shell/plugin-kubectl/heuristics'
+
+import Pods from './workloads/Pods'
+import Generic from './workloads/Generic'
+import Deployments from './workloads/Deployments'
+
+/**
+ * Create semantic mounts for a given Kubernetes context
+ *
+ */
+function initVFSForNamespace(contextName: string, ns: string, contextPath: string): VFS[] {
+  return [
+    new Pods(contextPath, contextName, ns),
+    new Deployments(contextPath, contextName, ns),
+    ...['replicasets'].map(kind => new Generic(contextPath, contextName, ns, kind))
+  ]
+}
+
+async function getAllNamespaces(repl: REPL, contextName: string): Promise<{ internal: string[]; user: string[] }> {
+  try {
+    return (await repl.qexec<string>(`kubectl get ns --context ${contextName} -o name`))
+      .split(/\n/)
+      .map(_ => _.replace(/^namespace\//, ''))
+      .reduce(
+        (P, ns) => {
+          if (isInternalNamespace(ns)) {
+            P.internal.push(ns)
+          } else {
+            P.user.push(ns)
+          }
+          return P
+        },
+        { user: [], internal: [] }
+      )
+  } catch (err) {
+    return {
+      user: [await getCurrentDefaultNamespace({ REPL: repl, parsedOptions: { context: contextName } })],
+      internal: []
+    }
+  }
+}
+
+/**
+ * Create one mount per Kubernetes context
+ *
+ */
+export default async function createNamespaceMounts(
+  repl: REPL,
+  contextName: string,
+  contextPath: string
+): Promise<VFS[]> {
+  const { user, internal } = await getAllNamespaces(repl, contextName)
+  return flatten([
+    ...user.map(ns => initVFSForNamespace(contextName, ns, ns === contextName ? contextPath : join(contextPath, ns))),
+    ...internal.map(ns => initVFSForNamespace(contextName, ns, join(contextPath, '.internal', ns)))
+  ])
+}

--- a/plugins/plugin-kubectl/fs/src/namespace-scoped/workloads/Deployments.ts
+++ b/plugins/plugin-kubectl/fs/src/namespace-scoped/workloads/Deployments.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename, join } from 'path'
+import { flatten } from '@kui-shell/core'
+import { DirEntry, VFS } from '@kui-shell/plugin-bash-like/fs'
+import { KubeItems, Pod, Deployment, getPodsCommand } from '@kui-shell/plugin-kubectl'
+
+import KubeSemanticFilesystem, { direntryForResource } from '../../KubeSemanticFilesystem'
+
+abstract class Pseudo<FS extends VFS> {
+  // eslint-disable-next-line no-useless-constructor
+  public constructor(private readonly kind: string) {}
+
+  public vfs(vfs: FS, resourceName: string): Pick<VFS, 'isLocal' | 'mountPath'> {
+    return {
+      isLocal: false,
+      mountPath: join(vfs.mountPath, resourceName, this.kind)
+    }
+  }
+
+  public direntry(vfs: FS, resourceName: string) {
+    return {
+      name: this.kind,
+      nameForDisplay: this.kind,
+      path: this.vfs(vfs, resourceName).mountPath,
+      stats: { size: 0, mtimeMs: 0, uid: 0, gid: 0, mode: 0 },
+      dirent: {
+        isFile: false,
+        isDirectory: true,
+        isSymbolicLink: false,
+        isSpecial: false,
+        isExecutable: false,
+        permissions: '',
+        username: '',
+        mount: { isLocal: vfs.isLocal, mountPath: vfs.mountPath }
+      }
+    }
+  }
+
+  public abstract ls(args: Parameters<VFS['ls']>[0], vfs: FS, deploy: Deployment): Promise<DirEntry[]>
+}
+
+class PodPseudo<FS extends VFS> extends Pseudo<FS> {
+  public constructor() {
+    super('pods')
+  }
+
+  public async ls(args: Parameters<VFS['ls']>[0], vfs: FS, deploy: Deployment): Promise<DirEntry[]> {
+    const pods = (await args.REPL.qexec<KubeItems<Pod>>(getPodsCommand(deploy) + ' -o json')).items
+    const pvfs = this.vfs(vfs, deploy.metadata.name)
+    return pods.map(pod => direntryForResource(pvfs, pod, true))
+  }
+}
+
+const pseudos = {
+  pods: new PodPseudo<DeploymentsFS>()
+}
+
+export default class DeploymentsFS extends KubeSemanticFilesystem<Deployment> {
+  public constructor(contextPath: string, contextName: string, ns: string) {
+    super(contextPath, contextName, ns, 'deployments', 'workloads')
+  }
+
+  protected get isFile() {
+    return false
+  }
+
+  public async ls(args: Parameters<VFS['ls']>[0], filepaths: string[]) {
+    const breakdown = filepaths.reduce(
+      (P, _) => {
+        const onbase = this.basename(_)
+        const pseudo = pseudos[basename(_)]
+        if (pseudo) {
+          const resourceName = onbase.slice(0, onbase.indexOf('/'))
+          P.pseudos.push({ resourceName, pseudo })
+        } else if (onbase) {
+          P.namedDeployments.push(_)
+        } else {
+          P.rest.push(_)
+        }
+        return P
+      },
+      { namedDeployments: [], pseudos: [], rest: [] }
+    )
+
+    const list1 = breakdown.rest.length === 0 ? [] : await super.ls(args, breakdown.rest)
+    const list2 =
+      breakdown.namedDeployments.length === 0 ? [] : await this.lsDeployments(args, breakdown.namedDeployments)
+    const list3 = breakdown.pseudos.length === 0 ? [] : await this.lsPseudos(args, breakdown.pseudos)
+
+    return list1.concat(list2).concat(list3)
+  }
+
+  private async lsPseudos(
+    args: Parameters<VFS['ls']>[0],
+    pseudos: { resourceName: string; pseudo: Pseudo<DeploymentsFS> }[]
+  ): Promise<DirEntry[]> {
+    const deployments = await super.enumerate(
+      args,
+      pseudos.map(_ => _.resourceName)
+    )
+    return flatten(await Promise.all(pseudos.map((_, idx) => _.pseudo.ls(args, this, deployments[idx]))))
+  }
+
+  private async lsDeployments(args: Parameters<VFS['ls']>[0], resourceNames: string[]): Promise<DirEntry[]> {
+    const deployments = await super.enumerate(args, resourceNames)
+    return flatten(await Promise.all(deployments.map(_ => this.dirEntriesForDeployment(args, _))))
+  }
+
+  private async dirEntriesForDeployment(args: Parameters<VFS['ls']>[0], deploy: Deployment): Promise<DirEntry[]> {
+    return Object.keys(pseudos).map(kind => pseudos[kind].direntry(this, deploy.metadata.name))
+  }
+}

--- a/plugins/plugin-kubectl/fs/src/namespace-scoped/workloads/Generic.ts
+++ b/plugins/plugin-kubectl/fs/src/namespace-scoped/workloads/Generic.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import KubeSemanticFilesystem from '../../KubeSemanticFilesystem'
+
+export default class GenericFS extends KubeSemanticFilesystem {
+  public constructor(contextPath: string, contextName: string, ns: string, kind: string) {
+    super(contextPath, contextName, ns, kind, 'workloads')
+  }
+}

--- a/plugins/plugin-kubectl/fs/src/namespace-scoped/workloads/Pods.ts
+++ b/plugins/plugin-kubectl/fs/src/namespace-scoped/workloads/Pods.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import KubeSemanticFilesystem from '../../KubeSemanticFilesystem'
+
+export default class PodsFS extends KubeSemanticFilesystem {
+  public constructor(contextPath: string, contextName: string, ns: string) {
+    super(contextPath, contextName, ns, 'pods', 'workloads')
+  }
+}

--- a/plugins/plugin-kubectl/fs/src/plugin.ts
+++ b/plugins/plugin-kubectl/fs/src/plugin.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename } from 'path'
+import { Registrar } from '@kui-shell/core'
+import { getAsMMRTransformer as viewTransformer } from '@kui-shell/plugin-kubectl'
+
+export default async function register(registrar: Registrar) {
+  registrar.listen('/kvfs-get', async args => {
+    const cmdline = args.command.replace(
+      /^kvfs-get( .+)? (\/.+)$/,
+      (_, p1, p2) => `kubectl get${p1 || ''} ${basename(p2)}`
+    )
+    return viewTransformer(args, await args.REPL.qexec(cmdline))
+  })
+}

--- a/plugins/plugin-kubectl/fs/src/preload.ts
+++ b/plugins/plugin-kubectl/fs/src/preload.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// this is for the resolveA and resolveB below
+/* eslint-disable promise/param-names */
+
+export let waitForInitDone: Promise<void>
+
+import { REPL } from '@kui-shell/core'
+
+/**
+ * Create all semantic mounts for Kubernetes
+ *
+ */
+export default async function preload() {
+  // We use an env var as a primitive feature toggle for now
+  if (process.env.KUI_SFS) {
+    const [{ mount }, { onKubectlConfigChangeEvents }, { default: createContextMounts }] = await Promise.all([
+      import('@kui-shell/plugin-bash-like/fs'),
+      import('@kui-shell/plugin-kubectl'),
+      import('./ContextFS')
+    ])
+
+    const init = (resolveA?: () => void) => {
+      waitForInitDone = new Promise((resolveB, reject) => {
+        setTimeout(() => {
+          mount(async (repl: REPL) => {
+            try {
+              const mounts = await createContextMounts(repl)
+              resolveB()
+              return mounts
+            } catch (err) {
+              console.error('Error initializing k8s vfs', err)
+              reject(err)
+            }
+          })
+
+          if (typeof resolveA === 'function') {
+            resolveA()
+          }
+        })
+      })
+    }
+
+    onKubectlConfigChangeEvents(() => init())
+    return new Promise(resolve => init(() => resolve(undefined)))
+  }
+}

--- a/plugins/plugin-kubectl/fs/src/root.ts
+++ b/plugins/plugin-kubectl/fs/src/root.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default '/k8s'

--- a/plugins/plugin-kubectl/fs/src/test/k8s1/k8s-vfs.ts
+++ b/plugins/plugin-kubectl/fs/src/test/k8s1/k8s-vfs.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect } from '@kui-shell/test'
+import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+
+const currentContext = require('child_process')
+  .execSync('kubectl config current-context')
+  .toString()
+  .trim()
+
+if (process.env.KUI_SFS) {
+  describe(`k8s vfs ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+    before(Common.before(this))
+    after(Common.after(this))
+
+    const ns: string = createNS()
+    allocateNS(this, ns)
+
+    // hack for now
+    it('should sleep for 5 seconds', () => new Promise(resolve => setTimeout(resolve, 5000)))
+
+    it(`should ls our local context via "ls /k8s"`, () => {
+      return CLI.command('ls -l /k8s', this.app)
+        .then(ReplExpect.okWith('local'))
+        .catch(Common.oops(this, true))
+    })
+
+    it(`should ls our currentContext via "ls /k8s/local"`, () => {
+      return CLI.command('ls -l /k8s/local', this.app)
+        .then(ReplExpect.okWith(currentContext + '/'))
+        .catch(Common.oops(this, true))
+    })
+
+    it(`should ls our namespace via ${currentContext}`, () => {
+      return CLI.command(`ls -l /k8s/local/${currentContext}`, this.app)
+        .then(ReplExpect.okWith(ns))
+        .catch(Common.oops(this, true))
+    })
+
+    deleteNS(this, ns)
+  })
+}

--- a/plugins/plugin-kubectl/fs/tsconfig.json
+++ b/plugins/plugin-kubectl/fs/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../node_modules/@kui-shell/builder/tsconfig-base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "mdist",
+    "rootDir": "src"
+  }
+}

--- a/plugins/plugin-kubectl/heuristics/src/InternalNamespace/index.ts
+++ b/plugins/plugin-kubectl/heuristics/src/InternalNamespace/index.ts
@@ -29,11 +29,12 @@ import kube from './kube'
 import istio from './istio'
 import calico from './calico'
 import knative from './knative'
+import rancher from './rancher'
 import openshift from './openshift'
 import operators from './operators'
 
 /** Make sure to add any new files to this array */
-const isInternal: string[] = [...ibm, ...kube, ...istio, ...calico, ...knative, ...openshift, ...operators]
+const isInternal: string[] = [...ibm, ...kube, ...istio, ...calico, ...knative, ...rancher, ...openshift, ...operators]
 
 /** Format a regex string from the internal namespaces list e.g. /(kube-node-lease|kube-public)/ */
 

--- a/plugins/plugin-kubectl/heuristics/src/InternalNamespace/rancher.ts
+++ b/plugins/plugin-kubectl/heuristics/src/InternalNamespace/rancher.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default [
+  '^local-path-storage$' // https://github.com/rancher/local-path-provisioner
+]

--- a/plugins/plugin-kubectl/src/controller/client/direct/create.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/create.ts
@@ -70,7 +70,6 @@ export default async function createDirect(
       kind === 'Namespace' &&
       version === 'v1' &&
       names.length > 0 &&
-      !args.parsedOptions.context &&
       !args.parsedOptions.kubeconfig
     ) {
       // WARNING: this is namespace-specific for now!
@@ -91,10 +90,10 @@ export default async function createDirect(
         .join(',')
       debug('attempting create namespace direct', names, urls)
 
-      const responses = await fetchFile(args.REPL, urls, { method: 'post', headers, returnErrors: true, data })
+      const responses = await fetchFile(args, urls, { method: 'post', headers, returnErrors: true, data })
 
       // then dissect it into errors and non-errors; the last true means return, don't throw, errors
-      const { errors, okIndices, ok } = await handleErrors(responses, formatUrl, kind, args.REPL, true)
+      const { errors, okIndices, ok } = await handleErrors(responses, formatUrl, kind, args, true)
       if (ok.length === 0) {
         // all errors? then tell the user about them (no need to re-invoke the CLI)
         if (errors.length > 0 && errors.every(is404or409)) {

--- a/plugins/plugin-kubectl/src/controller/client/direct/delete.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/delete.ts
@@ -39,7 +39,6 @@ export default async function deleteDirect(args: Arguments<KubeOptions>, _kind?:
     !getLabel(args) &&
     !args.parsedOptions['dry-run'] &&
     !args.parsedOptions['field-selector'] &&
-    !args.parsedOptions.context &&
     !args.parsedOptions.kubeconfig
   ) {
     const explainedKind = await (_kind ||
@@ -56,10 +55,10 @@ export default async function deleteDirect(args: Arguments<KubeOptions>, _kind?:
       const urls = names.map(formatUrl.bind(undefined, true, false)).join(',')
       debug('attempting delete direct', urls)
 
-      const responses = await fetchFile(args.REPL, urls, { method: 'delete', headers, returnErrors: true, data })
+      const responses = await fetchFile(args, urls, { method: 'delete', headers, returnErrors: true, data })
 
       // then dissect it into errors and non-errors
-      const { errors, ok } = await handleErrors(responses, formatUrl, kind, args.REPL)
+      const { errors, ok } = await handleErrors(responses, formatUrl, kind, args)
       if (ok.length === 0) {
         if (errors.length > 0 && errors.every(is404)) {
           // all 404 errors? then tell the user about them (no need to re-invoke the CLI)

--- a/plugins/plugin-kubectl/src/controller/client/direct/errors.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/errors.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { CodedError, isCodedError, REPL } from '@kui-shell/core'
+import { Arguments, CodedError, isCodedError } from '@kui-shell/core'
 
 import URLFormatter from './url'
+import KubeOptions from '../../kubectl/options'
 import { headersForPlainRequest } from './headers'
 import { Status, isStatus } from '../../../lib/model/resource'
 import { fetchFile, FetchedFile, isReturnedError, ReturnedError } from '../../../lib/util/fetch-file'
@@ -46,7 +47,7 @@ export default async function handleErrors(
   responses: FetchedFile[],
   formatUrl: URLFormatter,
   kind: string,
-  repl: REPL,
+  args: Pick<Arguments<KubeOptions>, 'REPL' | 'parsedOptions'>,
   returnErrors = false
 ): Promise<WithErrors> {
   const withErrors: (string | Buffer | object | CodedError)[] = await Promise.all(
@@ -68,10 +69,10 @@ export default async function handleErrors(
 
             const opts = { headers: headersForPlainRequest }
             const [nsData, kindData] = await Promise.all([
-              fetchFile(repl, nsUrl, opts)
+              fetchFile(args, nsUrl, opts)
                 .then(_ => _[0])
                 .catch(err => JSON.parse(err.message)),
-              fetchFile(repl, kindUrl, opts)
+              fetchFile(args, kindUrl, opts)
                 .then(_ => _[0])
                 .catch(err => JSON.parse(err.message))
             ])

--- a/plugins/plugin-kubectl/src/controller/client/direct/watch.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/watch.ts
@@ -251,7 +251,7 @@ export class SingleKindDirectWatcher extends DirectWatcher implements Abortable,
   private async initFooterUpdates() {
     // first: we need to fetch the initial table (so that we have a resourceVersion)
     const events = (
-      await fetchFile(this.args.REPL, this.formatEventUrl(), { headers: headersForTableRequest })
+      await fetchFile(this.args, this.formatEventUrl(), { headers: headersForTableRequest })
     )[0] as MetaTable
 
     if (isMetaTable(events)) {

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -272,7 +272,6 @@ async function rawGet(
     !args.argvNoOptions.includes('>') &&
     !args.argvNoOptions.includes('>>') &&
     !requestWithoutKind &&
-    !args.parsedOptions.context &&
     !args.parsedOptions.kubeconfig
   ) {
     // try talking to the apiServer directly

--- a/plugins/plugin-kubectl/src/index.ts
+++ b/plugins/plugin-kubectl/src/index.ts
@@ -100,6 +100,8 @@ export {
   withNamespaceBreadcrumb
 } from './lib/view/formatTable'
 
+export { getPodsCommand } from './lib/view/modes/pods'
+
 export { default as logsMode } from './lib/view/modes/logs-mode-id'
 
 export { isUsage, doHelp, withHelp } from './lib/util/help'

--- a/plugins/plugin-kubectl/src/test/k8s/contexts.ts
+++ b/plugins/plugin-kubectl/src/test/k8s/contexts.ts
@@ -109,9 +109,12 @@ Common.localDescribe('kubectl context switching', function(this: Common.ISuite) 
         try {
           const kconfig = parseYAML(getKUBECONFIG().toString())
           const newOnesFilepath = path.join(path.dirname(getKUBECONFIGFilepath()), 'forTesting.yml')
+          console.log('temporary kubeconfig', newOnesFilepath)
 
-          kconfig['contexts'][0].context.namespace = ns
-          kconfig['contexts'][0].name = contextName
+          // smash in our namespace and contextName
+          const currentContext = kconfig['contexts'].find(_ => _.name === kconfig['current-context'])
+          currentContext.context.namespace = ns
+          currentContext.name = contextName
           writeFileSync(newOnesFilepath, dump(kconfig))
 
           await this.app.client.execute(

--- a/plugins/plugin-kubectl/tsconfig.json
+++ b/plugins/plugin-kubectl/tsconfig.json
@@ -38,6 +38,9 @@
     },
     {
       "path": "view-utilization"
+    },
+    {
+      "path": "fs"
     }
   ]
 }

--- a/plugins/plugin-s3/src/providers/local-minio.ts
+++ b/plugins/plugin-s3/src/providers/local-minio.ts
@@ -66,7 +66,7 @@ async function init(repl: REPL, reinit: () => void) {
     try {
       // try pining minio to see if it is reachable
       await fetchFileString(
-        repl,
+        { REPL: repl },
         `${provider.useSSL ? 'https' : 'http'}://${provider.endPoint}:${provider.port}/minio/health/live`
       )
 


### PR DESCRIPTION
This PR adds support for a /k8s filesystem.

This PR also adds support for the client/direct kubernetes impl for `--context ccc` command lines. Previously, we always shunted these command lines to the far slower `kubectl` client impl.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
