### PR TITLE
fix(plugins/plugin-client-common): markdown links to other markdowns …

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/a.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/a.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { dirname, join, relative } from 'path'
+import { dirname, isAbsolute, join, relative } from 'path'
 import { REPL, maybeKuiLink, pexecInCurrentTab } from '@kui-shell/core'
 
 import { Props } from '../../Markdown'
@@ -52,13 +52,23 @@ export default function a(mdprops: Props, uuid: string, repl: REPL) {
                 tab.show(`[data-markdown-anchor="${anchorFrom(uuid, props.href.slice(1))}"]`)
               }
             } else if (file) {
-              if (mdprops.fullpath) {
-                const absoluteHref = join(dirname(mdprops.fullpath), props.href)
-                const relativeToCWD = relative(process.cwd() || process.env.PWD, absoluteHref)
-                file = relativeToCWD
+              if (isLocal && !isAbsolute(file)) {
+                // e.g. if a markdown has a relative reference to
+                // another in the same directory -- not the same as
+                // the user's CWD! the same as the directory of that
+                // first markdown
+                const baseUrl = mdprops.baseUrl || (mdprops.fullpath ? dirname(mdprops.fullpath) : undefined)
+                if (baseUrl) {
+                  const absoluteHref = join(baseUrl, props.href)
+                  const relativeToCWD = relative(process.cwd() || process.env.PWD, absoluteHref)
+                  file = relativeToCWD
+                }
               }
 
-              return repl.pexec(`open ${repl.encodeComponent(file)}`)
+              const md = /\.md$/.test(file)
+              const cmd = md ? 'replay' : 'open'
+              const exec = md ? 'qexec' : 'pexec'
+              return repl[exec](`${cmd} ${repl.encodeComponent(file)}`)
             }
           }
 
@@ -77,6 +87,10 @@ export default function a(mdprops: Props, uuid: string, repl: REPL) {
         ? `### Block Link\n\n\`Link will scroll the block into view\``
         : props.href.charAt(0) === '#'
         ? `### In-Page Link\n#### ${props.href}\n\n\`Element will scroll into view\``
+        : /\.md$/.test(props.href)
+        ? `### Notebook\n#### ${props.href.replace(/^\.\//, '')}\n\n\`The linked notebook will open in a separate tab\``
+        : isLocal
+        ? `### File Link\n#### ${props.href}\n\n\`The linked file will open in this tab\``
         : `### External Link\n#### ${props.href}\n\n\`Link will open in a separate window\``
 
       const kuiLink = maybeKuiLink(props.href)

--- a/plugins/plugin-client-common/src/controller/commentary.ts
+++ b/plugins/plugin-client-common/src/controller/commentary.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { dirname } from 'path'
 import { FStat } from '@kui-shell/plugin-bash-like/fs'
 import {
   Arguments,
@@ -130,7 +131,7 @@ async function addComment(args: Arguments<CommentaryOptions>): Promise<true | Co
           title,
           filepath,
           children: data,
-          baseUrl: args.parsedOptions['base-url']
+          baseUrl: args.parsedOptions['base-url'] || (filepath ? dirname(filepath) : undefined)
         }
       }
     }


### PR DESCRIPTION
…do not work

actually, to any local file that is not an absolute path.
also, the tool always shows "External Link" even for links to local pages

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
