### PR TITLE
fix: improve error handling of redirect handler vs error responses

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -133,6 +133,7 @@ export { PluginRegistration, PreloadRegistration, PreloadRegistrar } from './mod
 // REPL utils
 export { default as REPL } from './models/repl'
 export { split, _split, Split } from './repl/split'
+export { default as isError } from './repl/error'
 export { splitIntoPipeStages } from './repl/pipe-stages'
 export { ReplEval, DirectReplEval } from './repl/types'
 export { default as encodeComponent } from './repl/encode'

--- a/packages/core/src/repl/error.ts
+++ b/packages/core/src/repl/error.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KResponse, UsageError, isXtermErrorResponse } from '..'
+
+type CustomError = { name: string; message: string }
+type ErrorLike = Error | CustomError
+
+function isCustomError(response: KResponse): response is CustomError {
+  const err = response as CustomError
+  return err && typeof err === 'object' && typeof err.name === 'string' && typeof err.message === 'string'
+}
+
+export default function isError(response: KResponse): response is ErrorLike {
+  return (
+    response &&
+    (response.constructor === Error ||
+      response.constructor === UsageError ||
+      isXtermErrorResponse(response) ||
+      Object.getPrototypeOf(response).constructor === Error ||
+      isCustomError(response))
+  )
+}

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -26,6 +26,8 @@ const debug = Debug('core/repl')
 const debugCommandErrors = Debug('core/repl/errors')
 
 import { v4 as uuid } from 'uuid'
+
+import isError from './error'
 import encodeComponent from './encode'
 import { splitIntoPipeStages } from './pipe-stages'
 import { split, patterns, semiSplit } from './split'
@@ -511,7 +513,7 @@ class InProcessExecutor implements Executor {
       }
 
       // Here is where we handle redirecting the response to a file
-      if (redirectDesired) {
+      if (redirectDesired && !isError(await response)) {
         try {
           await redirectResponse(response, pipeStages.redirect, pipeStages.redirector)
 
@@ -771,6 +773,7 @@ async function redirectResponse<T extends KResponse>(
       throw new Error(`Error in redirect: ${err.message}`)
     }
   } else {
+    debug('Unsupported redirect response', response)
     throw new Error('Error: unsupported redirect response')
   }
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -21,13 +21,15 @@ import {
   CommandCompleteEvent,
   KResponse,
   ScalarResponse,
-  UsageError,
   hideReplayOutput,
   isCommentaryResponse,
   isCommentarySectionBreak,
-  isXtermErrorResponse,
+  isError,
   Util
 } from '@kui-shell/core'
+
+// this used to be defined here
+export { isError }
 
 export const enum BlockState {
   Active = 'repl-active',
@@ -119,25 +121,6 @@ export default BlockModel
 function cwd() {
   const dir = Util.cwd()
   return dir ? dir.replace(process.env.HOME, '~') : undefined
-}
-
-type CustomError = { name: string; message: string }
-type ErrorLike = Error | CustomError
-
-function isCustomError(response: KResponse): response is CustomError {
-  const err = response as CustomError
-  return err && typeof err === 'object' && typeof err.name === 'string' && typeof err.message === 'string'
-}
-
-export function isError(response: KResponse): response is ErrorLike {
-  return (
-    response &&
-    (response.constructor === Error ||
-      response.constructor === UsageError ||
-      isXtermErrorResponse(response) ||
-      Object.getPrototypeOf(response).constructor === Error ||
-      isCustomError(response))
-  )
 }
 
 export function isProcessing(block: BlockModel): block is ProcessingBlock {


### PR DESCRIPTION
the repl/exec redirect handler was treating error responses as an unhandled redirect type; this is correct at some level, but not very useful to the user. let's do what bash does here, and report the original error!

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
