### PR TITLE
fix(plugins/plugin-client-common): when re-running CodeBlocks, stream…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/StreamingConsumer.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/StreamingConsumer.tsx
@@ -106,8 +106,14 @@ export default abstract class StreamingConsumer<
     }
   }
 
+  private clearPriorStreamingOutput() {
+    this._streamingOutput = []
+    this.setState({ nStreamingOutputs: 0 })
+  }
+
   /** Wrap the execution of the given `cmdline` with handling of streaming output */
   protected async execWithStream(cmdline: string) {
+    this.clearPriorStreamingOutput()
     const streamingChannel = `/command/stdout/${this.props.tab.uuid}/${this.state.execUUID}`
 
     try {


### PR DESCRIPTION
…ing output piles up

We aren't clearing out streaming output from prior runs

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
