### PR TITLE
fix(plugins/plugin-client-common): Maximum width for executable block content

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
@@ -28,6 +28,12 @@ $margin-for-right-elements: calc(#{math.div(0.875 * $input-padding, $right-eleme
   }
 }
 
+@include Block {
+  @include NotEditable {
+    max-width: 960px;
+  }
+}
+
 /** These are special stylings for read only mode, for example, we don't wantt to show all block actions */
 @include Scrollback {
   @include FinishedBlock {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -296,6 +296,12 @@ $action-hover-delay: 210ms;
   }
 }
 
+@mixin NotEditable {
+  &:not([data-is-editable]) {
+    @content;
+  }
+}
+
 /** Hide the In[1] bits */
 @mixin HideIn {
   @include Block {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Added a maximum width for executable blocks typically found in notebooks. This is especially helpful when the Kui window is expanded.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
