### PR TITLE
feat(plugins/plugin-client-common): initial remark-tabbed markdown ex…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/remark-tabbed/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/remark-tabbed/index.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const tabStart = /^===\s+"(.+)"\s*(\n(.|[\n\r])*)?$/
+
+export default function plugin(/* options */) {
+  return function transformer(tree) {
+    let currentTabs = []
+    const flushTabs = children => {
+      children.push({ type: 'element', tagName: 'tabbed', children: currentTabs })
+      currentTabs = []
+    }
+
+    if (tree.children && tree.children.length > 0) {
+      tree.children = tree.children.reduce((newChildren, child) => {
+        const addToTab = child => {
+          const cur = currentTabs[currentTabs.length - 1]
+          cur.children.push(child)
+          if (child.position) {
+            cur.position.end = child.position.end
+          }
+          return newChildren
+        }
+
+        if (child.type === 'element' && child.tagName === 'p') {
+          if (child.children.length > 0) {
+            if (
+              currentTabs.length > 0 &&
+              (child.children[0].type !== 'text' || !tabStart.test(child.children[0].value))
+            ) {
+              // a new paragraph that doesn't start a new tab; add to current tab
+              return addToTab(child)
+            }
+
+            child.children = child.children.reduce((newChildren, pchild) => {
+              if (pchild.type === 'text') {
+                const startMatch = pchild.value.match(tabStart)
+                if (startMatch) {
+                  currentTabs.push({
+                    type: 'element',
+                    tagName: 'li',
+                    properties: { title: startMatch[1] },
+                    children: startMatch[2] ? [{ type: 'text', value: startMatch[2] }] : [],
+                    position: child.position
+                  })
+                  return newChildren
+                } else if (currentTabs.length > 0) {
+                  return addToTab(pchild)
+                }
+              }
+
+              newChildren.push(pchild)
+              return newChildren
+            }, [])
+          }
+          if (currentTabs.length > 0) {
+            return newChildren
+          }
+        } else if (currentTabs.length > 0) {
+          if (child.type === 'text' || (child.type === 'element' && !/^h\d+/.test(child.tagName))) {
+            return addToTab(child)
+          } else {
+            // transition to a new section
+            flushTabs(newChildren)
+          }
+        }
+
+        // no rewrite
+        newChildren.push(child)
+
+        return newChildren
+      }, [])
+    }
+
+    if (currentTabs.length > 0) {
+      flushTabs(tree.children)
+    }
+    return tree
+  }
+}
+
+/**
+ * pymdown uses indentation to define tab content; remark-parse seems
+ * to turn these into <pre> blocks before we get control; hack it for
+ * now
+ */
+export function hackIndentation(source: string): string {
+  let inTab = false
+  return source
+    .split(/\n/)
+    .map(line => {
+      if (/^===\s+".*"/.test(line)) {
+        inTab = true
+      } else if (inTab) {
+        if (line.length === 0 || /^ {4}/.test(line)) {
+          return line.replace(/^ {4}/, '')
+        } else {
+          inTab = false
+        }
+      }
+      return line
+    })
+    .join('\n')
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -24,6 +24,11 @@
 body[kui-theme-style] .pf-c-content {
   color: inherit;
   font-size: inherit;
+
+  /* odd bug in patternfly... */
+  .pf-c-tabs__list li + li {
+    margin-top: 0;
+  }
 }
 
 @mixin h1 {

--- a/plugins/plugin-core-support/src/test/core-support/commentary-util.ts
+++ b/plugins/plugin-core-support/src/test/core-support/commentary-util.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect, Selectors, Util } from '@kui-shell/test'
+
+export function lastOutput(inNotebook: boolean) {
+  return inNotebook ? Selectors.OUTPUT_LAST_IN_NOTEBOOK() : Selectors.OUTPUT_LAST
+}
+
+export function startEditing(ctx: Common.ISuite) {
+  it('should create a commentary editor', async () => {
+    try {
+      const res = await CLI.command('#', ctx.app).then(ReplExpect.ok)
+
+      await ctx.app.client
+        .$(`${Selectors.OUTPUT_N(res.count)} ${Selectors.COMMENTARY_EDITOR}`)
+        .then(_ => _.waitForDisplayed({ timeout: CLI.waitTimeout }))
+    } catch (err) {
+      await Common.oops(ctx, true)(err)
+    }
+  })
+}
+
+/** set the monaco editor text */
+export async function type(ctx: Common.ISuite, text: string, inNotebook: boolean): Promise<void> {
+  const selector = `${lastOutput(inNotebook)} .monaco-editor-wrapper .view-lines`
+  await ctx.app.client.$(selector).then(async _ => {
+    await _.click()
+    await _.waitForEnabled()
+  })
+
+  await ctx.app.client.keys(text)
+}
+
+export function verifyTextInMonaco(ctx: Common.ISuite, expectedText: string, inNotebook: boolean) {
+  let idx = 0
+  return ctx.app.client.waitUntil(
+    async () => {
+      const actualText = await Util.getValueFromMonaco({ app: ctx.app, count: -1 }, lastOutput(inNotebook))
+
+      if (++idx > 5) {
+        console.error(`still waiting for actual=${actualText} expected=${expectedText}`)
+      }
+
+      return actualText === expectedText
+    },
+    { timeout: CLI.waitTimeout }
+  )
+}
+
+export function typeAndVerify(ctx: Common.ISuite, text: string, expect: string, inNotebook: boolean) {
+  it(`should type ${text} and expect ${expect} in the comment`, async () => {
+    try {
+      await type(ctx, text, inNotebook)
+      await verifyTextInMonaco(ctx, expect, inNotebook)
+    } catch (err) {
+      await Common.oops(ctx, true)(err)
+    }
+  })
+}

--- a/plugins/plugin-core-support/src/test/core-support/remark-tabbed.ts
+++ b/plugins/plugin-core-support/src/test/core-support/remark-tabbed.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI } from '@kui-shell/test'
+
+import { lastOutput, startEditing, typeAndVerify } from './commentary-util'
+
+function expectTab(ctx: Common.ISuite, tabName: string) {
+  it(`should show a rendered tab with name ${tabName}`, () => {
+    return ctx.app.client
+      .$(`${lastOutput(false)} .kui--markdown-tab [data-title="${tabName}"]`)
+      .then(_ => _.waitForDisplayed({ timeout: CLI.waitTimeout }))
+  })
+}
+
+const nSpaces = 5
+const indent = (N = nSpaces) =>
+  Array(N)
+    .fill(' ')
+    .join('')
+
+describe('commentary using remark-tabbed', function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const tab1 = 'tab1'
+  const tab2 = 'tab2'
+  const input1 = `=== "${tab1}"\n\n${indent()}content1`
+  startEditing(this)
+  typeAndVerify(this, input1, input1, false)
+  expectTab(this, tab1)
+
+  typeAndVerify(this, '\n', input1 + `\n${indent()}`, false)
+  expectTab(this, 'tab1')
+
+  typeAndVerify(this, 'Backspace', input1 + `\n${indent(nSpaces - 1)}`, false)
+  expectTab(this, 'tab1')
+
+  // monaco then deletes the tab
+  typeAndVerify(this, 'Backspace', input1 + '\n', false)
+  expectTab(this, 'tab1')
+
+  const input2 = `\n=== "${tab2}"\n\n${indent()}content2`
+  typeAndVerify(this, input2, input1 + '\n' + input2, false)
+  expectTab(this, 'tab1')
+  expectTab(this, 'tab2')
+})


### PR DESCRIPTION
…tension

This attempts to mimic the [Tabbed](https://facelessuser.github.io/pymdown-extensions/extensions/tabbed) plugin for pymdown. It seems mostly faithful, except that we would need to figure out how to support the indentation syntax.  remark seems to preprocess indented blocks into `<pre>` before our rehype plugin gets control.

<img width="837" alt="tabbed-markdown" src="https://user-images.githubusercontent.com/4741620/145274033-dcb80945-1e03-4df2-be7b-5dc3bd0dd537.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
