### PR TITLE
fix(plugins/plugin-client-common): wizard behaves poorly when empty

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/index.tsx
@@ -86,7 +86,7 @@ export default class Wizard extends React.PureComponent<WizardProps> {
     return (
       <PatternFlyWizard
         hideClose
-        steps={steps}
+        steps={steps.length === 0 ? [{ name: '', component: '' }] : steps}
         className="kui--wizard"
         data-hide-cancel={true}
         footer={this.footer()}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/rehype-wizard.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/rehype-wizard.ts
@@ -109,7 +109,7 @@ function transformer(ast) {
   visitParents(ast, 'element', headingVisitor)
   visitParents(ast, 'element', stepsVisitor)
 
-  if (wizard.steps.length > 0) {
+  if (wizard.steps.length > 0 || wizard.title.trim() || wizard.description) {
     ast.children.push(
       u(
         'element',


### PR DESCRIPTION
renders as blank if there are not steps, but still plenty of content
or if we only have a title but no steps

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
