### PR TITLE
fix(plugins/plugin-kubectl): kubectl get events tables in split termi…

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -73,7 +73,7 @@ export const outerCSSForKey = {
   CURRENT: 'entity-name-group entity-name-group-extra-narrow text-center',
   DESIRED: 'entity-name-group entity-name-group-extra-narrow text-center',
 
-  'LAST SEEN': 'hide-with-sidecar entity-name-group-extra-narrow', // kubectl get events
+  'LAST SEEN': 'entity-name-group-extra-narrow', // kubectl get events
   'FIRST SEEN': 'hide-with-sidecar entity-name-group-extra-narrow', // kubectl get events
 
   COUNT: 'keep-with-sidecar',


### PR DESCRIPTION
…nals do not show Last Seen column

this column is pretty darn helpful when viewing events!

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
