### PR TITLE
fix(plugins/plugin-client-common): wizard nav can be too wide

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
@@ -42,9 +42,14 @@
     flex-direction: row;
   }
   @include WizardNav {
+    width: auto;
     position: unset;
-    min-width: var(--pf-c-wizard__nav--Width);
+    max-width: var(--pf-c-wizard__nav--Width);
   }
+}
+
+@include WizardFooter {
+  justify-content: flex-end;
 }
 
 @include WizardNavItem {

--- a/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
@@ -38,6 +38,12 @@
   }
 }
 
+@mixin WizardFooter {
+  .pf-c-wizard__footer {
+    @content;
+  }
+}
+
 @mixin WizardNav {
   .pf-c-wizard__nav {
     @content;


### PR DESCRIPTION
We can optimize the width/max-width settings here.
Also, perhaps we should flex-end align the footer buttons, to more closely mimic the positioning as done by PatternFly (background: they use absolute positioning of the nav, which forces them to use a fixed width to the nav; apparently, they need to use absolute positioning of the nav, because oddly the footer is not a sibling of the body, but rather a sibling of the nav+body pair. Probably bugs on their side.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
