### PR TITLE
fix(plugins/plugin-bash-like): kubectl prereq fails

### DIFF
--- a/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
@@ -27,6 +27,7 @@ const debug = Debug('plugins/bash-like/cmds/catchall')
  */
 export const dispatchToShell = async ({
   tab,
+  REPL,
   command,
   argv,
   argvNoOptions,
@@ -53,7 +54,7 @@ export const dispatchToShell = async ({
   const eOptions =
     useRaw || execOptions.isProxied
       ? execOptions
-      : Object.assign({ cwd: await cwd(execOptions, tab.REPL) }, { stdout: await createOutputStream() }, execOptions)
+      : Object.assign({ cwd: await cwd(execOptions, REPL) }, { stdout: await createOutputStream() }, execOptions)
 
   const actualCommand = command.replace(/^(!|sendtopty)\s+/, '')
 
@@ -75,7 +76,7 @@ export const dispatchToShell = async ({
     return response
   } else {
     const { doExec } = await import(/* webpackMode: "lazy" */ '../../pty/client')
-    const exec = () => doExec(tab, actualCommand, argvNoOptions, parsedOptions, eOptions)
+    const exec = () => doExec(tab, REPL, actualCommand, argvNoOptions, parsedOptions, eOptions)
 
     if (useRaw) {
       eOptions.quiet = true

--- a/plugins/plugin-bash-like/src/pty/index.ts
+++ b/plugins/plugin-bash-like/src/pty/index.ts
@@ -27,4 +27,4 @@ export const doExec = (
   argvNoOptions: string[],
   parsedOptions: Options,
   execOptions: ExecOptions
-) => import('./client').then(_ => _.doExec(tab, cmdline, argvNoOptions, parsedOptions, execOptions))
+) => import('./client').then(_ => _.doExec(tab, tab.REPL, cmdline, argvNoOptions, parsedOptions, execOptions))


### PR DESCRIPTION
This is due to a change in bash-like's new cwd() impl

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
