### PR TITLE
fix(plugins/plugin-client-common): saving code block responses is broken

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -186,6 +186,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
     if (filepath && execUUID) {
       const onSnapshot = async () => {
         const codeBlockResponses = this.codeBlockResponses()
+        console.error('!!!!!!!!', codeBlockResponses, this.props.codeBlockResponses, this.state.codeBlockResponses)
         if (codeBlockResponses.find(_ => _ !== undefined)) {
           const stats = (await this.repl.rexec<GlobStats[]>(`vfs ls ${encodeComponent(filepath)}`)).content
 
@@ -209,9 +210,12 @@ export default class Markdown extends React.PureComponent<Props, State> {
    *
    */
   private codeBlockResponses() {
-    return (this.props.codeBlockResponses || [])
-      .slice()
-      .map((fromProps, idx) => this.state.codeBlockResponses[idx] || fromProps)
+    const fromProps = this.props.codeBlockResponses || []
+    const fromState = this.state.codeBlockResponses || []
+
+    return Array(Math.max(fromProps.length, fromState.length))
+      .fill(undefined)
+      .map((_, idx) => fromState[idx] || fromProps[idx])
   }
 
   private codeBlockHasBeenReplayed(codeBlockIdx: number) {


### PR DESCRIPTION
ugh, regression in the way we assemble the list of responses from props and state

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
