### PR TITLE
feat(plugins/plugin-client-common): add support for `???` syntax in m…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown.tsx
@@ -49,6 +49,7 @@ import gfm from 'remark-gfm'
 
 import emojis from 'remark-emoji'
 
+import tip, { hackTipIndentation } from './remark-tip'
 import tabbed, { hackTabIndentation } from './remark-tabbed'
 
 // react-markdown v6+ now require use of these to support html
@@ -56,7 +57,7 @@ import rehypeRaw from 'rehype-raw'
 // import _rehypeSanitize, { Options as RHSOptions } from 'rehype-sanitize'
 // const rhsOptions: RHSOptions = { attributes: { '*': ['className'] } }
 // const rehypeSanitize: Options['rehypePlugins'][0] = [_rehypeSanitize, rhsOptions]
-const rehypePlugins: Options['rehypePlugins'] = [tabbed, rehypeRaw /*, rehypeSanitize */]
+const rehypePlugins: Options['rehypePlugins'] = [tabbed, tip, rehypeRaw /*, rehypeSanitize */]
 
 const Tooltip = React.lazy(() => import('../spi/Tooltip'))
 const CodeSnippet = React.lazy(() => import('../spi/CodeSnippet'))
@@ -117,7 +118,7 @@ export default class Markdown extends React.PureComponent<Props> {
       td.use(gfm)
       return td.turndown(this.props.source)
     } else {
-      return hackTabIndentation(this.props.source)
+      return hackTipIndentation(hackTabIndentation(this.props.source))
     }
   }
 
@@ -385,6 +386,13 @@ export default class Markdown extends React.PureComponent<Props> {
     // avoid typing issues
     const components = Object.assign(
       {
+        tip: props => {
+          return (
+            <ExpandableSection className="kui--markdown-tip" showMore={props.title} {...this.tipProps(props.open)}>
+              {props.children}
+            </ExpandableSection>
+          )
+        },
         tabbed: props => {
           return (
             <Tabs className="kui--markdown-tabs" defaultActiveKey={0}>

--- a/plugins/plugin-client-common/src/components/Content/remark-tip/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/remark-tip/index.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const RE_TIP = /^\?\?\?(\+)?\s+tip\s+"(.+)"\s*(\n(.|[\n\r])*)?$/
+
+export default function plugin(/* options */) {
+  return function transformer(tree) {
+    let currentTip
+    const flushTip = children => {
+      if (currentTip) {
+        children.push(currentTip)
+        currentTip = undefined
+      }
+    }
+
+    if (tree.children && tree.children.length > 0) {
+      tree.children = tree.children.reduce((newChildren, child) => {
+        const addToTip = child => {
+          currentTip.children.push(child)
+          if (child.position) {
+            currentTip.position.end = child.position.end
+          }
+          return newChildren
+        }
+
+        if (child.type === 'element' && child.tagName === 'p') {
+          if (child.children.length > 0) {
+            if (currentTip && (child.children[0].type !== 'text' || !RE_TIP.test(child.children[0].value))) {
+              // a new paragraph that doesn't start a new tab; add to current tab
+              return addToTip(child)
+            }
+
+            child.children = child.children.reduce((newChildren, pchild) => {
+              if (pchild.type === 'text') {
+                const startMatch = pchild.value.match(RE_TIP)
+                if (startMatch) {
+                  currentTip = {
+                    type: 'element',
+                    tagName: 'tip',
+                    properties: { title: startMatch[2], open: !!startMatch[1] },
+                    children: startMatch[3] ? [{ type: 'text', value: startMatch[3] }] : [],
+                    position: child.position
+                  }
+                  return newChildren
+                } else if (currentTip) {
+                  return addToTip(pchild)
+                }
+              }
+
+              newChildren.push(pchild)
+              return newChildren
+            }, [])
+          }
+          if (currentTip) {
+            return newChildren
+          }
+        } else if (currentTip) {
+          if (child.type === 'text' || (child.type === 'element' && !/^h\d+/.test(child.tagName))) {
+            return addToTip(child)
+          } else {
+            // transition to a new section
+            flushTip(newChildren)
+          }
+        }
+
+        // no rewrite
+        newChildren.push(child)
+
+        return newChildren
+      }, [])
+    }
+
+    if (currentTip) {
+      flushTip(tree.children)
+    }
+    return tree
+  }
+}
+
+/**
+ * pymdown uses indentation to define tip content; remark-parse seems
+ * to turn these into <pre> blocks before we get control; hack it for
+ * now
+ */
+export function hackTipIndentation(source: string): string {
+  let inTip = false
+  return source
+    .split(/\n/)
+    .map(line => {
+      if (/^\?\?\?(\+?)\s+tip\s+".*"/.test(line)) {
+        inTip = true
+      } else if (inTip) {
+        if (line.length === 0 || /^ {4}/.test(line)) {
+          return line.replace(/^ {4}/, '')
+        } else {
+          inTip = false
+        }
+      }
+      return line
+    })
+    .join('\n')
+}

--- a/plugins/plugin-client-common/src/components/spi/ExpandableSection/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/ExpandableSection/impl/PatternFly.tsx
@@ -53,15 +53,18 @@ export default class PatternFlyExpandableSection extends React.PureComponent<Pro
   public render() {
     const { isExpanded } = this.state
     const className = 'kui--expandable-section' + (this.props.className ? ' ' + this.props.className : '')
+    const toggleText = this.toggleText()
 
     return (
       <ExpandableSection
         className={className}
-        toggleText={this.toggleText()}
+        toggleText={toggleText}
         onToggle={this.onToggle}
         isExpanded={isExpanded}
         isWidthLimited={this.props.isWidthLimited}
         displaySize={this.props.isWidthLimited ? 'large' : 'default'}
+        data-title={toggleText}
+        data-expanded={isExpanded}
       >
         {isExpanded && this.props.children}
       </ExpandableSection>

--- a/plugins/plugin-core-support/src/test/core-support/remark-tip.ts
+++ b/plugins/plugin-core-support/src/test/core-support/remark-tip.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI } from '@kui-shell/test'
+
+import { lastOutput, startEditing, typeAndVerify } from './commentary-util'
+
+function expectTip(ctx: Common.ISuite, title: string, expanded: boolean) {
+  it(`should show a rendered tip with title ${title}`, () => {
+    return ctx.app.client
+      .$(`${lastOutput(false)} .kui--markdown-tip[data-expanded="${expanded}"][data-title="${title}"]`)
+      .then(_ => _.waitForDisplayed({ timeout: CLI.waitTimeout }))
+  })
+}
+
+const nSpaces = 5
+const indent = (N = nSpaces) =>
+  Array(N)
+    .fill(' ')
+    .join('')
+
+function tip(title: string, expanded: boolean, content = 'content') {
+  return `???${expanded ? '+' : ''} tip "${title}"\n\n${indent()}${content}`
+}
+
+describe('commentary using remark-tip', function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const expanded1 = false
+  const title1 = 'titlefun'
+  const input1 = tip(title1, expanded1)
+  startEditing(this)
+  typeAndVerify(this, input1, input1, false)
+  expectTip(this, title1, expanded1)
+
+  const expanded2 = true
+  const title2 = 'titleshouldbeexpanded'
+  const input2 = tip(title2, expanded2)
+  startEditing(this)
+  typeAndVerify(this, input2, input2, false)
+  expectTip(this, title2, expanded2)
+})


### PR DESCRIPTION
…arkdown

This useful syntax comes from [pymdown's details extension](https://facelessuser.github.io/pymdown-extensions/extensions/details/), and is commonly used in MkDocs source.

```markdown
??? tip "tiptitle"
     tip body
```

This is an alternate syntax to the already-supported:
```markdown
<details><section>tiptitle</section>

tip body

</details>
```

See https://github.com/kubernetes-sigs/kui/pull/8293 for a video of it in action.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
