### PR TITLE
fix: some error handling paths do not propagate exit code

### DIFF
--- a/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
@@ -38,7 +38,9 @@ export const dispatchToShell = async ({
   /** trim the first part of "/bin/sh: someNonExistentCommand: command not found" */
   const cleanUpError = (err: CodedError) => {
     if (err.message && typeof err.message === 'string') {
-      throw new Error(err.message.replace(/[a-zA-Z0-9/]+:\s*/, '').trim())
+      const error: CodedError = new Error(err.message.replace(/[a-zA-Z0-9/]+:\s*/, '').trim())
+      error.code = err.code
+      throw error
     } else {
       throw err
     }

--- a/plugins/plugin-bash-like/src/lib/util/exec.ts
+++ b/plugins/plugin-bash-like/src/lib/util/exec.ts
@@ -30,7 +30,8 @@ export const handleNonZeroExitCode = (
   const stderr = rawErr.length === 0 ? rawOut : rawErr
 
   // note for below: 127 means command not found in POSIX land
-  if (execOptions && execOptions.nested && exitCode !== 127) {
+  // 128 through (128+33) signify the 33 standard POSIX exit codes
+  if (execOptions && execOptions.nested && exitCode < 127) {
     const error = new Error(stderr)
     error['code'] = exitCode
     throw error
@@ -39,9 +40,9 @@ export const handleNonZeroExitCode = (
     error['html'] = parentNode
 
     if (execOptions.stderr) error['code'] = parentNode
-    else if (stderr.match(/File exists/i)) error['code'] = 409
+    else if (/File exists/i.test(stderr)) error['code'] = 409
     // re: i18n, this is for tests
-    else if (exitCode !== 127 && stderr.match(/not found/i)) error['code'] = 404
+    else if (exitCode !== 127 && /not found/i.test(stderr)) error['code'] = 404
     // re: i18n, this is for tests
     else error['code'] = exitCode
 


### PR DESCRIPTION
we seem to squash them down to `1` in cleanupError in plugin-bash-like

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
