### PR TITLE
fix(plugins/plugin-client-common): code block status and timer can ov…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -218,7 +218,7 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
     return (
       <div className="repl-input-element-wrapper flex-layout flex-fill kui--inverted-color-context kui--relative-positioning">
         {this.timer()}
-        {this.status()}
+        {this.state.execution !== 'processing' && this.status()}
         <div className="flex-fill">
           <CodeSnippet
             wordWrap="on"


### PR DESCRIPTION
…erlap

I don't think it makes sense, anyway, to show the validation status while the timer is active, because the timer being active while there is a validation status ui... this means that we are *re-validating*

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
