### PR TITLE
fix(plugins/plugin-bash-like): ls and tab completion may offer duplic…

### DIFF
--- a/plugins/plugin-kubectl/src/test/k8s3/source-ref.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/source-ref.ts
@@ -103,7 +103,7 @@ describe(`kubectl source ref ${process.env.MOCHA_RUN_TARGET || ''}`, function(th
       let isExpanded = false // default isExpanded?
       for (let idx = 0; idx < 5; idx++) {
         console.error(`SRK2.${idx}`)
-        await confirm(isExpanded, 'Deployment')
+        await confirm(isExpanded, 'ConfigMap')
         console.error(`SRK3.${idx}`)
         isExpanded = await toggle(isExpanded)
         console.error(`SRK4.${idx}`)


### PR DESCRIPTION
…ates

This happens when there is both command content and other content in the given directory.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
