### PR TITLE
chore: defer loading of needle

### DIFF
--- a/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
+++ b/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
@@ -22,7 +22,6 @@
  */
 
 import React from 'react'
-import needle from 'needle'
 
 import { Events, getCurrentTab, pexecInCurrentTab, i18n } from '@kui-shell/core'
 import { TextWithIconWidget as Widget, TextWithIconWidgetProps, Markdown } from '@kui-shell/plugin-client-common'
@@ -128,7 +127,8 @@ export default class UpdateChecker extends React.PureComponent<Props, State> {
 
   /** Ping the release feed to check for the latest release */
   private checkForUpdates() {
-    needle('get', FEED(), { json: true })
+    import('needle')
+      .then(_ => _.default('get', FEED(), { json: true }))
       .then(res => {
         const version = res.body.tag_name
 

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -16,7 +16,7 @@
 
 import Debug from 'debug'
 import { join } from 'path'
-import needle, { BodyData } from 'needle'
+import { BodyData } from 'needle'
 import { DirEntry } from '@kui-shell/plugin-bash-like/fs'
 import {
   Arguments,
@@ -89,7 +89,7 @@ export async function openStream<T extends object>(
   } else {
     // we need to set JSON to false to disable needle's parsing, which
     // seems not to be compatible with streaming
-    const uri = await rescheme(url, args)
+    const [uri, needle] = await Promise.all([rescheme(url, args), import('needle').then(_ => _.default)])
     debug('routing openStream request to endpoint', uri)
     const stream = needle.get(uri, { headers, parse: false })
     const onData = mgmt.onInit({
@@ -161,6 +161,7 @@ export async function _needle(
     }
 
     try {
+      const needle = (await import('needle')).default
       const { statusCode, body } = await needle(method, await rescheme(url, args), opts.data, {
         json: true,
         follow_max: 10,


### PR DESCRIPTION
this brings in crypto and a iconv-lite, which are not needed for offline clients

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
