### PR TITLE
fix(plugins/plugin-client-common): guidebooks render poorly in big wi…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -167,7 +167,7 @@ body[kui-theme-style] {
   flex: 1;
   display: flex;
   justify-content: flex-start;
-  max-width: 960px;
+  max-width: $max-column-width;
 
   /* This helps with monaco-editor reactive width, e.g. when adding or removing splits */
   min-width: 0;

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
@@ -30,7 +30,7 @@ $margin-for-right-elements: calc(#{math.div(0.875 * $input-padding, $right-eleme
 
 @include Block {
   @include NotEditable {
-    max-width: 960px;
+    max-width: $max-column-width;
   }
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -17,6 +17,9 @@
 @use 'sass:math';
 @import '../ExpandableSection/mixins';
 
+/* For commentary, to avoid super wide lines of text in large windows.  */
+$max-column-width: 66em;
+
 /** Terminal font size */
 $terminal-font-size: 0.875rem;
 

--- a/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
@@ -39,7 +39,7 @@
   }
   @include WizardNav {
     width: auto;
-    min-width: 8rem;
+    min-width: 14rem;
     max-width: 16rem;
     position: unset;
   }


### PR DESCRIPTION
…ndows with large fonts

we are using a fixed 960px in a few places.
also, dangit, but the wizard nav gets too narrow in these cases.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
