### PR TITLE
doc: shorten "Linux and Windows" to "Linux/Windows" in welcome.md

### DIFF
--- a/plugins/plugin-client-common/notebooks/welcome.md
+++ b/plugins/plugin-client-common/notebooks/welcome.md
@@ -29,7 +29,7 @@ click**.
     kubectl kui get pods
     ```
 
-=== "Linux and Windows"
+=== "Linux/Windows"
     
     [Kui-Linux-x64.zip](https://linux-zip.kui-shell.org) **|** [Kui-Linux-arm64.zip](https://linux-arm64-zip.kui-shell.org) **|** [Kui-Win32-x64.zip](https://win32-zip.kui-shell.org)
 


### PR DESCRIPTION
not much, but it helps a bit with avoiding overflow after which patternfly's left/right scrolling buttons in the tabs seems to stay stuck on :(

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
