### PR TITLE
feat: allow kubectl "direct" client to work with --context

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -84,7 +84,7 @@ export interface VFS {
 
   /** Remove filepath */
   rm(
-    opts: Pick<Arguments, 'command' | 'REPL' | 'parsedOptions' | 'execOptions'>,
+    opts: Pick<Arguments, 'command' | 'tab' | 'REPL' | 'parsedOptions' | 'execOptions'>,
     filepath: string,
     recursive?: boolean
   ): Promise<string | boolean>

--- a/plugins/plugin-kubectl/src/controller/client/direct/create.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/create.ts
@@ -70,7 +70,6 @@ export default async function createDirect(
       kind === 'Namespace' &&
       version === 'v1' &&
       names.length > 0 &&
-      !args.parsedOptions.context &&
       !args.parsedOptions.kubeconfig
     ) {
       // WARNING: this is namespace-specific for now!
@@ -91,10 +90,10 @@ export default async function createDirect(
         .join(',')
       debug('attempting create namespace direct', names, urls)
 
-      const responses = await fetchFile(args.REPL, urls, { method: 'post', headers, returnErrors: true, data })
+      const responses = await fetchFile(args, urls, { method: 'post', headers, returnErrors: true, data })
 
       // then dissect it into errors and non-errors; the last true means return, don't throw, errors
-      const { errors, okIndices, ok } = await handleErrors(responses, formatUrl, kind, args.REPL, true)
+      const { errors, okIndices, ok } = await handleErrors(responses, formatUrl, kind, args, true)
       if (ok.length === 0) {
         // all errors? then tell the user about them (no need to re-invoke the CLI)
         if (errors.length > 0 && errors.every(is404or409)) {

--- a/plugins/plugin-kubectl/src/controller/client/direct/delete.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/delete.ts
@@ -39,7 +39,6 @@ export default async function deleteDirect(args: Arguments<KubeOptions>, _kind?:
     !getLabel(args) &&
     !args.parsedOptions['dry-run'] &&
     !args.parsedOptions['field-selector'] &&
-    !args.parsedOptions.context &&
     !args.parsedOptions.kubeconfig
   ) {
     const explainedKind = await (_kind ||
@@ -56,10 +55,10 @@ export default async function deleteDirect(args: Arguments<KubeOptions>, _kind?:
       const urls = names.map(formatUrl.bind(undefined, true, false)).join(',')
       debug('attempting delete direct', urls)
 
-      const responses = await fetchFile(args.REPL, urls, { method: 'delete', headers, returnErrors: true, data })
+      const responses = await fetchFile(args, urls, { method: 'delete', headers, returnErrors: true, data })
 
       // then dissect it into errors and non-errors
-      const { errors, ok } = await handleErrors(responses, formatUrl, kind, args.REPL)
+      const { errors, ok } = await handleErrors(responses, formatUrl, kind, args)
       if (ok.length === 0) {
         if (errors.length > 0 && errors.every(is404)) {
           // all 404 errors? then tell the user about them (no need to re-invoke the CLI)

--- a/plugins/plugin-kubectl/src/controller/client/direct/errors.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/errors.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { CodedError, isCodedError, REPL } from '@kui-shell/core'
+import { Arguments, CodedError, isCodedError } from '@kui-shell/core'
 
 import URLFormatter from './url'
+import KubeOptions from '../../kubectl/options'
 import { headersForPlainRequest } from './headers'
 import { Status, isStatus } from '../../../lib/model/resource'
 import { fetchFile, FetchedFile, isReturnedError, ReturnedError } from '../../../lib/util/fetch-file'
@@ -46,7 +47,7 @@ export default async function handleErrors(
   responses: FetchedFile[],
   formatUrl: URLFormatter,
   kind: string,
-  repl: REPL,
+  args: Pick<Arguments<KubeOptions>, 'REPL' | 'parsedOptions'>,
   returnErrors = false
 ): Promise<WithErrors> {
   const withErrors: (string | Buffer | object | CodedError)[] = await Promise.all(
@@ -68,10 +69,10 @@ export default async function handleErrors(
 
             const opts = { headers: headersForPlainRequest }
             const [nsData, kindData] = await Promise.all([
-              fetchFile(repl, nsUrl, opts)
+              fetchFile(args, nsUrl, opts)
                 .then(_ => _[0])
                 .catch(err => JSON.parse(err.message)),
-              fetchFile(repl, kindUrl, opts)
+              fetchFile(args, kindUrl, opts)
                 .then(_ => _[0])
                 .catch(err => JSON.parse(err.message))
             ])

--- a/plugins/plugin-kubectl/src/controller/client/direct/watch.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/watch.ts
@@ -251,7 +251,7 @@ export class SingleKindDirectWatcher extends DirectWatcher implements Abortable,
   private async initFooterUpdates() {
     // first: we need to fetch the initial table (so that we have a resourceVersion)
     const events = (
-      await fetchFile(this.args.REPL, this.formatEventUrl(), { headers: headersForTableRequest })
+      await fetchFile(this.args, this.formatEventUrl(), { headers: headersForTableRequest })
     )[0] as MetaTable
 
     if (isMetaTable(events)) {

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -272,7 +272,6 @@ async function rawGet(
     !args.argvNoOptions.includes('>') &&
     !args.argvNoOptions.includes('>>') &&
     !requestWithoutKind &&
-    !args.parsedOptions.context &&
     !args.parsedOptions.kubeconfig
   ) {
     // try talking to the apiServer directly

--- a/plugins/plugin-kubectl/src/index.ts
+++ b/plugins/plugin-kubectl/src/index.ts
@@ -100,6 +100,8 @@ export {
   withNamespaceBreadcrumb
 } from './lib/view/formatTable'
 
+export { getPodsCommand } from './lib/view/modes/pods'
+
 export { default as logsMode } from './lib/view/modes/logs-mode-id'
 
 export { isUsage, doHelp, withHelp } from './lib/util/help'

--- a/plugins/plugin-kubectl/src/test/k8s/contexts.ts
+++ b/plugins/plugin-kubectl/src/test/k8s/contexts.ts
@@ -109,9 +109,12 @@ Common.localDescribe('kubectl context switching', function(this: Common.ISuite) 
         try {
           const kconfig = parseYAML(getKUBECONFIG().toString())
           const newOnesFilepath = path.join(path.dirname(getKUBECONFIGFilepath()), 'forTesting.yml')
+          console.log('temporary kubeconfig', newOnesFilepath)
 
-          kconfig['contexts'][0].context.namespace = ns
-          kconfig['contexts'][0].name = contextName
+          // smash in our namespace and contextName
+          const currentContext = kconfig['contexts'].find(_ => _.name === kconfig['current-context'])
+          currentContext.context.namespace = ns
+          currentContext.name = contextName
           writeFileSync(newOnesFilepath, dump(kconfig))
 
           await this.app.client.execute(

--- a/plugins/plugin-s3/src/providers/local-minio.ts
+++ b/plugins/plugin-s3/src/providers/local-minio.ts
@@ -66,7 +66,7 @@ async function init(repl: REPL, reinit: () => void) {
     try {
       // try pining minio to see if it is reachable
       await fetchFileString(
-        repl,
+        { REPL: repl },
         `${provider.useSSL ? 'https' : 'http'}://${provider.endPoint}:${provider.port}/minio/health/live`
       )
 


### PR DESCRIPTION
This PR adds support for the client/direct kubernetes impl for `--context ccc` command lines. Previously, we always shunted these command lines to the far slower `kubectl` client impl.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
