### PR TITLE
fix(plugins/plugin-client-common): in some browsers, hovering in wiza…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Wizard/MiniProgressStepper.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/MiniProgressStepper.scss
@@ -31,6 +31,7 @@ $regular: 1rem;
   }
   @include ConnectorUI {
     --pf-c-progress-stepper__step-connector--before--Left: 6px;
+    top: 8px !important; /* ugh, we conflict with the stock PatternFly rules here */
   }
 
   @include ProgressStep {


### PR DESCRIPTION
…rd mini step oddly moves elements

the connector between progress steps shifts down. this is due to some stock patternfly rules overriding ours

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
