### PR TITLE
fix(plugins/plugin-kubectl): Summary tab may not render as expected

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/modes/Summary/impl/convert.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/Summary/impl/convert.ts
@@ -25,7 +25,7 @@ export default function toDescriptionList(obj: Record<string, number | boolean |
     spec: {
       groups: Object.keys(obj).map(term => ({
         term,
-        description: obj[term].toString()
+        description: obj[term] ? obj[term].toString() : obj[term] === null ? 'null' : ''
       }))
     }
   }


### PR DESCRIPTION
This is due to a caught toString() call on a null pointer.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
