### PR TITLE
fix(plugins/plugin-kubectl): for now, send kubectl ... $(...) command…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
@@ -95,8 +95,10 @@ export function doExecWithStdout<O extends KubeOptions>(
  * required? That is, versus a plain nodejs spawn/exec.
  *
  */
-export function reallyNeedsPty({ argvNoOptions }: Pick<Arguments, 'argvNoOptions'>) {
-  return argvNoOptions.includes('|') || argvNoOptions.includes('>') || argvNoOptions.includes('>>')
+export function reallyNeedsPty({ argvNoOptions, parsedOptions }: Pick<Arguments, 'argvNoOptions' | 'parsedOptions'>) {
+  const test1 = (_: string) => /(\$\(|`)/.test(_) // subprocess execution?
+  const test2 = (_: string) => /^\s*(\||>|>>)\s*$/.test(_) || test1(_)
+  return !!argvNoOptions.find(test2) || !!Object.values(parsedOptions).find(test1)
 }
 
 /**


### PR DESCRIPTION
… lines to pty

At some point, we could get more sophisticated, and expand the $(...) subprocess executions, and still handle the rest in kui.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
