### PR TITLE
feat(plugins/plugin-client-common): noTopTabs, allowing clients to us…

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -301,6 +301,7 @@ export class Kui extends React.PureComponent<Props, State> {
                 title={this.props.initialTabTitle}
                 onTabReady={this.state.commandLine && this._onTabReady}
                 closeableTabs={this.props.closeableTabs}
+                noTopTabs={this.props.noTopTabs}
                 guidebooks={this.props.guidebooks}
                 guidebooksCommand={this.props.guidebooksCommand}
                 guidebooksExpanded={this.props.guidebooksExpanded}

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
@@ -65,6 +65,7 @@ export type TopTabStripeConfiguration = TabConfiguration
 type Props = TopTabStripeConfiguration & {
   tabs: TabModel[]
   activeIdx: number
+  noTopTabs: boolean
   closeableTabs: boolean
   onNewTab: () => void
   onCloseTab: (idx: number) => void
@@ -126,31 +127,33 @@ export default class TopTabStripe extends React.PureComponent<Props> {
   /** Render tabs */
   private tabs() {
     return (
-      <React.Fragment>
-        <Nav aria-label="Tabs" variant="horizontal" className="kui--header-tabs">
-          <NavList className="kui--tab-list">
-            {this.props.tabs.map((tab, idx) => (
-              <Tab
-                {...this.props}
-                key={idx}
-                idx={idx}
-                uuid={tab.uuid}
-                title={tab.title}
-                closeable={this.props.closeableTabs}
-                active={idx === this.props.activeIdx}
-                onCloseTab={(idx: number) => this.props.onCloseTab(idx)}
-                onSwitchTab={(idx: number) => this.props.onSwitchTab(idx)}
-              />
-            ))}
-          </NavList>
-        </Nav>
-        {!isReadOnlyClient() && (
-          <div className="kui--top-tab-buttons">
-            <NewTabButton onNewTab={this.props.onNewTab} />
-            <SplitTerminalButton />
-          </div>
-        )}
-      </React.Fragment>
+      !this.props.noTopTabs && (
+        <React.Fragment>
+          <Nav aria-label="Tabs" variant="horizontal" className="kui--header-tabs">
+            <NavList className="kui--tab-list">
+              {this.props.tabs.map((tab, idx) => (
+                <Tab
+                  {...this.props}
+                  key={idx}
+                  idx={idx}
+                  uuid={tab.uuid}
+                  title={tab.title}
+                  closeable={this.props.closeableTabs}
+                  active={idx === this.props.activeIdx}
+                  onCloseTab={(idx: number) => this.props.onCloseTab(idx)}
+                  onSwitchTab={(idx: number) => this.props.onSwitchTab(idx)}
+                />
+              ))}
+            </NavList>
+          </Nav>
+          {!isReadOnlyClient() && (
+            <div className="kui--top-tab-buttons">
+              <NewTabButton onNewTab={this.props.onNewTab} />
+              <SplitTerminalButton />
+            </div>
+          )}
+        </React.Fragment>
+      )
     )
   }
 

--- a/plugins/plugin-client-common/src/components/Client/props/Common.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Common.ts
@@ -26,4 +26,7 @@ export default interface CommonProps {
 
   /** Are tabs closeable? [default: true except for config.d/client.json readonly: true */
   closeableTabs?: boolean
+
+  /** Don't show top tabs [default: false] */
+  noTopTabs?: boolean
 }


### PR DESCRIPTION
…e the sidebar instead of top tabs

<img width="1469" alt="Screen Shot 2022-01-14 at 5 29 39 PM" src="https://user-images.githubusercontent.com/4741620/149593641-304e326e-9a4a-426d-b13a-3c80aa89158e.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
