### PR TITLE
fix(plugins/plugin-client-common): Code Blocks versus &;

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -21,7 +21,6 @@ import {
   KResponse,
   Tab,
   i18n,
-  isCodedError,
   isError,
   isMixedResponse,
   isTable,
@@ -143,8 +142,7 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
             emit('done')
             this.setState({ validated: true })
           } catch (err) {
-            const execution = isCodedError(err) && err.code === 404 ? 'not-yet' : 'error'
-            emit(execution)
+            emit('not-yet')
             this.setState({ validated: false })
           }
         }, 1000)
@@ -261,7 +259,7 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
       this.setState({ execution: 'processing' })
       this.emitLinkStatus('processing')
 
-      const cmdline = this.state.value.replace(/([^\\])(\n)/g, '$1; ')
+      const cmdline = this.state.value.replace(/([^\\])(\n)/g, '$1; ').replace(/&;/g, '&')
       const response = await this.execWithStream(cmdline)
 
       const execution = isXtermResponse(response)


### PR DESCRIPTION
This PR fixes execution of code blocks with '&;' in them.
It also has a small fix for validation errors: don't show them as errors in the progress stepper ui

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
