### PR TITLE
fix(plugins/plugin-client-common): escape in playground cancels editor

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -311,7 +311,7 @@ export default class Commentary extends React.PureComponent<Props, State> {
           simple
           wordWrap="on"
           onSave={this._onSaveFromEditor}
-          onCancel={this._onCancelFromEditor}
+          onCancel={!this.isCoupled && this._onCancelFromEditor}
           onContentChange={this._onContentChange}
           contentType="markdown"
           scrollIntoView={false}


### PR DESCRIPTION
it shouldn't, because there is no way to restore the editor

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
