### PR TITLE
fix(plugins/plugin-client-common): opening a guidebook from sidebar s…

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
@@ -18,6 +18,7 @@ import React from 'react'
 import { encodeComponent, i18n, pexecInCurrentTab } from '@kui-shell/core'
 import { PageSidebar } from '@patternfly/react-core'
 
+import CommonProps from './props/Common'
 import BrandingProps from './props/Branding'
 import GuidebookProps, { isGuidebook, isMenu, MenuItem } from './props/Guidebooks'
 
@@ -30,7 +31,8 @@ const NavExpandable = React.lazy(() => import('@patternfly/react-core').then(_ =
 
 const strings = i18n('plugin-client-common')
 
-type Props = BrandingProps &
+type Props = Pick<CommonProps, 'noTopTabs'> &
+  BrandingProps &
   GuidebookProps & {
     /** unfurled? */
     isOpen: boolean
@@ -92,7 +94,12 @@ export default class Sidebar extends React.PureComponent<Props, State> {
           className="kui--sidebar-nav-item"
           isActive={this.props.indicateActiveItem && (_.notebook === this.currentGuidebook || thisIsTheFirstNavItem)}
           onClick={() => {
-            pexecInCurrentTab(`${this.props.guidebooksCommand || 'replay'} ${encodeComponent(_.filepath)}`)
+            const quiet = !this.props.noTopTabs
+            pexecInCurrentTab(
+              `${this.props.guidebooksCommand || 'replay'} ${encodeComponent(_.filepath)}`,
+              undefined,
+              quiet
+            )
             this.setState({ currentGuidebook: _.notebook })
           }}
         >

--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -351,6 +351,7 @@ export default class TabContainer extends React.PureComponent<Props, State> {
         version={this.props.version}
         isOpen={this.state.isSidebarOpen}
         toggleOpen={this.toggleSidebar}
+        noTopTabs={this.props.noTopTabs}
         guidebooks={this.props.guidebooks}
         productName={this.props.productName}
         indicateActiveItem={!!this.props.noTopTabs}


### PR DESCRIPTION
…hows internal command execution

i don't think the users will ever care about the `replay /odd/path.md` being echo'd anywhere

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
