### PR TITLE
fix: improved error handling for MixedResponse

### DIFF
--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -735,7 +735,7 @@ async function semicolonInvoke(commands: string[], execOptions: ExecOptions): Pr
         return entity
       }
     } catch (err) {
-      return err.message
+      return err
     }
   })
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
@@ -32,12 +32,18 @@ export function tryFrontmatter(
   }
 }
 
+function stringifyError(response: Error) {
+  return { code: isCodedError(response) ? response.code : 1, message: response.message }
+}
+
 /** Blunt attempt to avoid serializing React bits */
 function reactRedactor(key: string, value: any) {
   if (key === 'tab') {
     return undefined
   } else if (key === 'block') {
     return undefined
+  } else if (typeof value === 'object' && value.constructor === Error) {
+    return stringifyError(value)
   } else {
     return value
   }
@@ -47,12 +53,7 @@ function encodePriorResponse(response: KResponse): { encoding: string; encodedRe
   return {
     encoding: 'base64+gzip',
     encodedResponse: Util.base64PlusGzip(
-      JSON.stringify(
-        response.constructor === Error
-          ? { code: isCodedError(response) ? response.code : 1, message: response.message }
-          : response,
-        reactRedactor
-      )
+      JSON.stringify(response.constructor === Error ? stringifyError(response) : response, reactRedactor)
     )
   }
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -307,7 +307,7 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
         : isError(response)
         ? 'error'
         : isMixedResponse(response)
-        ? response.find(_ => isXtermResponse(_) && _.code !== 0)
+        ? response.find(_ => (isXtermResponse(_) && _.code !== 0) || isError(_))
           ? 'error'
           : 'done'
         : 'done'


### PR DESCRIPTION
1. in the core, we were transmitting on the error message for error parts of a multi-part response
2. incorrect serialization of code blocks with a part error
3. in code block rendering, no recognition of error parts

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
