### PR TITLE
fix: improved markdown expandable section colors

### DIFF
--- a/plugins/plugin-carbon-themes/web/scss/colors.scss
+++ b/plugins/plugin-carbon-themes/web/scss/colors.scss
@@ -36,11 +36,17 @@
   --color-base0E: #fa75a6;
   --color-base0F: #d4bbff;
 
-  --color-base0B-rgb: 36, 161, 72;
   --color-base08-rgb: 255, 131, 137;
-
-  --color-green-rgb: var(--color-base0B-rgb);
   --color-red-rgb: var(--color-base08-rgb);
+
+  --color-base0B-rgb: 36, 161, 72;
+  --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 69, 137, 255;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 241, 194, 27;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-confirm-background: var(--color-sidecar-header);
   --color-confirm-foreground: var(--color-base06);
@@ -101,10 +107,16 @@
   --color-base0F: #8a3ffc;
 
   --color-base0B-rgb: 25, 128, 56;
-  --color-base08-rgb: 218, 30, 40;
+  --color-red-rgb: var(--color-base08-rgb);
 
   --color-green-rgb: var(--color-base0B-rgb);
-  --color-red-rgb: var(--color-base08-rgb);
+  --color-base08-rgb: 218, 30, 40;
+
+  --color-base0D-rgb: 5, 74, 218;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 142, 105, 38;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-red-sidecar: #fb4b53;
   --color-yellow-sidecar: #fdd13a;

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/details.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/details.tsx
@@ -24,13 +24,14 @@ export function tipProps(expanded: boolean) {
   return { isWidthLimited: true, expanded }
 }
 
+/** This feeds off our rehype-tip AST decorations */
 export function tip(props: React.DetailsHTMLAttributes<HTMLElement>) {
+  const className = ['kui--markdown-tip', 'kui--markdown-major-paragraph']
+    .concat((props.className ? props.className.split(/\s+/) : []).map(_ => `kui--markdown-tip_${_}`))
+    .join(' ')
+
   return (
-    <ExpandableSection
-      className="kui--markdown-tip kui--markdown-major-paragraph"
-      showMore={props.title}
-      {...tipProps(props.open)}
-    >
+    <ExpandableSection className={className} showMore={props.title} {...tipProps(props.open)}>
       {props.children}
     </ExpandableSection>
   )

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tip/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tip/index.ts
@@ -18,8 +18,8 @@ import { i18n } from '@kui-shell/core'
 
 const strings = i18n('plugin-client-common', 'markdown')
 
-const RE_TIP = /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning)(\s+"(.+)"\s*)?(\n(.|[\n\r])*)?$/
-const RE_TIP_START = /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning)(\s+"(.+))?$/
+const RE_TIP = /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning|success)(\s+"(.+)"\s*)?(\n(.|[\n\r])*)?$/
+const RE_TIP_START = /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning|success)(\s+"(.+))?$/
 const RE_TIP_END = /^(.*)"\s*(\n(.|[\n\r])*)?$/
 
 export const START_OF_TIP = `<!-- ____KUI_START_OF_TIP____ -->`
@@ -99,6 +99,7 @@ export default function plugin(/* options */) {
                     type: 'element',
                     tagName: 'tip',
                     properties: {
+                      className: startMatch[3], // e.g. tip, todo, bug, warning, ...
                       title: startMatch[5] || strings(startMatch[3]),
                       open: !!startMatch[2] || startMatch[1] === '!!!'
                     },
@@ -117,6 +118,7 @@ export default function plugin(/* options */) {
                       type: 'element',
                       tagName: 'tip',
                       properties: {
+                        className: startMatch[3], // e.g. tip, todo, bug, warning, ...
                         title: startMatch[5] || strings(startMatch[3]),
                         open: !!startMatch[2] || startMatch[1] === '!!!',
                         partial: true

--- a/plugins/plugin-client-common/web/scss/components/ExpandableSection/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/ExpandableSection/_mixins.scss
@@ -67,3 +67,11 @@ $expandablesection--spacing: 0.125rem;
     }
   }
 }
+
+@mixin ExpandableSectionToggleText {
+  @include ExpandableSectionToggle {
+    .pf-c-expandable-section__toggle-text {
+      @content;
+    }
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -319,22 +319,16 @@ body[kui-theme-style='light'] {
   }
 }
 
-@mixin InvertedTipAndTab {
-  @include MarkdownTip {
-    color: var(--color-base00);
-  }
+@mixin InvertedTab {
   @include MarkdownActiveTabButton {
     color: var(--color-text-01);
   }
 }
 @include InvertedColors {
-  @include InvertedTipAndTab;
+  @include InvertedTab;
 }
 body[kui-theme-style='dark'] {
-  @include InvertedTipAndTab;
-  @include ExpandableSectionToggle {
-    color: var(--pf-global--active-color--400);
-  }
+  @include InvertedTab;
   @include ExpandableSectionButtonIcon {
     color: inherit;
   }
@@ -345,13 +339,53 @@ body[kui-theme-style='dark'] {
   }
 }
 @include MarkdownTip {
-  background-color: #e7f1fa;
+  $tip-toggle-opacity: 0.3;
+  $tip-toggle-opacity-2: 0.9;
 
   @include ExpandableSectionToggle {
     width: 100%;
+    font-weight: 500;
     padding-top: 0.6875em;
     padding-bottom: 0.6875em;
-    mix-blend-mode: multiply;
+    background-color: #e7f1fa;
+  }
+  @include ExpandableSectionToggleText {
+    color: var(--color-text-01);
+  }
+  @include MarkdownTipVariant(success) {
+    $bgcolor: var(--color-base0B-rgb);
+    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+    @include ExpandableSectionToggle {
+      background-color: rgba($bgcolor, $tip-toggle-opacity);
+    }
+  }
+  @include MarkdownTipVariant(warning) {
+    $bgcolor: var(--color-yellow-rgb);
+    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+    @include ExpandableSectionToggle {
+      background-color: rgba($bgcolor, $tip-toggle-opacity);
+    }
+  }
+  @include MarkdownTipVariant(todo) {
+    $bgcolor: var(--color-blue-rgb);
+    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+    @include ExpandableSectionToggle {
+      background-color: rgba($bgcolor, $tip-toggle-opacity);
+    }
+  }
+  @include MarkdownTipVariant(note) {
+    $bgcolor: var(--color-yellow-rgb);
+    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+    @include ExpandableSectionToggle {
+      background-color: rgba($bgcolor, $tip-toggle-opacity);
+    }
+  }
+  @include MarkdownTipVariant(bug) {
+    $bgcolor: var(--color-red-rgb);
+    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+    @include ExpandableSectionToggle {
+      background-color: rgba($bgcolor, $tip-toggle-opacity);
+    }
   }
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -15,6 +15,7 @@
  */
 
 @use 'sass:math';
+@import '../ExpandableSection/mixins';
 
 /** Terminal font size */
 $terminal-font-size: 0.875rem;
@@ -577,6 +578,11 @@ $action-hover-delay: 210ms;
 
 @mixin MarkdownTip {
   .kui--markdown-tip {
+    @content;
+  }
+}
+@mixin MarkdownTipVariant($variant) {
+  &.kui--markdown-tip_#{$variant} {
     @content;
   }
 }

--- a/plugins/plugin-core-themes/web/scss/Mercury.scss
+++ b/plugins/plugin-core-themes/web/scss/Mercury.scss
@@ -67,8 +67,15 @@ $base0F: #a3685a;
 
   --color-base08-rgb: 204, 102, 102;
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: 181, 189, 104;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 40, 61, 86;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 93, 69, 53;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-table-border1: #82857b;
 

--- a/plugins/plugin-core-themes/web/scss/atelier-seaside.scss
+++ b/plugins/plugin-core-themes/web/scss/atelier-seaside.scss
@@ -42,10 +42,16 @@ body[kui-theme='Atelier'] {
   --color-base0F: #e619c3;
 
   --color-base0B-rgb: 41, 163, 41;
-  --color-base08-rgb: 230, 25, 60;
-
-  --color-green-rgb: var(--color-base0B-rgb);
   --color-red-rgb: var(--color-base08-rgb);
+
+  --color-base08-rgb: 230, 25, 60;
+  --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 134, 157, 249;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 178, 178, 31;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-ui-06: hsla(120, 8%, 14%, 1);
 

--- a/plugins/plugin-core-themes/web/scss/dark.scss
+++ b/plugins/plugin-core-themes/web/scss/dark.scss
@@ -43,11 +43,17 @@ body[kui-theme='Dark'] {
 
   --color-light-blue: #c8dfff;
 
-  --color-base0B-rgb: 61, 187, 97;
+  --color-red-rgb: var(--color-base08-rgb);
   --color-base08-rgb: 251, 75, 83;
 
+  --color-base0B-rgb: 61, 187, 97;
   --color-green-rgb: var(--color-base0B-rgb);
-  --color-red-rgb: var(--color-base08-rgb);
+
+  --color-base0D-rgb: 151, 193, 255;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 253, 209, 58;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-table-border1: #616466;
   --color-table-border2: #4d5358;

--- a/plugins/plugin-core-themes/web/scss/dracula.scss
+++ b/plugins/plugin-core-themes/web/scss/dracula.scss
@@ -41,11 +41,17 @@ body[kui-theme='Dracula'] {
   --color-base0E: #b45bcf;
   --color-base0F: #00f769;
 
-  --color-base0A-rgb: 0, 247, 105;
   --color-base08-rgb: 234, 81, 178;
-
-  --color-green-rgb: var(--color-base0A-rgb);
   --color-red-rgb: var(--color-base08-rgb);
+
+  --color-base0B-rgb: 0, 247, 105;
+  --color-green-rgb: var(--color-base0A-rgb);
+
+  --color-base0D-rgb: 98, 214, 232;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 235, 255, 135;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-green: var(--color-base0A);
   --color-yellow: var(--color-base0B);

--- a/plugins/plugin-core-themes/web/scss/gruvbox-dark-medium.scss
+++ b/plugins/plugin-core-themes/web/scss/gruvbox-dark-medium.scss
@@ -43,8 +43,15 @@ body[kui-theme='Gruvbox'] {
 
   --color-base08-rgb: 251, 73, 52;
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: 184, 187, 38;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 166, 191, 181;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 250, 189, 47;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-latency-0: #1b7837;
   --color-latency-1: #7fbf7b;

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -118,10 +118,17 @@ body[kui-theme='Light'] {
 
   --color-light-blue: #edf4ff;
 
-  --color-base0B-rgb: 29, 189, 90;
-  --color-green-rgb: var(--color-base0B-rgb);
   --color-base08-rgb: 231, 29, 50;
   --color-red-rgb: var(--color-base08-rgb);
+
+  --color-base0B-rgb: 29, 189, 90;
+  --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 0, 114, 195;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 176, 138, 12;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-name: var(--color-base0D);
   --color-map-key: var(--color-base0D);

--- a/plugins/plugin-core-themes/web/scss/lucario.scss
+++ b/plugins/plugin-core-themes/web/scss/lucario.scss
@@ -44,9 +44,16 @@ body[kui-theme='Lucario'] {
   --color-base0F: #e6b5ff;
 
   --color-base08-rgb: 255, 108, 96;
-  --color-green-rgb: var(--color-base0B-rgb);
-  --color-base0B-rgb: 142, 228, 120;
   --color-red-rgb: var(--color-base08-rgb);
+
+  --color-base0B-rgb: 142, 228, 120;
+  --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 87, 150, 237;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 255, 255, 182;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-ui-06: hsla(209, 25%, 22%, 1);
 

--- a/plugins/plugin-core-themes/web/scss/monokai.scss
+++ b/plugins/plugin-core-themes/web/scss/monokai.scss
@@ -43,8 +43,15 @@ body[kui-theme='Monokai'] {
 
   --color-base08-rgb: 249, 38, 114;
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: 166, 226, 46;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 102, 217, 239;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 244, 191, 117;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-error-cell-bg: var(--color-base0E);
   --color-error-cell-text: var(--color-base00);

--- a/plugins/plugin-core-themes/web/scss/nord.scss
+++ b/plugins/plugin-core-themes/web/scss/nord.scss
@@ -47,11 +47,19 @@ body[kui-theme='Nord'] {
   --color-red: var(--color-base0B);
   --color-green: var(--color-base0E);
   --color-yellow: var(--color-base0D);
+  --color-blue: var(--color-base0A);
+
+  --color-base0B-rgb: 191, 97, 106;
+  --color-red-rgb: var(--color-base0B-rgb);
 
   --color-base0E-rgb: 163, 190, 140;
   --color-green-rgb: var(--color-base0E-rgb);
-  --color-base0B-rgb: 191, 97, 106;
-  --color-red-rgb: var(--color-base0B-rgb);
+
+  --color-base0A-rgb: 144, 168, 198;
+  --color-blue-rgb: var(--color-base0A-rgb);
+
+  --color-base0D-rgb: 235, 203, 139;
+  --color-yellow-rgb: var(--color-base0D-rgb);
 
   --color-latency-0: #4575b4;
   --color-latency-1: #91bfdb;

--- a/plugins/plugin-core-themes/web/scss/paraiso.scss
+++ b/plugins/plugin-core-themes/web/scss/paraiso.scss
@@ -44,8 +44,15 @@ body[kui-theme='Paraiso'] {
 
   --color-base08-rgb: 239, 97, 85;
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: 72, 182, 133;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 6, 182, 239;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 254, 196, 24;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-latency-0: #542788;
   --color-latency-1: #998ec3;

--- a/plugins/plugin-core-themes/web/scss/solarized-dark.scss
+++ b/plugins/plugin-core-themes/web/scss/solarized-dark.scss
@@ -44,8 +44,15 @@ body[kui-theme='Solarized'] {
 
   --color-base08-rgb: 220, 50, 47;
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: 133, 153, 0;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 74, 160, 222;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 194, 145, 0;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-ui-06: hsla(194, 20%, 20%, 0.8);
 

--- a/plugins/plugin-core-themes/web/scss/tomorrow-night.scss
+++ b/plugins/plugin-core-themes/web/scss/tomorrow-night.scss
@@ -49,8 +49,15 @@ body[kui-theme='tomorrow-night'] {
 
   --color-base08-rgb: 204, 102, 102;
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: 181, 189, 104;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 129, 162, 190;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 240, 198, 116;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-error-cell-bg: var(--color-base0E);
   --color-error-cell-text: var(--color-base00);

--- a/plugins/plugin-core-themes/web/scss/zenburn.scss
+++ b/plugins/plugin-core-themes/web/scss/zenburn.scss
@@ -43,8 +43,15 @@ body[kui-theme='Zenburn'] {
 
   --color-base08-rgb: 220, 163, 163;
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: 95, 127, 95;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: 124, 184, 187;
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: 224, 207, 159;
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-latency-0: #1a9850;
   --color-latency-1: #91cf60;

--- a/plugins/plugin-patternfly4-themes/web/scss/common.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/common.scss
@@ -48,7 +48,9 @@ body.kui--patternfly4[kui-theme-style] {
   --pf-global--palette--blue-100: #bee1f4;
   --pf-global--palette--blue-200: #73bcf7;
   --pf-global--palette--blue-300: #2b9af3;
+  --pf-global--palette--blue-300-rgb: 43, 154, 243;
   --pf-global--palette--blue-400: #06c;
+  --pf-global--palette--blue-400-rgb: 0, 102, 204;
   --pf-global--palette--blue-500: #004080;
   --pf-global--palette--blue-600: #002952;
   --pf-global--palette--blue-700: #001223;
@@ -64,6 +66,7 @@ body.kui--patternfly4[kui-theme-style] {
   --pf-global--palette--gold-100: #f9e0a2;
   --pf-global--palette--gold-200: #f6d173;
   --pf-global--palette--gold-300: #f4c145;
+  --pf-global--palette--gold-300-rgb: 244, 193, 69;
   --pf-global--palette--gold-400: #f0ab00;
   --pf-global--palette--gold-500: #c58c00;
   --pf-global--palette--gold-600: #795600;
@@ -97,6 +100,7 @@ body.kui--patternfly4[kui-theme-style] {
   --pf-global--palette--orange-300: #ec7a08;
   --pf-global--palette--orange-400: #c46100;
   --pf-global--palette--orange-500: #8f4700;
+  --pf-global--palette--orange-500-rgb: 143, 71, 0;
   --pf-global--palette--orange-600: #773d00;
   --pf-global--palette--orange-700: #3b1f00;
   --pf-global--palette--purple-100: #cbc1ff;

--- a/plugins/plugin-patternfly4-themes/web/scss/dark.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/dark.scss
@@ -68,8 +68,15 @@
 
   --color-base08-rgb: var(--pf-global--palette--red-100-rgb);
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: var(--pf-global--palette--green-400-rgb);
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: var(--pf-global--palette--blue-300-rgb);
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: var(--pf-global--palette--gold-300-rgb);
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-light-red: var(--pf-global--palette--red-200);
 

--- a/plugins/plugin-patternfly4-themes/web/scss/light.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/light.scss
@@ -57,8 +57,15 @@
 
   --color-base08-rgb: var(--pf-global--palette--red-100-rgb);
   --color-red-rgb: var(--color-base08-rgb);
+
   --color-base0B-rgb: var(--pf-global--palette--green-500-rgb);
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-base0D-rgb: var(--pf-global--palette--blue-400-rgb);
+  --color-blue-rgb: var(--color-base0D-rgb);
+
+  --color-base0A-rgb: var(--pf-global--palette--orange-500-rgb);
+  --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-background-03: var(--pf-global--palette--black-200);
 


### PR DESCRIPTION
we were using fixed colors before. this pr allows some variation by tip, using one of

??? note "tip title"
??? bug ...
??? success ...
??? warning ...
??? todo ...

![tips](https://user-images.githubusercontent.com/4741620/150452020-66b2d815-2ac6-4c0c-b740-07d6435fc7a5.gif)

the source for this gif is 

```sh
replay https://raw.githubusercontent.com/knative/docs/main/docs/snippets/install-kn.md`
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
