### PR TITLE
feat: Use Patternfly Text components for text styling

### DIFF
--- a/plugins/plugin-client-common/web/css/static/ui.css
+++ b/plugins/plugin-client-common/web/css/static/ui.css
@@ -457,7 +457,7 @@ pre.monospace {
   font-size: inherit;
   font-weight: inherit;
 }
-body[kui-theme-style] {
+body {
   /** This group of rules override default user-agent stylings */
   ol,
   ul {
@@ -813,11 +813,6 @@ body.oops-total-catastrophe #restart-needed-warning {
 }
 .page-content p {
   font-size: inherit;
-  margin: 0;
-}
-.page-content li > p,
-.page-content p:only-child {
-  padding: 0;
 }
 .page-content code {
   font-family: var(--font-monospace);
@@ -886,71 +881,8 @@ body[kui-theme-style="dark"] .repl {
 }
 $kui--page-content-h4-padding: 0.5em;
 $kui--page-content-paragraph-padding: 0.375em;
-.page-content p,
 .page-content .paragraph {
   padding: $kui--page-content-paragraph-padding 0;
-}
-.page-content h1 {
-  &,
-  & a {
-    font-family: var(--font-sans-serif-title);
-    margin-bottom: 1em;
-    font-size: 2.75em;
-    letter-spacing: 0;
-    line-height: 1.25;
-    padding: 0;
-  }
-}
-.page-content h1:only-child {
-  margin-bottom: 0;
-}
-.page-content h2,
-.page-h2 {
-  font-family: var(--font-sans-serif-title);
-  font-size: 1.875em;
-  font-weight: 500;
-  margin: 0.875em 0 0.5em;
-  line-height: 1.25;
-}
-.page-content > h3:first-child,
-.page-content > h2:first-child,
-.page-content hr + h3 {
-  margin-top: 0;
-  padding-top: 0;
-}
-.repl {
-  .page-content h3,
-  .page-h3 {
-    color: var(--color-text-01);
-  }
-}
-.page-content h3,
-.page-h3 {
-  font-family: var(--font-sans-serif-title);
-  font-size: 1.375em;
-  font-weight: 300;
-  letter-spacing: 0;
-  padding: 1em 0 0.5em;
-  margin: 0;
-}
-.page-content h4 {
-  font-family: var(--font-sans-serif-title);
-  color: var(--color-brand-01);
-  letter-spacing: 0.32px;
-  padding-top: $kui--page-content-h4-padding;
-  font-size: unset;
-  line-height: unset;
-  margin: 0;
-}
-.page.content:not([data-is-nested]) {
-  h4:not([data-is-href]) + p {
-    padding-top: calc(0.5em + #{$kui--page-content-paragraph-padding});
-  }
-}
-.page-content h5 {
-  font-family: var(--font-sans-serif-title);
-  font-size: 1.25em;
-  line-height: 2em;
 }
 .page-content .kui--structured-list {
   tr {

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -61,6 +61,7 @@ $z-index: var(--pf-global--ZIndex--xs);
 
   /* markdown */
   p {
+    margin: 0;
     letter-spacing: 0.16px;
     code {
       font-family: var(--font-sans-serif);

--- a/plugins/plugin-client-common/web/scss/components/Table/Events.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/Events.scss
@@ -58,6 +58,7 @@ $inter-message-spacing: 0.1875rem;
     white-space: pre-wrap;
     font-family: var(--font-monospace);
     font-size: 0.75rem;
+    margin: 0;
     padding: 0;
   }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -21,6 +21,11 @@
 @import '../../Themes/mixins';
 @import 'BlockLinks';
 
+body[kui-theme-style] .pf-c-content {
+  color: inherit;
+  font-size: inherit;
+}
+
 @mixin h1 {
   @include CommentaryCard {
     h1 {
@@ -38,6 +43,22 @@
 }
 
 @mixin h3 {
+  @include CommentaryCard {
+    h3 {
+      @content;
+    }
+  }
+}
+
+@mixin h4 {
+  @include CommentaryCard {
+    h3 {
+      @content;
+    }
+  }
+}
+
+@mixin h5 {
   @include CommentaryCard {
     h3 {
       @content;
@@ -82,42 +103,9 @@
 }
 
 @include Scrollback {
-  @include h1 {
-    font-weight: 300;
-    font-size: 2em;
-    letter-spacing: 0.32px;
-    margin: 0.5em 1em 0.875em 0;
-
-    &:first-child {
-      padding-top: 0;
-    }
-  }
-
   @include blockquote {
     border-left-color: var(--color-brand-03);
     color: var(--color-text-02);
-  }
-
-  @include h2 {
-    font-weight: 300;
-    font-size: 1.875em;
-    letter-spacing: 0.32px;
-    margin: 0.5em 0;
-
-    &:first-child {
-      margin-top: 0;
-    }
-
-    &:before {
-      display: none;
-    }
-  }
-
-  .page-content {
-    ol,
-    li {
-      margin: 0.5em 0;
-    }
   }
 
   @include Paragraphs {
@@ -194,4 +182,20 @@ body[kui-theme-style='light'] {
       }
     }
   }
+}
+
+@include h1 {
+  --pf-c-content--heading--FontFamily: var(--font-sans-serif-title);
+}
+@include h2 {
+  --pf-c-content--heading--FontFamily: var(--font-sans-serif-title);
+}
+@include h3 {
+  --pf-c-content--heading--FontFamily: var(--font-sans-serif-title);
+}
+@include h4 {
+  --pf-c-content--heading--FontFamily: var(--font-sans-serif-title);
+}
+@include h5 {
+  --pf-c-content--heading--FontFamily: var(--font-sans-serif-title);
 }


### PR DESCRIPTION
We have a bunch of home-grown stylings for p and h1 and h2, etc. Let's stop DIYing it here.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
