### PR TITLE
fix(plugins/plugin-client-common): don't show BlockBorder for finishe…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -245,13 +245,14 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
         return M
       }, {})
 
+    // on li, if you want a BlockBorder for finished blocks:
+    // data-has-border={!!this.props.response || undefined}
     return (
       <MutabilityContext.Consumer>
         {mutability => (
           <li
             className={`repl-block ${this.responseStatus()} ${this.props.className || ''}`}
             data-is-executable={mutability.executable}
-            data-has-border={!!this.props.response || undefined}
             {...dataProps}
           >
             {this.input()}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -226,9 +226,12 @@ body[kui-theme-style='light'] {
 
 @include Scrollback {
   @include Commentary {
+    margin: 0 0.5em;
+
     @include Block {
       --input-padding-left: 0;
       --input-padding-right: 0;
+      margin-top: 0;
 
       /** Code blocks nested inside of the outer Block; no need to repeat the padding, unless we are showing a BlockBorder */
       @include NotAlwaysHasBorder {


### PR DESCRIPTION
…d code blocks

also increase spacing around split content

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
