### PR TITLE
fix: multi-notebook replay does not properly handle tab titles

### DIFF
--- a/plugins/plugin-client-common/.gitignore
+++ b/plugins/plugin-client-common/.gitignore
@@ -1,1 +1,2 @@
 dist
+mdist

--- a/plugins/plugin-client-common/notebook/package.json
+++ b/plugins/plugin-client-common/notebook/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@kui-shell/plugin-client-common-notebook",
+  "version": "6.0.12",
+  "description": "Kui plugin that offers notebook utilities",
+  "license": "Apache-2.0",
+  "author": "Nick Mitchell",
+  "homepage": "https://github.com/IBM/kui#readme",
+  "bugs": {
+    "url": "https://github.com/IBM/kui/issues/new"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/IBM/kui.git"
+  },
+  "keywords": [
+    "kui",
+    "plugin"
+  ],
+  "contributors": [
+    "Mengting Yan"
+  ],
+  "main": "dist/index.js",
+  "module": "mdist/index.js",
+  "types": "mdist/index.d.ts",
+  "publishConfig": {
+    "access": "private"
+  }
+}

--- a/plugins/plugin-client-common/notebook/src/index.ts
+++ b/plugins/plugin-client-common/notebook/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { loadNotebook } from './load'

--- a/plugins/plugin-client-common/notebook/src/load.ts
+++ b/plugins/plugin-client-common/notebook/src/load.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FStat } from '@kui-shell/plugin-bash-like/fs'
+import { Arguments, Util, encodeComponent } from '@kui-shell/core'
+
+export async function loadNotebook(
+  filepath: string,
+  { REPL }: Pick<Arguments, 'REPL'>,
+  errOk = false
+): Promise<string | object> {
+  try {
+    if (/^https:/.test(filepath)) {
+      return (await REPL.rexec<(string | object)[]>(`_fetchfile ${encodeComponent(filepath)}`)).content[0]
+    } else {
+      //   --with-data says give us the file contents
+      const fullpath = Util.findFile(Util.expandHomeDir(filepath))
+      const stats = (await REPL.rexec<FStat>(`vfs fstat ${encodeComponent(fullpath)} --with-data`)).content
+
+      if (stats.isDirectory) {
+        throw new Error('Invalid filepath')
+      } else {
+        return stats.data as string
+      }
+    }
+  } catch (err) {
+    if (!errOk) {
+      throw err
+    } else {
+      return undefined
+    }
+  }
+}

--- a/plugins/plugin-client-common/notebook/tsconfig.json
+++ b/plugins/plugin-client-common/notebook/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../packages/builder/tsconfig-base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "mdist",
+    "rootDir": "src"
+  }
+}

--- a/plugins/plugin-client-common/tsconfig.json
+++ b/plugins/plugin-client-common/tsconfig.json
@@ -6,5 +6,6 @@
     "jsx": "react",
     "outDir": "mdist",
     "rootDir": "src"
-  }
+  },
+  "references": [{ "path": "./notebook" }]
 }


### PR DESCRIPTION
due to the way replay loads notebooks, versus commentary; this PR consolidates this logic

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
