### PR TITLE
fix(plugins/plugin-client-common): improve padding-background for cod…

### DIFF
--- a/plugins/plugin-client-common/web/css/static/ui.css
+++ b/plugins/plugin-client-common/web/css/static/ui.css
@@ -857,7 +857,8 @@ body[kui-theme-style="dark"] .repl {
 }
 .kui .page-content code.kui--code--editor {
   display: block;
-  padding: 0.5em 1em;
+  padding: 1em;
+  background-color: var(--color-sidecar-background-01);
 }
 
 .page-content pre > code {


### PR DESCRIPTION
…e snippets in markdown.

The YAML code block previously had no padding, the content with the gray background butted right up to the surrounding green section.

<img width="944" alt="Screen Shot 2022-01-03 at 8 31 39 PM" src="https://user-images.githubusercontent.com/4741620/147997954-57e43bef-f280-4168-a739-bf79877bb452.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
