### PR TITLE
fix(plugins/plugin-bash-like): `false` pty executions do not exit wit…

### DIFF
--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -576,10 +576,7 @@ async function initOnMessage(
 
       /** emit our final response and return control to the repl */
       const respondToRepl = async (response?: XtermResponse) => {
-        // vi, then :wq, then :q, you will get an exit code of
-        // 1, but with no output (!bytesWereWritten); note how
-        // we treat this as "ok", i.e. no error thrown
-        if (msg.exitCode !== 0 && (bytesWereWritten || execOptions.onInit)) {
+        if (msg.exitCode !== 0) {
           const error = new Error('')
           if (sawCode === 409) error['code'] = 409
           // re: i18n, this is for tests

--- a/plugins/plugin-bash-like/src/test/bash-like/false.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/false.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect } from '@kui-shell/test'
+
+describe(`false command should have failed block ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  it('should show failure for `false` command', () =>
+    CLI.command(`false`, this.app)
+      .then(ReplExpect.error(1))
+      .catch(Common.oops(this)))
+
+  it('should show failure for `true && false` command', () =>
+    CLI.command(`true && false`, this.app)
+      .then(ReplExpect.error(1))
+      .catch(Common.oops(this)))
+
+  it('should show failure for `false >& /dev/null` command', () =>
+    CLI.command(`(echo hi && false) >& /dev/null`, this.app)
+      .then(ReplExpect.error(1))
+      .catch(Common.oops(this)))
+})


### PR DESCRIPTION
…h code 1

in pty/client.ts, we are swallowing these, because the command has no output

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
