### PR TITLE
fix(plugins/plugin-client-common): work around mkdocs {target=} syntax

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -177,7 +177,9 @@ export default class Markdown extends React.PureComponent<Props, State> {
       td.use(gfm)
       return td.turndown(props.source)
     } else {
-      return hackIndentation(props.source).trim()
+      return hackIndentation(props.source)
+        .trim()
+        .replace(/\){target=[^}]+}/g, ')')
     }
   }
 


### PR DESCRIPTION
For now, we just throw away this information. For the cases where it is `target=_blank`, this does not harm Kui behavior, since it is the default behavior.

Fixes #8432 
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
