### PR TITLE
fix(plugins/plugin-client-common): fix for small regression in paragr…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -339,3 +339,10 @@ body[kui-theme-style] .kui--repl-block-right-element {
     opacity: 0;
   }
 }
+
+/** Markdown or Scalar uses a paragraph wrapper around the text output of PTY commands */
+@include CommandOutput {
+  p:only-child {
+    margin: 0;
+  }
+}


### PR DESCRIPTION
…aph margin

Recently, in https://github.com/kubernetes-sigs/kui/pull/8278, we switched over to use PatternFly for text/paragraph/heading spacing. This caused a minor regression in the margin around PTY output, which seems to use a `<p>` wrapper.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
