### PR TITLE
fix(packages/proxy): proxy does not properly run in external clients

### DIFF
--- a/packages/proxy/app/bin/run-proxy.sh
+++ b/packages/proxy/app/bin/run-proxy.sh
@@ -17,6 +17,11 @@
 #
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
-cd "$SCRIPTDIR"/../@kui-shell/proxy/app
+cd "$SCRIPTDIR"/../@kui-shell/proxy
 
-PORT=8081 KUI_USE_HTTP=true ./bin/www
+export PORT=8081
+export KUI_USE_HTTP=true
+
+ROOT="$SCRIPTDIR"/../..
+export CLIENT_HOME="$ROOT"
+/usr/bin/env node "$ROOT"/dist/headless/kui-proxy.min.js

--- a/packages/proxy/app/routes/exec.js
+++ b/packages/proxy/app/routes/exec.js
@@ -23,7 +23,9 @@ const { parse: parseCookie } = require('cookie')
 
 const sessionKey = 'kui_websocket_auth'
 
-const mainPath = join(process.env.CLIENT_HOME, 'dist/headless/kui.min.js')
+const { productName } = require('@kui-shell/client/config.d/name.json')
+
+const mainPath = join(process.env.CLIENT_HOME, `dist/headless/${productName.toLowerCase()}.min.js`)
 const { main: wssMain } = require('@kui-shell/plugin-bash-like')
 const { StdioChannelWebsocketSide } = require('@kui-shell/plugin-bash-like')
 

--- a/packages/webpack/headless-webpack.config.js
+++ b/packages/webpack/headless-webpack.config.js
@@ -175,7 +175,7 @@ kuiPluginExternals.forEach(_ => {
   externals[_] = _
 })
 
-const config = (entry, target, extraPlugins = [], nameSuffix = '') => ({
+const config = (entry, target, extraPlugins = [], filename = productName.toLowerCase(), nameSuffix = '') => ({
   context: process.env.CLIENT_HOME,
   stats: {
     // while developing, you should set this to true
@@ -292,7 +292,7 @@ const config = (entry, target, extraPlugins = [], nameSuffix = '') => ({
 
   // stats: 'verbose',
   output: {
-    filename: productName.toLowerCase() + nameSuffix + '.min.js',
+    filename: filename + '.min.js',
     publicPath: '',
     path: outputPath,
     library: {
@@ -307,7 +307,7 @@ if (process.env.TARGET !== 'electron-renderer') {
   // with a kui-proxy backed client, we need notebooks in the "main"
   console.log('Processing webpack electron-main and kui-proxy', process.env.TARGET)
   const electronMain = config(kuiHeadlessMain, 'node')
-  const proxy = config(kuiProxyMain, 'node', ignoreNotebooks, '-proxy')
+  const proxy = config(kuiProxyMain, 'node', ignoreNotebooks, 'kui-proxy', '-proxy')
   module.exports = [electronMain, proxy]
 } else {
   console.log('Processing webpack for electron-main')


### PR DESCRIPTION
clients with their own productName (different than "Kui") will be unable to properly run the proxy process. There are a few places that assume the bundles are named e.g. "kui-min.js"

Also the kui-run-proxy script was not updated to use the minified bundles.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
