### PR TITLE
feat: table watchers should be able to provide incremental progress

### DIFF
--- a/packages/core/src/core/jobs/watchable.ts
+++ b/packages/core/src/core/jobs/watchable.ts
@@ -46,6 +46,24 @@ export interface WatchPusher {
    */
   update: (response: Row, batch?: boolean, changed?: boolean, idxToUpdate?: number) => void
 
+  /**
+   * Update progress bar for a given row
+   *
+   * @param rowIdx row index (assumes no sorting, for now)
+   * @param percentComplete how far along is the processing of this row?
+   * @param [message] any transient message that might help understand the progress
+   * @param [totalSize] if the row represents a sized of object, how big is it?
+   * @param [fileName] if the row represents a named object, what is it called?
+   *
+   */
+  progress: (progress: {
+    rowIdx: number
+    percentComplete: number
+    message?: string
+    totalSize?: number
+    fileName?: string
+  }) => void
+
   /** set table body */
   setBody: (response: Row[]) => void
 

--- a/plugins/plugin-client-common/src/components/Content/Scalar/Ansi.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/Ansi.tsx
@@ -23,6 +23,7 @@ interface Props {
   className?: string
   children: string
   onRender?: () => void
+  noWrap?: boolean
 }
 
 /** Special overrides for CSS classes; otherwise, we will use the raw values from `anser`, e.g. "italic" and "underline" and "strikethrough" */
@@ -65,8 +66,15 @@ export default function Ansi(props: Props) {
     props.onRender()
   }
 
+  const style: Record<string, any> = { margin: 0 }
+  if (!props.noWrap) {
+    style.wordBreak = 'break-all'
+  } else {
+    style.whiteSpace = 'nowrap'
+  }
+
   return (
-    <pre className={props.className} style={{ margin: 0, wordBreak: 'break-all' }}>
+    <pre className={props.className} style={style}>
       {model.map(
         (_, idx) => _.content && React.createElement(tagOf(_), { key: idx, className: classOf(_) }, content(_.content))
       )}

--- a/plugins/plugin-client-common/src/components/Content/Table/Bar.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/Bar.tsx
@@ -59,15 +59,16 @@ export default class Bar extends React.PureComponent<Props> {
         />
 
         {/* "overlays", make sure this comes last:  */}
-        {this.props.overheads.map(({ title, width, offset }, idx) => (
-          <div
-            key={idx}
-            title={title}
-            data-overlay={idx}
-            style={{ marginLeft: str(offset + this.props.left), width: str(width) }}
-            className={'kui--bar' + (this.props.onClick ? ' clickable' : '')}
-          />
-        ))}
+        {this.props.overheads &&
+          this.props.overheads.map(({ title, width, offset }, idx) => (
+            <div
+              key={idx}
+              title={title}
+              data-overlay={idx}
+              style={{ marginLeft: str(offset + this.props.left), width: str(width) }}
+              className={'kui--bar' + (this.props.onClick ? ' clickable' : '')}
+            />
+          ))}
       </div>
     )
   }

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -34,6 +34,7 @@ import Card from '../../spi/Card'
 import Timeline from './Timeline'
 import renderBody from './TableBody'
 import renderHeader from './TableHeader'
+import ProgressState from './ProgressState'
 import SequenceDiagram from './SequenceDiagram'
 import Histogram from './Histogram'
 import kuiHeaderFromBody from './kuiHeaderFromBody'
@@ -86,19 +87,20 @@ export type Props<T extends KuiTable = KuiTable> = PaginationConfiguration & {
 }
 
 /** state of PaginatedTable component */
-export type State<T extends KuiTable = KuiTable> = ToolbarProps & {
-  response: T
-  header: KuiRow
-  body: KuiRow[]
-  footer: string[]
+export type State<T extends KuiTable = KuiTable> = ToolbarProps &
+  ProgressState & {
+    response: T
+    header: KuiRow
+    body: KuiRow[]
+    footer: string[]
 
-  page: number
-  pageSize: number
+    page: number
+    pageSize: number
 
-  /* sorting */
-  activeSortIdx: number
-  activeSortDir: SortByDirection
-}
+    /* sorting */
+    activeSortIdx: number
+    activeSortDir: SortByDirection
+  }
 
 export function getBreadcrumbsFromTable(response: KuiTable, prefixBreadcrumbs: BreadcrumbView[]) {
   const titleBreadcrumb: BreadcrumbView[] = response.title
@@ -401,7 +403,14 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
   }
 
   private sequence() {
-    return <SequenceDiagram {...this.props} isWatching={this.isWatching()} />
+    return (
+      <SequenceDiagram
+        {...this.props}
+        isWatching={this.isWatching()}
+        progressVersion={this.state.progressVersion}
+        progress={this.state.progress}
+      />
+    )
   }
 
   private histogram() {

--- a/plugins/plugin-client-common/src/components/Content/Table/ProgressState.ts
+++ b/plugins/plugin-client-common/src/components/Content/Table/ProgressState.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WatchPusher } from '@kui-shell/core'
+
+/** Progress per row; keyed by rowKey, value is the same as the progress update parameter */
+export default interface ProgressState {
+  progress: Record<string, Parameters<WatchPusher['progress']>[0]>
+  progressVersion: number
+}


### PR DESCRIPTION
This PR adds a `progress()` method to the `WatchPusher` API.

```typescript
  /**
   * Update progress bar for a given row
   *
   * @param rowIdx row index (assumes no sorting, for now)
   * @param percentComplete how far along is the processing of this row?
   * @param [message] any transient message that might help understand the progress
   * @param [totalSize] if the row represents a sized of object, how big is it?
   * @param [fileName] if the row represents a named object, what is it called?
   *
   */
  progress: (progress: { rowIdx: number, percentComplete: number, message?: string, totalSize?: number, fileName?: string }) => void
```

![table-progress](https://user-images.githubusercontent.com/4741620/142641486-c63a4cf7-2a2b-4af4-ba11-020aac151639.gif)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
