### PR TITLE
fix: pty xterm causes tab to scroll to bottom, even if output is not …

### DIFF
--- a/packages/core/src/webapp/tab.ts
+++ b/packages/core/src/webapp/tab.ts
@@ -36,7 +36,15 @@ export interface Tab extends HTMLDivElement {
   removeClass(cls: string): void
 
   scrollToTop(): void
-  scrollToBottom(): void
+
+  /**
+   * If given the optional parameter, only scroll into view if the
+   * specified block (identified by its execUUID) is the last block in
+   * this tab
+   *
+   */
+  scrollToBottom(execUUID?: string): void
+
   show(selector: string): void
 
   getSize(): { width: number; height: number }

--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -438,10 +438,10 @@ async function initOnMessage(
   //
   const doScroll = () => {
     if (!resizer.inAltBufferMode()) {
-      tab.scrollToBottom()
+      tab.scrollToBottom(execOptions.execUUID)
     }
   }
-  const scrollPoll = terminal && setInterval(doScroll, 200)
+  const scrollPoll = terminal && setInterval(doScroll, 400)
 
   const onFirstMessage = () => {
     const queuedInput = disableInputQueueing(tab)

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -619,7 +619,24 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
     state.scrollableRef = (ref: HTMLElement) => {
       if (ref) {
         state.facade.scrollToTop = () => (ref.scrollTop = 0)
-        state.facade.scrollToBottom = () => (ref.scrollTop = ref.scrollHeight)
+
+        /**
+         * If given the optional parameter, only scroll into view if the
+         * specified block (identified by its execUUID) is the last block in
+         * this tab
+         *
+         */
+        state.facade.scrollToBottom = (execUUID?: string) => {
+          const sbidx = this.findSplit(this.state, sbuuid)
+          if (sbidx >= 0) {
+            const { blocks } = this.state.splits[sbidx]
+            const lastBlock = blocks[blocks.length - 1]
+            if (!execUUID || (hasUUID(lastBlock) && lastBlock.execUUID === execUUID)) {
+              ref.scrollTop = ref.scrollHeight
+            }
+          }
+        }
+
         state.facade.show = (sel: string) => {
           const elt = this.props.tab.querySelector(sel)
           if (elt) {


### PR DESCRIPTION
…from last block

we have this feature so that continuous output from an active pty results in scrolling of the tab to the bottom. however, in some cases the pty is not part of the last block. as a result, output from that "inner" pty causes kui to scroll to the bottom every time the pty emits something. oof.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
