### PR TITLE
fix(plugins/plugin-client-common): allow code block id to be optional

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code.tsx
@@ -31,6 +31,7 @@ export { CodeBlockResponse }
 
 export default function code(
   mdprops: Props,
+  uuid: string,
   codeBlockResponses: (codeBlockIdx: number) => CodeBlockResponse & { replayed: boolean },
   spliceInCodeExecution: (status: 'done' | 'error', response: KResponse, codeIdx: number) => void
 ) {
@@ -68,6 +69,8 @@ export default function code(
       // TODO: we should also look at the command registration, for the command that was executed
       const outputOnly = attributes.outputOnly === true || attributes.outputOnly === 'true'
 
+      const blockId = attributes.id || `${uuid}-${myCodeIdx}`
+
       return (
         <React.Fragment>
           {attributes.id && <a id={`kui-link-${attributes.id}`} />}
@@ -78,7 +81,7 @@ export default function code(
             value={body}
             watch={attributes.watch}
             language={language}
-            blockId={attributes.id}
+            blockId={blockId}
             validate={attributes.validate === '$body' ? body : attributes.validate}
             response={response}
             status={statusConsideringReplay}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
@@ -49,7 +49,7 @@ function typedComponents(args: Args): Components {
   const a = _a(mdprops, uuid, repl)
   const div = _div(uuid)
   const img = _img(mdprops)
-  const code = _code(mdprops, codeBlockResponses, spliceInCodeExecution)
+  const code = _code(mdprops, uuid, codeBlockResponses, spliceInCodeExecution)
   const heading = _heading(uuid)
 
   return {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -48,7 +48,14 @@ import rehypeRaw from 'rehype-raw'
 import rehypeSlug from 'rehype-slug'
 import { kuiFrontmatter, tryFrontmatter, encodePriorResponses } from './frontmatter'
 
-const rehypePlugins: Options['rehypePlugins'] = [wizard, tabbed, tip, codeIndexer, rehypeRaw, rehypeSlug]
+const rehypePlugins = (uuid: string): Options['rehypePlugins'] => [
+  wizard,
+  tabbed,
+  tip,
+  [codeIndexer, uuid],
+  rehypeRaw,
+  rehypeSlug
+]
 const remarkPlugins: (tab: KuiTab) => Options['remarkPlugins'] = (tab: KuiTab) => [
   gfm,
   [frontmatter, ['yaml', 'toml']],
@@ -223,11 +230,13 @@ export default class Markdown extends React.PureComponent<Props, State> {
     return Object.assign({ replayed }, response)
   }
 
+  private readonly uuid = uuid()
+
   /** This will be the `components` argument to `<ReactMarkdown/>` */
   private readonly _components = components({
     mdprops: this.props,
     repl: this.repl,
-    uuid: uuid(),
+    uuid: this.uuid,
     spliceInCodeExecution: this.spliceInCodeExecution.bind(this),
     codeBlockResponses: this.codeBlockHasBeenReplayed.bind(this)
   })
@@ -293,7 +302,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
         <TextContent>
           <ReactMarkdown
             remarkPlugins={remarkPlugins(this.props.tab)}
-            rehypePlugins={rehypePlugins}
+            rehypePlugins={rehypePlugins(this.uuid)}
             components={this._components()}
             data-is-nested={this.props.nested || undefined}
             className={


### PR DESCRIPTION
We had required a code block id attribute in order for code block validation to function. We can assign one for the user, if not specified.

Also, the validation logic did not re-fire after a source update e.g. in the playground. Fixed

Also added types to the code-indexer rehype plugin.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
