### PR TITLE
fix(plugins/plugin-kubectl): workaround for kubectl commands versus s…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/raw.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/raw.ts
@@ -67,7 +67,9 @@ const doNativeExecOnce = (args: Args): Promise<RawResponse> =>
     expandTildes(args, env)
 
     const executable = args.argv[0].replace(/^_/, '')
-    const child = spawn(executable, args.argv.slice(1), { env })
+    const argv = args.argv.slice(1)
+    const shell = !!args.argv.find(_ => /['$]/.test(_)) // single quotes or $var -> shell
+    const child = spawn(executable, argv, { env, shell })
 
     // this is needed e.g. to handle ENOENT; otherwise the kui process may die with an uncaught exception
     child.on('error', (err: Error) => {

--- a/plugins/plugin-kubectl/src/test/k8s3/run.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/run.ts
@@ -19,6 +19,24 @@ import { waitForGreen, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-
 
 const synonyms = ['kubectl', 'k']
 
+describe(`kubectl run single quotes ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const ns: string = createNS()
+  allocateNS(this, ns)
+
+  it('should kubectl run with single quotes', () =>
+    CLI.command(`kubectl run nginx --image=nginx --overrides='{ "apiVersion": "v1" }' -n ${ns}`, this.app)
+      .then(
+        ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME('nginx') })
+      )
+      .then(selector => waitForGreen(this.app, selector))
+      .catch(Common.oops(this, true)))
+
+  deleteNS(this, ns)
+})
+
 describe(`kubectl run ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))


### PR DESCRIPTION
…ingle quotes

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
