### PR TITLE
feat(plugins/plugin-bash-like): allow `open` to pass through "rest" a…

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/open.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/open.ts
@@ -101,7 +101,8 @@ async function open(args: Arguments): Promise<KResponse> {
       return REPL.qexec(`ls ${REPL.encodeComponent(filepath)}`)
     } else {
       if (stats.viewer && stats.viewer !== 'open') {
-        const cmdline = `${stats.viewer} ${REPL.encodeComponent(filepath)}`
+        const rest = args.command.replace(filepath, '').replace(/^\s*open/, '')
+        const cmdline = `${stats.viewer} ${REPL.encodeComponent(filepath)}${rest}`
         debug('delegating to fstat-provided viewer', cmdline)
         return REPL.qexec(cmdline)
       }


### PR DESCRIPTION
…rguments

This PR updates the Kui `open` command so that it passes through the rest of the command line.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
