### PR TITLE
fix(plugins/plugin-client-common): stop using larger font-size for pa…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -119,8 +119,6 @@ body[kui-theme-style] .pf-c-content {
   }
 
   @include Paragraphs {
-    font-size: 1rem;
-
     /* see https://github.com/IBM/kui/issues/5981 */
     word-break: break-word;
     word-wrap: break-word;


### PR DESCRIPTION
…ragraphs in markdown

for some reason, we decided in the past to use `font-size: 1rem` for paragraph text in markdown. This is at odds with the font sizes that patternfly uses for headings.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
