### PR TITLE
chore: a few minor tweaks to APIs

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -84,7 +84,7 @@ export interface VFS {
 
   /** Remove filepath */
   rm(
-    opts: Pick<Arguments, 'command' | 'REPL' | 'parsedOptions' | 'execOptions'>,
+    opts: Pick<Arguments, 'command' | 'tab' | 'REPL' | 'parsedOptions' | 'execOptions'>,
     filepath: string,
     recursive?: boolean
   ): Promise<string | boolean>

--- a/plugins/plugin-kubectl/src/index.ts
+++ b/plugins/plugin-kubectl/src/index.ts
@@ -100,6 +100,8 @@ export {
   withNamespaceBreadcrumb
 } from './lib/view/formatTable'
 
+export { getPodsCommand } from './lib/view/modes/pods'
+
 export { default as logsMode } from './lib/view/modes/logs-mode-id'
 
 export { isUsage, doHelp, withHelp } from './lib/util/help'


### PR DESCRIPTION
- export `getPodsCommand` from plugin-kubectl
- update `VFS.rm` to accept a `tab`, which allows `rm` impls to call `ls` impls
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
