### PR TITLE
fix(plugins/plugin-bash-like): bracket-expansion against TrieVFS does…

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/TrieVFS.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/TrieVFS.ts
@@ -86,7 +86,7 @@ export abstract class TrieVFS<D extends any, L extends Leaf<D> = Leaf<D>> implem
   /** Looks in the trie for any matches for the given filepath, handling the "contents of directory" case */
   private find(filepath: string, dashD = false, exact = false): (Directory | L)[] {
     const dirPattern = this.dirPattern(filepath)
-    const matches = this.trieGet(filepath.replace(/\*.*$/, ''))
+    const matches = this.trieGet(filepath.replace(/[*{].*$/, '')) // trim off trailing globby bits when looking up in the trie
     const flexMatches = matches.filter(_ =>
       exact ? _.mountPath === filepath : micromatch.isMatch(_.mountPath, filepath) || dirPattern.test(_.mountPath)
     )


### PR DESCRIPTION
… not work

e.g.
```sh
ls /kui/{iter8,kubernetes}
```

should find those two, but finds nothing

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
