### PR TITLE
fix(plugins/plugin-bash-like): ls may report duplicates

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
@@ -108,7 +108,12 @@ async function lsMounts(path: string): Promise<DirEntry[]> {
 function removeDuplicates2(vfses: DirEntry[]): DirEntry[] {
   // nice nodejs; set.add doesn't indicate whether something was added??
   const set = new Set()
-  return vfses.filter(_ => !set.has(_.path) && set.add(_.path))
+  return vfses.filter(_ => {
+    // some vfses may report directories with a trailing slash
+    const canon = _.path.replace(/\/$/, '')
+
+    return !set.has(canon) && set.add(canon)
+  })
 }
 
 /**


### PR DESCRIPTION
this happens if a VFS has both commands and file content in a directory

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
