### PR TITLE
feat(plugins/plugin-kubectl): CurrentContext/Namespace widgets should…

### DIFF
--- a/plugins/plugin-client-common/src/components/spi/Select/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Select/impl/PatternFly.tsx
@@ -57,9 +57,9 @@ export default class PatternFlySelect extends React.PureComponent<Props, State> 
   private async onClick(option: SelectOptions) {
     if (option.command) {
       if (typeof option.command === 'string') {
-        pexecInCurrentTab(option.command)
+        pexecInCurrentTab(option.command, undefined, undefined, option.quietExec)
       } else {
-        pexecInCurrentTab(await option.command())
+        pexecInCurrentTab(await option.command(), undefined, undefined, option.quietExec)
       }
     }
   }

--- a/plugins/plugin-client-common/src/components/spi/Select/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/Select/model.ts
@@ -16,6 +16,7 @@
 export type SelectOptions = {
   label: string
   command?: string | (() => Promise<string>)
+  quietExec?: boolean
   description?: React.ReactNode
   isSelected?: boolean
   isDisabled?: boolean

--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -143,6 +143,7 @@ export default class CurrentContext extends React.PureComponent<Props, State> {
         label,
         isSelected,
         description: isSelected ? strings('This is your current context') : undefined,
+        quietExec: true,
         command: `${kubectl} config use-context ${encodeComponent(name)}`
       }
     })

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -223,6 +223,7 @@ export default class CurrentNamespace extends React.PureComponent<Props, State> 
       label: ns,
       isSelected,
       description: isSelected ? strings('This is your current namespace') : undefined,
+      quietExec: true,
       command: async () => {
         const kubectl = await this.kubectl()
         return `${kubectl} config set-context --current --namespace=${ns}`


### PR DESCRIPTION
…n't echo the switch commands

Probably pollutes the terminal for no great benefit. In guidebook contexts, this is actively harmful.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
