### PR TITLE
fix(plugins/plugin-kubectl): kube apply can respond with `--response …

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
@@ -272,7 +272,7 @@ export const doExecWithStatus = <O extends KubeOptions>(
     return response.content.stdout
   } else {
     const statusArgs = await prepareForStatus(verb, args)
-    const initialResponse = response ? `--response "${response.content.stdout}"` : ''
+    const initialResponse = response ? response.content.stdout : ''
 
     return doStatus(args, verb, command, initialResponse, finalState, statusArgs)
   }


### PR DESCRIPTION
…...`

Not sure why we had that `--response ` prefix to the actual response text from the pty

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
