### PR TITLE
fix: multi-line input is partially broken

### DIFF
--- a/packages/core/src/repl/split.ts
+++ b/packages/core/src/repl/split.ts
@@ -96,6 +96,10 @@ export const _split = (
 
       if (!escapeActive) {
         escapeActive = true
+        if (/\n/.test(str.charAt(idx + 1))) {
+          // see https://github.com/kubernetes-sigs/kui/issues/8274
+          idx++
+        }
         continue
         // char = str.charAt(++idx)
         // if (!removeOuterQuotes) {

--- a/plugins/plugin-bash-like/fs/src/lib/head.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/head.ts
@@ -79,6 +79,8 @@ async function head(args: Arguments<HeadOptions>): Promise<KResponse> {
     // change `head -10 file` to `head -n 10 file`
     const newarg = `-n ${filepath * -1}`
     return args.REPL.qexec(args.command.replace(filepath, newarg))
+  } else if (typeof filepath === 'undefined') {
+    throw new Error('Missing input file')
   }
 
   try {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/OnKeyPress.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/OnKeyPress.ts
@@ -42,8 +42,12 @@ export default async function onKeyPress(this: Input, event: KeyboardEvent) {
       this.setState({ isReEdit: false })
 
       // FIXME: shiftreturned line should be joined with '\'?
-      doEval(this.props.tab, this.props._block, this.state.prompt.value.trim(), execUUID)
-      //                                                                        ^^^^ reusing execUUID
+      doEval(
+        this.props.tab,
+        this.props._block,
+        this.state.prompt.value.trim(),
+        execUUID // reusing execUUID
+      )
     }
   }
 }


### PR DESCRIPTION
1) broken handling of manually typed backslash-escaped multiline commands
2) broken handling of pasted backslash-escaped multiline commands

part of #8274

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
