### PR TITLE
fix(plugins/plugin-client-common): stop using blue and a grayscale fi…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
@@ -15,7 +15,6 @@
  */
 
 @import '../StatusStripe/mixins';
-@import '../StatusStripe/StatusStripe.scss';
 @import '../Terminal/mixins';
 
 body[kui-theme-style] {

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -21,19 +21,7 @@
 
 $font-size: 0.75rem;
 
-/** StatusStripeChangeEvent.type */
-$fg-type-default: var(--color-text-01);
-$bg-type-default: var(--color-sidecar-header);
-
-$fg-type-blue: var(--color-base00);
-$bg-type-blue: var(--color-base0D);
-
-$bg-type-yellow: var(--color-yellow);
-$bg-type-red: var(--color-red);
-
 $element-padding: 1rem;
-
-$status-stripe-hover-bg-color: var(--color-table-border3);
 
 /* see https://github.com/IBM/kui/issues/6880 */
 $z-index: var(--pf-global--ZIndex--xs);
@@ -47,7 +35,6 @@ $z-index: var(--pf-global--ZIndex--xs);
   &[data-type='blue'] {
     color: $fg-type-blue;
     background-color: $bg-type-blue;
-    filter: grayscale(0.75);
     @include StatusStripeElement {
       color: $fg-type-blue;
     }

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/_mixins.scss
@@ -16,6 +16,16 @@
 
 $element-border: 1px solid var(--color-table-border2);
 
+/** StatusStripeChangeEvent.type */
+$fg-type-default: var(--color-text-01);
+$bg-type-default: var(--color-sidecar-header);
+$fg-type-blue: var(--color-base00);
+$bg-type-blue: var(--color-base05);
+$bg-type-yellow: var(--color-yellow);
+$bg-type-red: var(--color-red);
+
+$status-stripe-hover-bg-color: var(--color-table-border3);
+
 @mixin StatusStripe {
   .kui--status-stripe {
     @content;


### PR DESCRIPTION
…lter on StatusStripe

this causes weird transitions, where the status stripe becomes momentarily unfiltered blue.

This PR also fixes an issue that resulted in StatusStripe.scss being incorporated twice into the built css.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
