### PR TITLE
fix(plugins/plugin-client-common): nested tabs and tips

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown.tsx
@@ -60,11 +60,11 @@ import rehypeRaw from 'rehype-raw'
 import rehypeSlug from 'rehype-slug'
 const rehypePlugins: Options['rehypePlugins'] = [tabbed, tip, rehypeRaw, rehypeSlug]
 
-const Tooltip = React.lazy(() => import('../spi/Tooltip'))
-const CodeSnippet = React.lazy(() => import('../spi/CodeSnippet'))
-const SimpleEditor = React.lazy(() => import('./Editor/SimpleEditor'))
-const LinkStatus = React.lazy(() => import('./LinkStatus'))
 const Hint = React.lazy(() => import('../spi/Hint'))
+const Tooltip = React.lazy(() => import('../spi/Tooltip'))
+const LinkStatus = React.lazy(() => import('./LinkStatus'))
+const SimpleEditor = React.lazy(() => import('./Editor/SimpleEditor'))
+const Input = React.lazy(() => import('../Views/Terminal/Block/Inputv2'))
 
 interface Props {
   source: string
@@ -326,11 +326,7 @@ export default class Markdown extends React.PureComponent<Props> {
       const language = match ? match[1] : undefined
 
       if (this.props.nested) {
-        return (
-          <div className="paragraph">
-            <CodeSnippet value={String(props.children).trim()} language={language} tabUUID={tabUUID} />
-          </div>
-        )
+        return <Input value={String(props.children).trim()} language={language} tabUUID={tabUUID} />
       } else {
         return (
           <div className="paragraph">
@@ -408,7 +404,7 @@ export default class Markdown extends React.PureComponent<Props> {
           // the combination of <Tabs isBox> and <Card boxShadow>
           // gives the tab content adefined border
           return (
-            <Tabs isBox className="kui--markdown-tabs kui--markdown-major-paragraph" defaultActiveKey={0}>
+            <Tabs isBox variant="light300" className="kui--markdown-tabs" defaultActiveKey={0}>
               {props.children.map((_, idx) => (
                 <Tab
                   className="kui--markdown-tab"

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+// import { i18n } from '@kui-shell/core'
+
+// import TwoFaceIcon from '../../../spi/Icons/TwoFaceIcon'
+const CodeSnippet = React.lazy(() => import('../../../spi/CodeSnippet'))
+
+// const strings = i18n('plugin-client-common')
+
+interface Props {
+  tabUUID: string
+
+  readonly?: boolean
+  value: string
+  language: string
+}
+
+type State = {}
+
+export default class Input extends React.PureComponent<Props, State> {
+  public render() {
+    return (
+      <div className="paragraph">
+        <CodeSnippet {...this.props}>{/* this.props.readonly !== true && <Run/> */}</CodeSnippet>
+      </div>
+    )
+  }
+}
+
+/*
+class Run extends React.PureComponent {
+  private readonly _onClick = () => {
+    //this.props.repl.reexec(this.props.command, { execUUID: this.props.model.execUUID })
+  }
+
+  public render() {
+    return (
+      <TwoFaceIcon
+        a="Play"
+        b="At"
+        delay={4000}
+        onClick={this._onClick}
+        classNameB="green-text"
+        className="kui--block-action"
+        title={strings('Execute this command')}
+      />
+    )
+    
+  }
+}
+*/

--- a/plugins/plugin-client-common/src/components/spi/CodeSnippet/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/CodeSnippet/impl/PatternFly.tsx
@@ -62,7 +62,7 @@ export default class PatternFlyCodeSnippet extends React.PureComponent<Props> {
         options={this._monacoOptions}
       /> */
 
-      <div style={this.style}>
+      <div style={this.style} className="flex-layout">
         <SimpleEditor
           simple
           readonly
@@ -72,6 +72,7 @@ export default class PatternFlyCodeSnippet extends React.PureComponent<Props> {
           content={this.props.value}
           contentType={this.language()}
         />
+        {this.props.children}
       </div>
     )
   }

--- a/plugins/plugin-client-common/src/components/spi/CodeSnippet/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/CodeSnippet/model.ts
@@ -29,6 +29,9 @@ interface Props {
 
   /** default: true */
   isLanguageLabelVisible?: boolean
+
+  /** Optional children to be positioned to the right of the code */
+  children?: React.ReactNode
 }
 
 export default Props

--- a/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.scss
+++ b/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.scss
@@ -25,6 +25,11 @@ body[kui-theme-style] .monaco-editor .line-numbers {
   font-weight: 300;
 }
 
+/* oddly, the // part of http:// */
+body[kui-theme-style] .monaco-editor .mtk9 {
+  color: var(--color-text-02);
+}
+
 body[kui-theme-style] .monaco-editor .mtk8,
 body[kui-theme-style] .monaco-editor .keyword {
   transition: color 300ms ease-in-out;

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -219,12 +219,23 @@ body[kui-theme-style='light'] {
   --pf-c-content--heading--FontFamily: var(--font-sans-serif-title);
 }
 
-@include MarkdownTabContent {
-  @include MarkdownTabContentCard {
-    padding-left: 16px; /* should be: --pf-c-tabs__link--PaddingLeft */
+@include MarkdownMajorParagraph {
+  margin: 1.5em 0;
+}
+
+@include Commentary {
+  .marked-content {
+    pre {
+      margin: 0;
+    }
   }
 }
 
-@include MarkdownMajorParagraph {
-  margin: 1.5em 0;
+@include MarkdownTabContent {
+  .paragraph:first-child {
+    padding-top: 0;
+  }
+  .paragraph:last-child {
+    padding-bottom: 0;
+  }
 }


### PR DESCRIPTION
This PR also switches markdown tabs to use the "box light" variant from PatternFly
This PR also introduces the initial stub for the markdown-based "Inputv2"

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
