### PR TITLE
doc: update notebook menu structure to place Kui content in its own s…

### DIFF
--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -1,8 +1,13 @@
 {
   "label": "Notebooks",
   "submenu": [
-    { "notebook": "Welcome to Kui", "filepath": "/kui/welcome.md" },
-    { "type": "separator" },
+    {
+      "label": "Kui",
+      "submenu": [
+        { "notebook": "Welcome to Kui", "filepath": "/kui/welcome.md" },
+        { "notebook": "Make Your Own Notebook", "filepath": "/kui/make-notebook.md" }
+      ]
+    },
     {
       "label": "Kubernetes",
       "submenu": [
@@ -17,8 +22,6 @@
         { "notebook": "Welcome to Iter8", "filepath": "/kui/iter8/welcome.md" },
         { "notebook": "Tutorial 1", "filepath": "/kui/iter8/tutorial1.md" }
       ]
-    },
-    { "type": "separator" },
-    { "notebook": "Make Your Own Notebook", "filepath": "/kui/make-notebook.md" }
+    }
   ]
 }


### PR DESCRIPTION
…ubmenu

This works better with the Sidebar UI.

<img width="281" alt="Screen Shot 2022-01-17 at 5 37 26 PM" src="https://user-images.githubusercontent.com/4741620/149844298-2817f584-6640-4256-a56c-3532a50cf588.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
