### PR TITLE
fix(plugins/plugin-client-common): avoid font-weight shifting in top …

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
@@ -128,7 +128,6 @@ $tab-label-font-size: 0.875rem;
     &.kui--tab--active {
       @include TabLabel {
         color: var(--color-text-01);
-        font-weight: 500;
         &:hover {
           color: var(--color-text-01);
         }


### PR DESCRIPTION
…tabs

When switching tabs, we currently alter the font-weight of the tab labels. This causes a reflow effect that would be nice to avoid.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
