### PR TITLE
11.1.1

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -311,7 +311,7 @@ export default class Commentary extends React.PureComponent<Props, State> {
           simple
           wordWrap="on"
           onSave={this._onSaveFromEditor}
-          onCancel={this._onCancelFromEditor}
+          onCancel={!this.isCoupled && this._onCancelFromEditor}
           onContentChange={this._onContentChange}
           contentType="markdown"
           scrollIntoView={false}


### PR DESCRIPTION
[11.1.1 981941187] fix(plugins/plugin-client-common): escape in playground cancels editor
 Date: Mon Jan 24 19:33:26 2022 -0500
 1 file changed, 1 insertion(+), 1 deletion(-)