### PR TITLE
fix(plugins/plugin-s3): null pointer exception in plugin-s3/ibm init

### DIFF
--- a/plugins/plugin-s3/ibm/src/IBMCloudS3Provider.ts
+++ b/plugins/plugin-s3/ibm/src/IBMCloudS3Provider.ts
@@ -51,7 +51,7 @@ export default class IBMCloudS3Provider implements S3Provider {
     // e.g. s3.ap.cloud-object-storage.appdomain.cloud -> s3.direct.ap.cloud-object-storage.appdomain.cloud
     this.directEndPoint = this.endPoint.replace(/^s3\./, 's3.direct.')
 
-    const defaultRegion = GeoDefaults[config['Default Region']] || config['Default Region']
+    const defaultRegion = config ? GeoDefaults[config['Default Region']] || config['Default Region'] : undefined
     this.isDefault = config && geo === defaultRegion
 
     // use the closest available endpoint for listBuckets, since it is geo-agnostic

--- a/plugins/plugin-s3/ibm/src/controller/local.ts
+++ b/plugins/plugin-s3/ibm/src/controller/local.ts
@@ -14,14 +14,23 @@
  * limitations under the License.
  */
 
+import Debug from 'debug'
 import { REPL, encodeComponent } from '@kui-shell/core'
 import { FStat } from '@kui-shell/plugin-bash-like/fs'
 
 import filepath from './filepath'
 import Config, { hasDefaultRegion, hasEndpoint, isGoodConfigIgnoringEndpoint } from '../model/Config'
 
+const debug = Debug('plugin-s3/ibm/controller/local')
+
 export function isGoodConfig(config: void | Record<string, any>): config is Config {
-  return isGoodConfigIgnoringEndpoint(config) && hasEndpoint(config) && hasDefaultRegion(config)
+  const checkA = isGoodConfigIgnoringEndpoint(config)
+  const checkB = hasEndpoint(config)
+  const checkC = hasDefaultRegion(config)
+  debug('ibm s3 config check a', checkA)
+  debug('ibm s3 config check b', checkB)
+  debug('ibm s3 config check c', checkC)
+  return checkA && checkB && checkC
 }
 
 export default async function findLocal(repl: REPL): Promise<void | Config> {
@@ -32,5 +41,7 @@ export default async function findLocal(repl: REPL): Promise<void | Config> {
     if (isGoodConfig(config)) {
       return config
     }
-  } catch (err) {}
+  } catch (err) {
+    debug('ibm s3 config error reading config', err)
+  }
 }

--- a/plugins/plugin-s3/ibm/src/preload.ts
+++ b/plugins/plugin-s3/ibm/src/preload.ts
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
+import Debug from 'debug'
 import { addProviderInitializer } from '@kui-shell/plugin-s3'
 
 export async function registerCapability() {
-  const ibmcloud = await import('./s3provider').then(_ => _.default)
-  addProviderInitializer(ibmcloud)
+  const debug = Debug('plugin-s3/ibm/register')
+  debug('registering ibm s3 provider 1')
+
+  try {
+    const ibmcloud = await import('./s3provider').then(_ => _.default)
+    debug('registering ibm s3 provider 2', ibmcloud)
+    addProviderInitializer(ibmcloud)
+  } catch (err) {
+    debug('registering ibm s3 provider error', err)
+    return []
+  }
 }


### PR DESCRIPTION
This would result in the ibm s3 provider not initializing itself.

This PR also adds more debug to the ibm s3 provider.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
