### PR TITLE
fix(plugins/plugin-client-common): new tab/new split button size does…

### DIFF
--- a/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
@@ -91,7 +91,7 @@ export default function PatternFly4Icons(props: Props) {
     case 'At':
       return <At style={StatusStripe} {...props} />
     case 'Add':
-      return <Add style={size20} {...props} />
+      return <Add {...props} />
     case 'Back':
       return <Back style={Sidecar} {...props} />
     case 'ChartBar':
@@ -173,7 +173,7 @@ export default function PatternFly4Icons(props: Props) {
     case 'ScreenshotInProgress':
       return <ScreenshotInProgress {...props} />
     case 'Split':
-      return <TerminalPlusSidecar style={size20} {...props} />
+      return <TerminalPlusSidecar {...props} />
     case 'Search':
       return <Search style={size20} {...props} />
     case 'Trash':


### PR DESCRIPTION
… not match the rest of kui

we have these at 16px for some reason

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
