### PR TITLE
feat(plugins/plugin-client-common): display code block status in code…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/ProgressStepper.tsx
+++ b/plugins/plugin-client-common/src/components/Content/ProgressStepper.tsx
@@ -54,6 +54,8 @@ type ProgressStepProps = React.PropsWithChildren<{
   className?: string
   title: React.ReactNode
 
+  customIcon?: React.ReactNode
+
   defaultStatus: Status | Promise<Status>
   liveStatusChannel?: string
 }>
@@ -98,6 +100,10 @@ export class ProgressStep extends React.PureComponent<ProgressStepProps, Progres
   }
 
   private icon() {
+    if (this.props.customIcon) {
+      return this.props.customIcon
+    }
+
     const { icon, className } = this.icons[this.state.status]
     return icon && <Icons icon={icon} className={className} />
   }
@@ -139,8 +145,8 @@ export class ProgressStep extends React.PureComponent<ProgressStepProps, Progres
           <span className="pf-c-progress-stepper__step-icon kui--progress-step-status-icon">{this.icon()}</span>
         </div>
         <div className="pf-c-progress-stepper__step-main">
-          <div className="pf-c-progress-stepper__step-title">{this.props.title}</div>
-          <div className="pf-c-progress-stepper__step-description">{this.props.children}</div>
+          {this.props.title && <div className="pf-c-progress-stepper__step-title">{this.props.title}</div>}
+          {this.props.children && <div className="pf-c-progress-stepper__step-description">{this.props.children}</div>}
         </div>
       </li>
     )

--- a/plugins/plugin-client-common/src/components/Content/Scalar/XtermDom.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/XtermDom.tsx
@@ -50,7 +50,10 @@ export default class XtermDom extends React.PureComponent<Props> {
     return this.props.response.rows.length === 0 ? (
       <React.Fragment />
     ) : (
-      <div className="padding-content scrollable scrollable-auto page-content" style={{ display: 'flex', flex: 1 }}>
+      <div
+        className="kui--xterm-output padding-content scrollable scrollable-auto page-content"
+        style={{ display: 'flex', flex: 1 }}
+      >
         <div style={{ display: 'flex', flex: 1 }}>
           <div className="xterm-container xterm-terminated">
             <div className="xterm-rows">

--- a/plugins/plugin-client-common/web/scss/components/ProgressStepper/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/ProgressStepper/_index.scss
@@ -39,6 +39,10 @@ $minor-step-color: var(--color-base05);
 @include ProgressStep {
   @include Main {
     margin-left: 0.5rem;
+    &:empty {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }
 
   @include Minor {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/BlockBorder.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/BlockBorder.scss
@@ -55,20 +55,6 @@
   }
 }
 
-@include Block {
-  @include AlwaysHasBorder {
-    @include Error {
-      @include BlockBorder {
-        @include ErrorDecorations;
-      }
-    }
-
-    @include BlockBorder {
-      @include NormalDecorations;
-    }
-  }
-}
-
 @include FocusedBlock {
   @include Editable {
     @include BlockBorder {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -18,6 +18,7 @@
 @import '../Card/mixins';
 @import '../Sidecar/mixins';
 @import '../common/narrow-window';
+@import '../ProgressStepper/mixins';
 @import '../ExpandableSection/mixins';
 @import '../../Themes/mixins';
 @import 'BlockLinks';
@@ -234,6 +235,12 @@ body[kui-theme-style='light'] {
     border: 1px solid var(--color-table-border1);
     background-color: var(--color-base00);
   }
+
+  @include PtyOutputContainer {
+    &:not(:first-child) {
+      margin-top: 0.5em;
+    }
+  }
 }
 
 @include Scrollback {
@@ -248,11 +255,6 @@ body[kui-theme-style='light'] {
       --input-padding-left: 0;
       --input-padding-right: 0;
       margin-top: 0;
-
-      /** Code blocks nested inside of the outer Block; no need to repeat the padding, unless we are showing a BlockBorder */
-      @include NotAlwaysHasBorder {
-        padding: 0;
-      }
     }
   }
 }
@@ -281,18 +283,20 @@ body[kui-theme-style='light'] {
   }
 
   @include CommandOutput {
+    flex-direction: column; /* in case of multi-output, e.g. from semicolonInvoke */
     font-size: 0.875rem;
     line-height: initial; /* PatternFly intercepts this for pf-c-content */
   }
+}
 
-  @include MarkdownTip {
-    background-color: #e7f1fa;
+@include MarkdownTip {
+  background-color: #e7f1fa;
+  filter: hue-rotate(45deg);
 
-    @include ExpandableSectionButton {
-      width: 100%;
-      padding-top: 0.6875em;
-      padding-bottom: 0.6875em;
-    }
+  @include ExpandableSectionButton {
+    width: 100%;
+    padding-top: 0.6875em;
+    padding-bottom: 0.6875em;
   }
 }
 
@@ -318,5 +322,38 @@ body[kui-theme-style='light'] {
   /** Nested tabs */
   @include MarkdownTabContentCard {
     padding: 0;
+  }
+}
+
+@mixin CodeBlock {
+  .kui--code-block-in-markdown {
+    @content;
+  }
+}
+@mixin CodeBlockActions {
+  .kui--code-block-actions {
+    @content;
+  }
+}
+
+@include CodeBlock {
+  &:hover {
+    @include CodeBlockActions {
+      opacity: 1;
+    }
+  }
+}
+@include CodeBlockActions {
+  position: absolute;
+
+  &[data-align='top-left'] {
+    left: -1em;
+    top: -1em;
+    opacity: 0.8;
+  }
+  &[data-align='top-right'] {
+    right: -1em;
+    top: -1em;
+    opacity: 0.8;
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -148,18 +148,6 @@ $action-hover-delay: 210ms;
   }
 }
 
-@mixin AlwaysHasBorder {
-  &[data-has-border] {
-    @content;
-  }
-}
-
-@mixin NotAlwaysHasBorder {
-  &:not(&[data-has-border]) {
-    @content;
-  }
-}
-
 @mixin SectionBreak {
   @include Block {
     &[data-is-section-break] {
@@ -559,6 +547,11 @@ $action-hover-delay: 210ms;
   }
 }
 
+@mixin PtyOutputContainer {
+  .kui--xterm-output {
+    @content;
+  }
+}
 @mixin PtyOutput {
   .xterm-container.xterm-terminated {
     @content;


### PR DESCRIPTION
… block

<img width="669" alt="Screen Shot 2021-12-25 at 2 34 49 PM" src="https://user-images.githubusercontent.com/4741620/147392341-828cf65b-6f23-4e0c-b016-4dc85ddeafc8.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
