### PR TITLE
fix(plugins/plugin-client-common): markdown code block edits not durable

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
@@ -212,7 +212,15 @@ export default class SimpleEditor extends React.Component<Props, State> {
       })
 
       if (props.onContentChange) {
-        editor.onDidChangeModelContent(SimpleEditor.onChange(props, editor))
+        // Notes: using onDidChangeModelContent does not let us
+        // distinguish between the initial model change and changes
+        // resulting from user input. Maybe we could look at the
+        // `versionId` property of the model content change event
+        // (does 1 mean the first version? it seems to be 2, dunno
+        // why)... but i'd rather not get into that kind of low-level
+        // dependence on the internal workings of monaco-editor
+        // editor.onDidChangeModelContent(SimpleEditor.onChange(props, editor))
+        editor.onKeyUp(SimpleEditor.onChange(props, editor))
       }
 
       if (!options.readOnly && this.props.focus !== false) {


### PR DESCRIPTION
When editing the code block within Kui (i.e. not in the markdown text source), ... changes are possible, but re-executing the command does not reflect the updated code block text.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
