### PR TITLE
feat: Use patternfly Sidebar to display guidebooks

### DIFF
--- a/packages/test/src/api/Sidebar.ts
+++ b/packages/test/src/api/Sidebar.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default class Sidebar {
+  /** Sidebar hamburger button that toggles the sidebar when clicked */
+  public readonly hamburgerButton = '.kui--top-tab-stripe-header .kui--top-tab-stripe-header--toggle-button'
+
+  /** Sidebar content is inside of this */
+  public readonly contentContainer = '.kui--tab-container-sidebar'
+
+  /** Sidebar content container, either visible or not */
+  public contentContainerVisible(visible = true) {
+    return `${this.contentContainer}[aria-hidden="${!visible}"]`
+  }
+
+  /** Sidebar nav item */
+  public item(title: string) {
+    return `${this.contentContainer} .kui--sidebar-nav-item[data-title="${title}"]`
+  }
+}

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import SidebarApi from './Sidebar'
+
+export const Sidebar = new SidebarApi()
+
 /* eslint-disable @typescript-eslint/camelcase */
 export const TOP_TAB = '.kui--tab-list > .kui--tab'
 export const TOP_TAB_N = (N: number) => `${TOP_TAB}:nth-child(${N})`

--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -23,6 +23,7 @@ import { Capabilities, Events, i18n, REPL, pexecInCurrentTab, encodeComponent, T
 
 import KuiContext from './context'
 import CommonClientProps from './props/Common'
+import GuidebookProps from './props/Guidebooks'
 import KuiConfiguration from './KuiConfiguration'
 import StatusStripe, { Props as StatusStripeProps } from './StatusStripe'
 import { TabContainer, Loading, Alert } from '../..'
@@ -41,6 +42,7 @@ const defaultThemeProperties: Themes.ThemeProperties = {
 }
 
 export type Props = Partial<KuiConfiguration> &
+  GuidebookProps &
   CommonClientProps & {
     /** no Kui bootstrap needed? */
     noBootstrap?: boolean
@@ -292,10 +294,16 @@ export class Kui extends React.PureComponent<Props, State> {
           <React.Suspense fallback={<div />}>
             <div className="kui--full-height">
               <TabContainer
+                productName={this.props.productName}
+                version={this.props.version}
                 noActiveInput={this.props.noActiveInput || !!this.props.bottomInput}
                 bottom={bottom}
                 title={this.props.initialTabTitle}
                 onTabReady={this.state.commandLine && this._onTabReady}
+                closeableTabs={this.props.closeableTabs}
+                guidebooks={this.props.guidebooks}
+                guidebooksCommand={this.props.guidebooksCommand}
+                guidebooksExpanded={this.props.guidebooksExpanded}
               ></TabContainer>
               {this.props.toplevel}
               {this.props.statusStripe !== false && (

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
@@ -15,7 +15,16 @@
  */
 
 import React from 'react'
-import { Nav, NavList, PageHeader } from '@patternfly/react-core'
+import {
+  Nav,
+  NavList,
+  Masthead,
+  MastheadMain,
+  MastheadBrand,
+  MastheadContent,
+  MastheadToggle,
+  PageToggleButton
+} from '@patternfly/react-core'
 import { Capabilities, KeyCodes, isReadOnlyClient } from '@kui-shell/core'
 
 import TabModel from '../TabModel'
@@ -23,6 +32,8 @@ import KuiContext from '../context'
 import NewTabButton from './NewTabButton'
 import Tab, { TabConfiguration } from './Tab'
 import SplitTerminalButton from './SplitTerminalButton'
+
+import Icons from '../../spi/Icons'
 
 import '../../../../web/scss/components/TopTabStripe/_index.scss'
 
@@ -54,13 +65,15 @@ export type TopTabStripeConfiguration = TabConfiguration
 type Props = TopTabStripeConfiguration & {
   tabs: TabModel[]
   activeIdx: number
+  closeableTabs: boolean
   onNewTab: () => void
   onCloseTab: (idx: number) => void
   onSwitchTab: (idx: number) => void
-}
 
-/** @types/carbon-react is insufficient here; filling in the gaps for now */
-type CarbonHeaderArgs = { onClickSideNavExpand: React.MouseEventHandler; isSideNavExpanded: boolean }
+  needsSidebar: boolean
+  isSidebarOpen: boolean
+  onToggleSidebar: () => void
+}
 
 export default class TopTabStripe extends React.PureComponent<Props> {
   public componentDidMount() {
@@ -123,7 +136,7 @@ export default class TopTabStripe extends React.PureComponent<Props> {
                 idx={idx}
                 uuid={tab.uuid}
                 title={tab.title}
-                closeable={this.props.tabs.length > 1 && !isReadOnlyClient()}
+                closeable={this.props.closeableTabs}
                 active={idx === this.props.activeIdx}
                 onCloseTab={(idx: number) => this.props.onCloseTab(idx)}
                 onSwitchTab={(idx: number) => this.props.onSwitchTab(idx)}
@@ -153,21 +166,35 @@ export default class TopTabStripe extends React.PureComponent<Props> {
     )
   }
 
-  private header() {
-    const logoProps = {
-      /*      href: 'https://patternfly.org',
-      onClick: () => console.log('clicked logo'),
-      target: '_blank' */
-    }
-
+  private sidebarToggle() {
     return (
-      <PageHeader
-        className="kui--top-tab-stripe-header"
-        logo={this.headerName()}
-        logoProps={logoProps}
-        logoComponent="span"
-        topNav={this.tabs()}
-      />
+      this.props.needsSidebar && (
+        <MastheadToggle className="kui--top-tab-stripe-header--toggle">
+          <PageToggleButton
+            className="kui--top-tab-stripe-header--toggle-button"
+            variant="plain"
+            aria-label="Global navigation"
+            isNavOpen={this.props.isSidebarOpen}
+            onNavToggle={this.props.onToggleSidebar}
+          >
+            <Icons icon="Hamburger" className="kui--top-tab-stripe-header--toggle-button-icon" />
+          </PageToggleButton>
+        </MastheadToggle>
+      )
+    )
+  }
+
+  private header() {
+    return (
+      <Masthead className="kui--top-tab-stripe-header">
+        {this.sidebarToggle()}
+        <MastheadMain className="kui--top-tab-stripe-header--main">
+          <MastheadBrand component="span" className="kui--top-tab-stripe-header--brand">
+            {this.headerName()}
+          </MastheadBrand>
+          <MastheadContent className="kui--top-tab-stripe-header--content">{this.tabs()}</MastheadContent>
+        </MastheadMain>
+      </Masthead>
     )
   }
 

--- a/plugins/plugin-client-common/src/components/Client/props/Branding.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Branding.ts
@@ -17,6 +17,9 @@
 type BrandingProps = {
   /** [Optional] This will be displayed in the upper left of the TopTabStripe. Default: "Kui" */
   productName?: string
+
+  /** [Optional] client version */
+  version?: string
 }
 
 export default BrandingProps

--- a/plugins/plugin-client-common/src/components/Client/props/Common.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Common.ts
@@ -23,4 +23,7 @@ export default interface CommonProps {
 
   /** do not show Settings/Themes widget */
   noSettings?: boolean
+
+  /** Are tabs closeable? [default: true except for config.d/client.json readonly: true */
+  closeableTabs?: boolean
 }

--- a/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type Guidebook = { notebook: string; filepath: string }
+type Menu = { label: string; submenu: MenuItem[] }
+export type MenuItem = Guidebook | Menu | object
+
+export function isGuidebook(item: MenuItem): item is Guidebook {
+  const gb = item as Guidebook
+  return typeof gb === 'object' && typeof gb.notebook === 'string' && typeof gb.filepath === 'string'
+}
+
+export function isMenu(item: MenuItem): item is Menu {
+  const menu = item as Menu
+  return typeof menu === 'object' && typeof menu.label === 'string' && Array.isArray(menu.submenu)
+}
+
+export default interface GuidebookProps {
+  /** Is guidebook content default-expanded [default: false] */
+  guidebooksExpanded?: boolean
+
+  /** Command prefix to execute to open a guidebook [default: replay] */
+  guidebooksCommand?: string
+
+  /** Present a fixed set of guidebook content */
+  guidebooks?: MenuItem[]
+}

--- a/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
@@ -18,6 +18,7 @@ import React from 'react'
 
 import {
   AdjustIcon as Contrast,
+  BarsIcon as Hamburger,
   OutlinedDotCircleIcon as Waiting,
   EraserIcon as Clear,
   CameraIcon as Screenshot,
@@ -121,6 +122,8 @@ export default function PatternFly4Icons(props: Props) {
       return <Grid {...props} />
     case 'Github':
       return <Github {...props} />
+    case 'Hamburger':
+      return <Hamburger {...props} />
     case 'Help':
       return <Help style={size20} {...props} />
     case 'Info':

--- a/plugins/plugin-client-common/src/components/spi/Icons/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/index.tsx
@@ -36,6 +36,7 @@ export type SupportedIcon =
   | 'Forward'
   | 'Grid'
   | 'Github'
+  | 'Hamburger'
   | 'Help'
   | 'Info'
   | 'InProgress'

--- a/plugins/plugin-client-common/src/test/core/sidebar.ts
+++ b/plugins/plugin-client-common/src/test/core/sidebar.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, Selectors, Util } from '@kui-shell/test'
+
+const guidebookTitle = 'Welcome to Kui'
+
+describe(`sidebar ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  Util.closeAllExceptFirstTab.bind(this)()
+
+  it('should have a sidebar hamburger menu button', () =>
+    this.app.client
+      .$(Selectors.Sidebar.hamburgerButton)
+      .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+      .catch(Common.oops(this, true)))
+
+  it('should have a hidden sidebar on load', () =>
+    this.app.client
+      .$(Selectors.Sidebar.contentContainerVisible(false))
+      .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+      .catch(Common.oops(this, true)))
+
+  it('should show the sidebar on click of the hamburger', async () => {
+    try {
+      await this.app.client.$(Selectors.Sidebar.hamburgerButton).then(_ => _.click())
+      await this.app.client
+        .$(Selectors.Sidebar.contentContainerVisible(true))
+        .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+
+  it(`should have an sidebar item for ${guidebookTitle}`, async () => {
+    try {
+      const item = await this.app.client.$(Selectors.Sidebar.item(guidebookTitle))
+      await item.waitForExist({ timeout: CLI.waitTimeout })
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+
+  it(`should show the ${guidebookTitle} guidebook on click`, async () => {
+    try {
+      const item = await this.app.client.$(Selectors.Sidebar.item(guidebookTitle))
+      await item.waitForExist({ timeout: CLI.waitTimeout })
+      await item.click()
+
+      await this.app.client
+        .$(Selectors.TOP_TAB_WITH_TITLE(guidebookTitle))
+        .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+
+      // confirm it is the current tab
+      await this.app.client.waitUntil(async () => {
+        const text = await this.app.client.$(Selectors.CURRENT_TAB_TITLE).then(_ => _.getText())
+        return text === guidebookTitle
+      })
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+})

--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/Sidebar.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/Sidebar.scss
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import 'mixins';
+
+body[kui-theme-style='light'] {
+  @include Sidebar {
+    --kui--sidebar-color-01: var(--color-base00);
+    --kui--sidebar-color-02: var(--color-base02);
+  }
+  @include TopTabStripe {
+    @include SidebarToggleButton {
+      --kui--sidebar-toggle-button-color: var(--color-text-02);
+    }
+  }
+}
+
+@include TopTabStripe {
+  @include Sidebar {
+    --kui--sidebar-color-01: var(--color-text-01);
+    --kui--sidebar-color-02: var(--color-text-02);
+
+    display: flex;
+    flex-direction: column;
+  }
+  @include SidebarBody {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+  @include SidebarNav {
+    flex: 1;
+  }
+  @include SidebarOther {
+    padding: 0 var(--pf-global--spacer--lg);
+    color: var(--kui--sidebar-color-01);
+  }
+
+  @include SidebarNavMenuButton {
+    color: var(--kui--sidebar-color-01);
+  }
+
+  @include SidebarNavMenu {
+    @include SidebarNavItem {
+      color: var(--kui--sidebar-color-02);
+    }
+  }
+  @include SidebarNavItem {
+    color: var(--kui--sidebar-color-01);
+
+    a:hover {
+      cursor: pointer;
+    }
+  }
+  @include SidebarToggleButton {
+    --kui--sidebar-toggle-button-color: var(--kui--sidebar-color-02);
+    font-size: 1.25em;
+    color: var(--kui--sidebar-toggle-button-color);
+  }
+  @include SidebarToggleIcon {
+    color: var(--kui--sidebar-color-02);
+  }
+  @include HeaderNameContainer {
+    min-height: $height;
+  }
+  @include HeaderName {
+    display: flex;
+    align-items: center;
+  }
+  @include TopTabStripe_Main {
+    min-height: $height;
+  }
+  @include TopTabStripe_Content {
+    min-height: $height;
+    align-items: stretch;
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
@@ -15,14 +15,14 @@
  */
 
 @import 'mixins';
+@import 'Sidebar';
 @import '../../PatternFly/common';
 
-$height: 3em;
 $tab-label-font-size: 0.875rem;
 
 @include TopTabStripeAbsolute {
   --tab-shadow: inset 0 -3px 0 0;
-  --pf-c-page__header--BackgroundColor: var(--color-stripe-01);
+  --pf-c-masthead--BackgroundColor: var(--color-stripe-01);
 
   .kui--top-tab-stripe-header {
     display: flex;

--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_mixins.scss
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+$height: 3em;
+
 @mixin TopTabStripe {
   .pf-c-page,
-  .kui--top-tab-stripe {
+  .kui--top-tab-stripe-header {
     @content;
   }
 }
@@ -28,6 +30,29 @@
   }
 }
 
+@mixin TopTabStripe_Main {
+  .kui--top-tab-stripe-header--main {
+    @content;
+  }
+}
+@mixin TopTabStripe_Content {
+  .kui--top-tab-stripe-header--content {
+    @content;
+  }
+}
+
+@mixin SidebarToggleButton {
+  button.kui--top-tab-stripe-header--toggle-button {
+    @content;
+  }
+}
+
+@mixin SidebarToggleIcon {
+  .kui--top-tab-stripe-header--toggle-button-icon {
+    @content;
+  }
+}
+
 @mixin TopTabStripe_ProductName {
   .kui--header--name {
     @content;
@@ -35,8 +60,7 @@
 }
 
 @mixin TopTabs {
-  .pf-c-page__header-nav {
-    /* I can't find a way to give us a kui-- className here */
+  .kui--header-tabs {
     @content;
   }
 }
@@ -67,8 +91,7 @@
 }
 
 @mixin HeaderNameContainer {
-  .pf-c-page__header-brand {
-    /* I can't find a way to give us a kui-- className here */
+  .kui--top-tab-stripe-header--brand {
     @content;
   }
 }
@@ -87,5 +110,49 @@
 @mixin TabClose {
   .kui--tab-close {
     @content;
+  }
+}
+
+@mixin Sidebar {
+  .kui--tab-container-sidebar {
+    @content;
+  }
+}
+
+@mixin SidebarBody {
+  .pf-c-page__sidebar-body {
+    @content;
+  }
+}
+
+@mixin SidebarNav {
+  .kui--tab-container-sidebar-nav {
+    @content;
+  }
+}
+
+@mixin SidebarOther {
+  .kui--tab-container-sidebar-other {
+    @content;
+  }
+}
+
+@mixin SidebarNavItem {
+  .kui--sidebar-nav-item {
+    @content;
+  }
+}
+
+@mixin SidebarNavMenu {
+  .kui--sidebar-nav-menu {
+    @content;
+  }
+}
+
+@mixin SidebarNavMenuButton {
+  @include SidebarNavMenu {
+    & > button {
+      @content;
+    }
   }
 }

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -37,6 +37,8 @@ const ProxyOfflineIndicator = React.lazy(() =>
   import('@kui-shell/plugin-proxy-support').then(_ => ({ default: _.ProxyOfflineIndicator }))
 )
 
+import { version } from '@kui-shell/client/package.json'
+import guidebooks from '@kui-shell/client/config.d/notebooks.json'
 import { productName } from '@kui-shell/client/config.d/name.json'
 
 /**
@@ -77,12 +79,14 @@ export default function renderMain(props: KuiProps) {
 
   return (
     <Kui
+      version={version}
       productName={productName}
       lightweightTables
       {...props}
       isPopup={isPopup}
       quietExecCommand={quietExecCommand}
       toplevel={!Capabilities.inBrowser() && <Search />}
+      guidebooks={guidebooks.submenu}
       commandLine={
         props.commandLine ||
         (!isPopup && [

--- a/plugins/plugin-core-support/src/test/core-support2/tab-navigation.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/tab-navigation.ts
@@ -127,7 +127,7 @@ describe('tab navigation', function(this: Common.ISuite) {
 
   const testFullCycle = () => {
     it('should be the beginning of a full cycle', promptBetterBeFocused)
-    testSelector(TAB_BUTTON_N(1))
+    testSelector(TAB_BUTTON_N(1), undefined, undefined, true)
     testSelector(TAB_BUTTON_N(2))
     testSelector(tabButtonSelector)
     testSelector('#help-button', false, undefined, true)
@@ -141,7 +141,7 @@ describe('tab navigation', function(this: Common.ISuite) {
   hitBackspace()
 
   // tab to new tab button and hit enter
-  testSelector(TAB_BUTTON_N(1))
+  testSelector(TAB_BUTTON_N(1), undefined, undefined, true)
   testSelector(tabButtonSelector, true, Selectors.TAB_SELECTED_N(2))
   testPromptIsSelected(false, true)
 

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -134,6 +134,8 @@ body[kui-theme='Light'] {
 
   --color-brand-03: #008fff;
 
+  --pf-global--BackgroundColor--dark-300: #393939;
+
   --color-confirm-background: var(--color-base00);
   --color-confirm-foreground: var(--color-base05);
 


### PR DESCRIPTION
Also ports from older Patternfly Page* elements to new Masthead* elements

<img width="842" alt="guidebooks in sidebar" src="https://user-images.githubusercontent.com/4741620/149431706-33ebbbcd-4046-4090-b584-ac8a25166f60.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
