### PR TITLE
fix(plugins/plugin-client-common): improved color contrast for tooltips

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
@@ -18,10 +18,14 @@ $color: var(--color-base00);
 $bgcolor: var(--color-base06);
 
 .kui--tooltip {
+  color: $color;
+  background-color: $bgcolor;
+
   &[data-is-markdown] {
     .pf-c-tooltip__content {
       padding: 0;
       font-size: 0.75rem;
+      background-color: transparent;
     }
 
     h1,
@@ -29,6 +33,7 @@ $bgcolor: var(--color-base06);
     h3,
     h4,
     p {
+      font-size: inherit;
       padding: var(--pf-c-tooltip__content--PaddingTop) var(--pf-c-tooltip__content--PaddingRight)
         var(--pf-c-tooltip__content--PaddingBottom) var(--pf-c-tooltip__content--PaddingLeft);
     }
@@ -49,12 +54,18 @@ $bgcolor: var(--color-base06);
       }
     }
 
+    p {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+
     p + p {
       padding-top: 0;
     }
 
     code {
-      color: var(--color-base02);
+      opacity: 0.9;
+      color: var(--color-base00);
       font-family: var(--font-sans-serif);
     }
 
@@ -85,7 +96,7 @@ $bgcolor: var(--color-base06);
     font-weight: normal;
 
     &:not(:last-child) {
-      border-bottom: 1px solid var(--color-table-border2);
+      border-bottom: 1px solid var(--color-base02);
     }
   }
 


### PR DESCRIPTION
This mainly affects dark themes.

Fixes #8318 

<img width="324" alt="Screen Shot 2021-12-22 at 5 20 47 PM" src="https://user-images.githubusercontent.com/4741620/147161612-84c99bfb-12ca-479d-9b37-e4318f47c003.png">
<img width="363" alt="Screen Shot 2021-12-22 at 5 20 57 PM" src="https://user-images.githubusercontent.com/4741620/147161615-ac53f65b-6f17-4c7c-9bb8-fcb7f5ba7656.png">
<img width="349" alt="Screen Shot 2021-12-22 at 5 21 07 PM" src="https://user-images.githubusercontent.com/4741620/147161622-20ed60f1-2c7e-4673-83d6-7fb6c35648c4.png">



<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
