### PR TITLE
fix: dockerized proxy installs incorrect version of node-pty

### DIFF
--- a/packages/proxy/Dockerfile
+++ b/packages/proxy/Dockerfile
@@ -72,7 +72,7 @@ RUN debconf-set-selections /tmp/preseed.txt && \
     rm -f /etc/timezone /etc/localtime && \
     apt update && apt install -y --no-install-recommends build-essential python sed git tzdata nginx ca-certificates bash git python build-essential curl upx gettext-base && \
     cd /usr/share/nginx/html/kui && npm link ./app --no-package-lock && \
-    (cd /tmp && mkdir npty && cd npty && npm init -y && npm install node-pty@$NODE_PTY_VERSION && cd /usr/share/nginx/html/kui/dist/headless && cp /tmp/npty/node_modules/node-pty/build/Release/pty.node . && cp pty.node pty-proxy.node) && \
+    (cd /tmp && mkdir npty && cd npty && npm init -y && npm install node-pty@$NODE_PTY_VERSION && cd /usr/share/nginx/html/kui/dist/headless && cp /tmp/npty/node_modules/node-pty/build/Release/pty.node . && cp pty.node pty-proxy.node && mkdir -p ../build/Release && cp /tmp/npty/node_modules/node-pty/build/Release/spawn-helper ../build/Release) && \
     curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/kubectl && upx /usr/local/bin/kubectl && \
     curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar zxf - && mv linux-amd64/helm /usr/local/bin/helm && chmod +x /usr/local/bin/helm && upx /usr/local/bin/helm && rm -rf linux-amd64 && \
     curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz | tar zxf - && \

--- a/packages/proxy/build-docker.sh
+++ b/packages/proxy/build-docker.sh
@@ -115,7 +115,15 @@ function image {
         echo "Loading ContentSecurityPolicy from env $CSP"
     fi
 
-    NODE_PTY_VERSION=$(npm view node-pty version)
+    # sigh, this is harder than it should be: we want to get the
+    # *installed* version of node-pty do not use `npm view node-pty
+    # version` has this seems to get info about what is *published*
+    # maybe most of the time those are the same, but e.g. if we have
+    # installed a beta version e.g. 0.11.0-beta17, then there *will*
+    # be a difference between the two, because `npm view node-pty`
+    # will use implicitly the @latest dist-tag
+    NODE_PTY_VERSION=$(npm list node-pty | grep node-pty | cut -d @ -f2)
+    echo "Using node-pty@${NODE_PTY_VERSION}"
     (cd "$BUILDDIR" && docker build . -t kuishell/kui --build-arg CSP="$CSP" --build-arg OPENGRAPH="$OPENGRAPH" --build-arg KUBE_VERSION=$KUBE_VERSION --build-arg HELM_VERSION=$HELM_VERSION --build-arg OC_VERSION=$OC_VERSION $KUBECONFIG_ARG --build-arg NODE_PTY_VERSION=$NODE_PTY_VERSION)
 }
 

--- a/packages/webpack/headless-webpack.config.js
+++ b/packages/webpack/headless-webpack.config.js
@@ -65,6 +65,7 @@ const allFiles = /.*/
 plugins.push(new IgnorePlugin({ resourceRegExp: /\.css/, contextRegExp: /@kui-shell/ }))
 plugins.push(new IgnorePlugin({ resourceRegExp: /\.scss/, contextRegExp: /@kui-shell/ }))
 plugins.push(new IgnorePlugin({ resourceRegExp: allFiles, contextRegExp: /\/tests\// }))
+plugins.push(new IgnorePlugin({ resourceRegExp: /tsconfig\.cjs\.spec\.json/ }))
 plugins.push(new IgnorePlugin({ resourceRegExp: /@patternfly\/react-charts/ }))
 plugins.push(new IgnorePlugin({ resourceRegExp: /@patternfly\/react-core/ }))
 plugins.push(new IgnorePlugin({ resourceRegExp: /@patternfly\/react-icons/ }))


### PR DESCRIPTION
apparently `npm view node-pty version` shows the published version of the latest dist-tag, not the version we have installed.

also, the Dockerfile does not copy the `spawn-helper` that is now part of linux (and macos) node-pty builds

this PR also fixes a spurious error in the headless bundle build

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
