### PR TITLE
fix(plugins/plugin-bash-like): cd against TrieVFS may fail due to tra…

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/TrieVFS.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/TrieVFS.ts
@@ -219,7 +219,8 @@ export abstract class TrieVFS<D extends any, L extends Leaf<D> = Leaf<D>> implem
     withData: boolean,
     enoentOk: boolean
   ): Promise<FStat> {
-    const entry = await this.findExact(filepath, withData)
+    const entry =
+      (await this.findExact(filepath.replace(/\/$/, ''), withData)) || (await this.findExact(filepath + '/', withData))
     if (!entry) {
       if (enoentOk) {
         // i don't think it makes sense to ignore ENOENT for this VFS


### PR DESCRIPTION
…iling slash discrepancies

We need to canonicalize this, so that fstat/cd work whether or not a) the path was mounted with/without a trailing slash; and b) the cd/fstat was issued with/without a trailing slash

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
