### PR TITLE
fix(plugins/plugin-client-common): don't use inverted colors for Sour…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/SourceRef.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SourceRef.tsx
@@ -39,7 +39,7 @@ export default class SourceRef extends React.PureComponent<Props> {
           tabUUID={getPrimaryTabId(this.props.tab)}
           content={content.replace(/\n$/, '')} /* monaco's renderFinalNewline option doesn't seem to do what we need */
           contentType={contentType}
-          className="kui--source-ref-editor kui--inverted-color-context"
+          className="kui--source-ref-editor"
           fontSizeAdjust={12 / 14}
           simple
         />


### PR DESCRIPTION
…ceRef component

Reasoning: markdown CodeBlocks use inverted colors, and i think we need to preserve the impact of this distinction. Using inverted colors too much will water down that impact.

<img width="930" alt="non-inverted sourceref" src="https://user-images.githubusercontent.com/4741620/147861549-30f3ad49-d887-40d4-82a1-d7868462e1b7.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
