### PR TITLE
feat: kubernetes dashboard guidebook

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/SpaceFiller.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/SpaceFiller.tsx
@@ -21,5 +21,5 @@ import React from 'react'
  *
  */
 export default function SpaceFiller() {
-  return <div className="flex-fill" />
+  return <div className="flex-fill kui--status-stripe-space-filler kui--hide-in-guidebook kui--status-stripe-element" />
 }

--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/index.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/index.tsx
@@ -111,7 +111,7 @@ export default class StatusStripe extends React.PureComponent<Props, State> {
   private message() {
     if (this.state.type !== 'default' && this.state.message) {
       return (
-        <div className="kui--status-stripe-element left-pad kui--status-stripe-message-element">
+        <div className="kui--status-stripe-element left-pad kui--status-stripe-message-element flex-fill">
           {this.simpleMarkdown(this.state.message)}
         </div>
       )
@@ -125,7 +125,7 @@ export default class StatusStripe extends React.PureComponent<Props, State> {
    *
    */
   private widgets() {
-    if (this.state.type !== 'default' || React.Children.count(this.props.children) === 0) {
+    if (React.Children.count(this.props.children) === 0) {
       return this.filler()
     } else {
       return this.props.children

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code.tsx
@@ -77,6 +77,7 @@ export default function code(
             className="kui--code-block-in-markdown"
             tab={mdprops.tab}
             value={body}
+            watch={attributes.watch}
             language={language}
             blockId={attributes.id}
             validate={attributes.validate === '$body' ? body : attributes.validate}

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -38,6 +38,9 @@ $z-index: var(--pf-global--ZIndex--xs);
     @include StatusStripeElement {
       color: $fg-type-blue;
     }
+    @include StatusStripeElementHiddenInGuidebook {
+      display: none;
+    }
   }
   &[data-type='yellow'] {
     background-color: $bg-type-yellow;

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/_mixins.scss
@@ -46,6 +46,14 @@ $status-stripe-hover-bg-color: var(--color-table-border3);
   }
 }
 
+@mixin StatusStripeElementHiddenInGuidebook {
+  @include StatusStripeElement {
+    &.kui--hide-in-guidebook {
+      @content;
+    }
+  }
+}
+
 @mixin StatusStripeButton {
   .kui--status-stripe-button {
     @content;

--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -12,6 +12,7 @@
     {
       "label": "Kubernetes",
       "submenu": [
+        { "notebook": "Dashboard", "filepath": "/kui/kubernetes/dashboard1.md" },
         { "notebook": "CRUD Operations", "filepath": "/kui/kubernetes/crud-operations.md" },
         { "notebook": "Working with Jobs", "filepath": "/kui/kubernetes/create-jobs.md" },
         { "notebook": "Deploying Applications", "filepath": "/kui/kubernetes/deploy-applications.md" }

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -109,8 +109,8 @@ export default function renderMain(props: KuiProps) {
       }
     >
       <ContextWidgets>
-        {!isPopup && <CurrentWorkingDirectory />}
-        <CurrentGitBranch className="kui--hide-in-narrower-windows" />
+        {!isPopup && <CurrentWorkingDirectory className="kui--hide-in-guidebook" />}
+        <CurrentGitBranch className="kui--hide-in-narrower-windows kui--hide-in-guidebook" />
         <CurrentContext />
         <CurrentNamespace />
       </ContextWidgets>

--- a/plugins/plugin-kubectl/notebooks/dashboard1.md
+++ b/plugins/plugin-kubectl/notebooks/dashboard1.md
@@ -1,0 +1,41 @@
+---
+title: Dashboard
+layout:
+    1: default
+    2: default
+    3: default
+    4:
+        position: default
+        placeholder: Click on entries in the tables, and output will show up here
+---
+
+```bash
+---
+execute: now
+watch: /kubectl/config/change
+---
+k get deploy --watch
+```
+
+---
+
+```bash
+---
+execute: now
+watch: /kubectl/context/change
+---
+k get pods --watch
+```
+
+---
+
+```bash
+---
+execute: now
+watch: /kubectl/config/change
+---
+k get events --sort-by='{.metadata.creationTimestamp}' --watch
+```
+
+---
+

--- a/plugins/plugin-kubectl/src/non-headless-preload.ts
+++ b/plugins/plugin-kubectl/src/non-headless-preload.ts
@@ -78,6 +78,7 @@ export default async (registrar: PreloadRegistrar) => {
       'plugin://plugin-kubectl/notebooks/create-jobs.json',
       'plugin://plugin-kubectl/notebooks/crud-operations.md',
       'plugin://plugin-kubectl/notebooks/crud-operations.json',
+      'plugin://plugin-kubectl/notebooks/dashboard1.md',
       'plugin://plugin-kubectl/notebooks/deploy-applications.md',
       'plugin://plugin-kubectl/notebooks/deploy-applications.json'
     ],


### PR DESCRIPTION
This PR also updates the default client so as not to hide the StatusStripe kubernetes context/namespace switcher widgets when showing a notebook/guidebook.

This PR also allows guidebook code blocks to add a `watch` topmatter, which specifies one or more channels. If an even is fired on any of those channels, the code block will automatically be re-executed.

See `plugin-client-kubectl/notebooks/dashboard1.md` for an example.

<img width="1392" alt="kubernetes dashboard guidebook" src="https://user-images.githubusercontent.com/4741620/150413473-d56df6ad-374d-4cb6-956d-5edf76858355.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
