### PR TITLE
fix(plugins/plugin-client-common): code block status updates do not h…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/ProgressStepper.tsx
+++ b/plugins/plugin-client-common/src/components/Content/ProgressStepper.tsx
@@ -102,11 +102,17 @@ export class ProgressStep extends React.PureComponent<ProgressStepProps, Progres
     return icon && <Icons icon={icon} className={className} />
   }
 
-  private readonly _statusUpdateHandler = (status: number[]) => {
-    this.setState(curState => ({
-      status:
-        status[0] !== 0 ? 'success' : status[1] !== 0 ? 'error' : status[2] !== 0 ? 'in-progress' : curState.status // TODO. what does it mean in this case?
-    }))
+  private readonly _statusUpdateHandler = (statusVector: number[]) => {
+    const status =
+      statusVector[0] !== 0
+        ? 'success'
+        : statusVector[1] !== 0
+        ? 'error'
+        : statusVector[2] !== 0
+        ? 'in-progress'
+        : 'blank'
+
+    this.setState({ status })
   }
 
   /** Once we have mounted, subscribe to link status update events */

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -21,6 +21,7 @@ import {
   KResponse,
   Tab,
   i18n,
+  isCodedError,
   isError,
   isTable,
   isXtermResponse,
@@ -131,7 +132,8 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
             await pexecInCurrentTab(this.props.validate, undefined, true, true)
             emit('done')
           } catch (err) {
-            emit('error')
+            const execution = isCodedError(err) && err.code === 404 ? 'not-yet' : 'error'
+            emit(execution)
           }
         }, 1000)
       }


### PR DESCRIPTION
…andle 404s

we treat these as errors currently
also, the ProgressStep UI may not transition from processing back to not-yet

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
