### PR TITLE
feat: allow table controllers to specify drilldownTo property on a pe…

### DIFF
--- a/packages/core/src/webapp/models/table.ts
+++ b/packages/core/src/webapp/models/table.ts
@@ -84,6 +84,8 @@ export class Row {
 
   onclick?: any // eslint-disable-line @typescript-eslint/no-explicit-any
 
+  drilldownTo?: 'side-split' | 'this-split' | 'new-window'
+
   css?: string
 
   outerCSS?: string
@@ -105,6 +107,8 @@ export class Cell {
   outerCSS?: string
 
   onclick?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  drilldownTo?: 'side-split' | 'this-split' | 'new-window'
 
   key?: string
 

--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -53,7 +53,10 @@ export function onClickForCell(
   cell?: KuiCell,
   opts?: Pick<KuiTable, 'drilldownTo'> & { selectRow?: () => void }
 ): CellOnClickHandler {
-  const { drilldownTo = 'side-split', selectRow = () => undefined } = opts || {}
+  const { selectRow = () => undefined } = opts || {}
+
+  // precedence order of drilldownTo protocol, with a default to drill down to a side split
+  const drilldownTo = (cell && cell.drilldownTo) || row.drilldownTo || (opts && opts.drilldownTo) || 'side-split'
 
   const handler = cell && cell.onclick ? cell.onclick : row.onclick
   if (handler === false) {


### PR DESCRIPTION
…r-cell basis

This PR also updates the `ls` command so that non-directory drilldowns now go to the side-split.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
