### PR TITLE
fix: ls in vfs directories is not normalized

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -15,7 +15,7 @@
  */
 
 import slash from 'slash'
-import { isAbsolute, join } from 'path'
+import { isAbsolute, join, normalize } from 'path'
 import { Arguments, Events, ParsedOptions, REPL, Table, getCurrentTab, inBrowser, Util } from '@kui-shell/core'
 
 import { FStat } from '../lib/fstat'
@@ -210,7 +210,7 @@ export function mount(vfs: VFS | VFSProducingFunction, placeholderMountPath?: st
 
 /** @return the absolute path to `filepath` */
 export function absolute(filepath: string): string {
-  return isAbsolute(Util.expandHomeDir(filepath.toString())) ? filepath : join(Util.cwd(), filepath.toString())
+  return normalize(isAbsolute(Util.expandHomeDir(filepath.toString())) ? filepath : join(Util.cwd(), filepath))
 }
 
 /** Lookup compiatible matching mount */

--- a/plugins/plugin-client-test/src/test/bash-like/command-fs.ts
+++ b/plugins/plugin-client-test/src/test/bash-like/command-fs.ts
@@ -49,6 +49,12 @@ describe(`CommandFS: ls command subdirectories ${process.env.MOCHA_RUN_TARGET ||
       .then(ReplExpect.okWithString('bin/'))
       .catch(Common.oops(this, true)))
 
+  // test path normalization
+  it('ls /test/bin/.. and see bin/ directory', () =>
+    CLI.command('ls /test/bin/..', this.app)
+      .then(ReplExpect.okWithString('bin/'))
+      .catch(Common.oops(this, true)))
+
   it('ls /test/bin and see testing-subdirectory* command', () =>
     CLI.command('ls /test/bin', this.app)
       .then(ReplExpect.okWithString('testing-subdirectory*'))


### PR DESCRIPTION
e.g. ls /kui/foo/.. should list /kui

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
