### PR TITLE
11.1.3

### DIFF
--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -20,7 +20,7 @@ import { productName } from '@kui-shell/client/config.d/name.json'
 import { Menu, MenuItemConstructorOptions } from 'electron'
 
 import open from './open'
-import saveAsNotebook from './save'
+import saveAsGuidebook from './save'
 import tellRendererToExecute from './tell'
 import { openNotebook, loadClientNotebooksMenuDefinition, clientNotebooksDefinitionToElectron } from './notebooks'
 import { isOfflineClient, isReadOnlyClient } from '..'
@@ -92,8 +92,8 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
         // TODO find exactly what keyboard shortcut => accelerator: 'CommandOrControl+E'
       },
       {
-        label: 'Save as Notebook...',
-        click: saveAsNotebook,
+        label: 'Save as Guidebook',
+        click: saveAsGuidebook,
         accelerator: 'CommandOrControl+S'
       },
       { type: 'separator' },

--- a/packages/core/src/main/save.ts
+++ b/packages/core/src/main/save.ts
@@ -17,7 +17,7 @@
 import tellRendererToExecute from './tell'
 
 /**
- * Save the current tab as a Notebook
+ * Save the current tab as a Guidebook
  *
  */
 export default async function saveAsNotebook() {

--- a/plugins/plugin-client-common/notebooks/code-blocks.md
+++ b/plugins/plugin-client-common/notebooks/code-blocks.md
@@ -11,7 +11,7 @@ Lists](#progress-step-lists).
 echo hello
 ```
 
-<!-- Hello viewers of the source to this notebook! Note that we have
+<!-- Hello viewers of the source to this guidebook! Note that we have
 used a language of `bashy` here, to prevent Kui from rendering this as
 an executable code block. -->
 

--- a/plugins/plugin-client-common/notebooks/make-notebook.md
+++ b/plugins/plugin-client-common/notebooks/make-notebook.md
@@ -1,10 +1,10 @@
 ---
-title: Make Your Own Notebook
+title: Make Your Own Guidebook
 layout:
   1: left
 ---
 
-# Authoring Kui Notebooks
+# Authoring Kui Guidebooks
 
 Kui interprets and displays markdown source. Kui has special
 interpretation for a some of the common bits of markdown syntax,
@@ -23,11 +23,11 @@ allowing you to author:
   guide the user through a list of code executions
   
 In addition, you can define the metadata and structure of your
-notebook:
+guidebook:
 
-- [Set a title](#setting-a-title) for your notebook
+- [Set a title](#setting-a-title) for your guidebook
 - Define the [_split layout_](#creating-a-split-layout) for your
-  notebook
+  guidebook
 
 ---
 
@@ -111,7 +111,7 @@ id: my-first-command
 echo hello
 ```
 
-<!-- Hello viewers of the source to this notebook! Note that we have
+<!-- Hello viewers of the source to this guidebook! Note that we have
 used a language of `bashy` here, to prevent Kui from rendering this as
 an executable code block. -->
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
@@ -17,7 +17,15 @@
 export interface WizardSteps {
   /** An alternate way to define the steps of a wizard layout */
   wizard: {
-    steps: string[]
+    /** Optional subtitle in the wizard header */
+    description?: string
+
+    /**
+     * Specification of the steps, each of which is the name of a
+     * heading in the markdown source. Optionally, a step description
+     * may be overlaid
+     */
+    steps: (string | { name: string; description: string })[]
   }
 }
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface WizardSteps {
+  /** An alternate way to define the steps of a wizard layout */
+  wizard: {
+    steps: string[]
+  }
+}
+
+type KuiFrontmatter = Partial<WizardSteps> & {
+  /** Title of the Notebook */
+  title?: string
+
+  layoutCount?: Record<string, number>
+
+  /**
+   * A mapping that indicates which section (the `number` values) should be rendered in a given split position.
+   */
+  layout?: 'wizard' | Record<number | 'default', SplitPositionSpec>
+}
+
+export function hasWizardSteps(frontmatter: KuiFrontmatter): frontmatter is KuiFrontmatter & Required<WizardSteps> {
+  return (
+    frontmatter.wizard &&
+    frontmatter.wizard.steps &&
+    Array.isArray(frontmatter.wizard.steps) &&
+    frontmatter.wizard.steps.length > 0
+  )
+}
+
+type SplitPosition = 'left' | 'bottom' | 'default' | 'wizard'
+type SplitPositionObj = { position: SplitPosition; placeholder?: string; maximized?: boolean | 'true' | 'false' }
+type SplitPositionSpec = SplitPosition | SplitPositionObj
+
+export type PositionProps = {
+  'data-kui-split': SplitPosition
+}
+
+export function isValidPosition(position: SplitPositionSpec): position is SplitPosition {
+  return (
+    typeof position === 'string' &&
+    (position === 'default' || position === 'left' || position === 'bottom' || position === 'wizard')
+  )
+}
+
+export function isValidPositionObj(position: SplitPositionSpec): position is SplitPositionObj {
+  const pos = position as SplitPositionObj
+  return typeof pos === 'object' && typeof pos.position === 'string'
+}
+
+export default KuiFrontmatter

--- a/plugins/plugin-client-common/src/components/Content/Markdown/codeblocks/encoding.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/codeblocks/encoding.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isCodedError, isWatchable } from '@kui-shell/core'
+import { CodeBlockResponse } from '../components/code'
+
+function stringifyError(response: Error) {
+  return { code: isCodedError(response) ? response.code : 1, message: response.message }
+}
+
+/** Blunt attempt to avoid serializing React bits */
+function reactRedactor(key: string, value: any) {
+  if (key === 'tab') {
+    return undefined
+  } else if (key === 'block') {
+    return undefined
+  } else if (value && typeof value === 'object' && value.constructor === Error) {
+    // the first check guards against typeof null === 'object'
+    return stringifyError(value)
+  } else {
+    return value
+  }
+}
+
+export default function encodePriorResponses(responses: CodeBlockResponse[]): string {
+  return JSON.stringify(
+    responses.map(response => {
+      if (response.response.constructor === Error) {
+        return Object.assign({}, response, { response: stringifyError(response.response) })
+      } else if (isWatchable(response.response)) {
+        delete response.response.watch
+      }
+      return response
+    }),
+    reactRedactor
+  )
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/rehype-wizard.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/rehype-wizard.ts
@@ -17,7 +17,7 @@
 import { u } from 'unist-builder'
 import { visitParents } from 'unist-util-visit-parents'
 
-import { PositionProps } from '../../frontmatter'
+import { PositionProps } from '../../KuiFrontmatter'
 
 interface Primordial {
   title: string

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
@@ -20,7 +20,7 @@ import { TextContent } from '@patternfly/react-core'
 import SplitInjector from '../../../Views/Terminal/SplitInjector'
 import SplitPosition from '../../../Views/Terminal/SplitPosition'
 
-import { PositionProps } from '../frontmatter'
+import { PositionProps } from '../KuiFrontmatter'
 
 import { isWizard } from './Wizard/rehype-wizard'
 const Wizard = React.lazy(() => import('./Wizard'))

--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -46,7 +46,9 @@ import { CodeBlockResponse } from './components/code'
 // react-markdown v6+ now require use of these to support html
 import rehypeRaw from 'rehype-raw'
 import rehypeSlug from 'rehype-slug'
-import { kuiFrontmatter, tryFrontmatter, encodePriorResponses } from './frontmatter'
+
+import encodePriorResponses from './codeblocks/encoding'
+import { kuiFrontmatter, tryFrontmatter } from './frontmatter'
 
 const rehypePlugins = (uuid: string): Options['rehypePlugins'] => [
   wizard,

--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -186,6 +186,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
     if (filepath && execUUID) {
       const onSnapshot = async () => {
         const codeBlockResponses = this.codeBlockResponses()
+        console.error('!!!!!!!!', codeBlockResponses, this.props.codeBlockResponses, this.state.codeBlockResponses)
         if (codeBlockResponses.find(_ => _ !== undefined)) {
           const stats = (await this.repl.rexec<GlobStats[]>(`vfs ls ${encodeComponent(filepath)}`)).content
 
@@ -209,9 +210,12 @@ export default class Markdown extends React.PureComponent<Props, State> {
    *
    */
   private codeBlockResponses() {
-    return (this.props.codeBlockResponses || [])
-      .slice()
-      .map((fromProps, idx) => this.state.codeBlockResponses[idx] || fromProps)
+    const fromProps = this.props.codeBlockResponses || []
+    const fromState = this.state.codeBlockResponses || []
+
+    return Array(Math.max(fromProps.length, fromState.length))
+      .fill(undefined)
+      .map((_, idx) => fromState[idx] || fromProps[idx])
   }
 
   private codeBlockHasBeenReplayed(codeBlockIdx: number) {

--- a/plugins/plugin-client-common/src/test/core/wizards-in-markdown.ts
+++ b/plugins/plugin-client-common/src/test/core/wizards-in-markdown.ts
@@ -59,11 +59,11 @@ const IN2 = {
 const IN3 = {
   input: join(ROOT, 'tests/data/wizard-steps-in-topmatter.md'),
   title: 'Getting Started with Knative',
-  description: '',
+  description: 'WizardDescriptionInTopmatter',
   expectedSplitCount: 1,
   steps: [
     { name: 'Before you begin', body: 'Before you can get started', description: '', codeBlocks: [] },
-    { name: 'Prepare local Kubernetes cluster', body: 'You can use', description: '', codeBlocks: [] }
+    { name: 'Prepare local Kubernetes cluster', body: 'You can use', description: 'TestDescription2', codeBlocks: [] }
   ]
 }
 ;[IN1, IN2, IN3].forEach(markdown => {

--- a/plugins/plugin-client-common/src/test/core/wizards-in-markdown.ts
+++ b/plugins/plugin-client-common/src/test/core/wizards-in-markdown.ts
@@ -54,7 +54,19 @@ const IN2 = {
   steps,
   expectedSplitCount: 2
 }
-;[IN1, IN2].forEach(markdown => {
+
+// make sure we can display wizards in tabs with splits
+const IN3 = {
+  input: join(ROOT, 'tests/data/wizard-steps-in-topmatter.md'),
+  title: 'Getting Started with Knative',
+  description: '',
+  expectedSplitCount: 1,
+  steps: [
+    { name: 'Before you begin', body: 'Before you can get started', description: '', codeBlocks: [] },
+    { name: 'Prepare local Kubernetes cluster', body: 'You can use', description: '', codeBlocks: [] }
+  ]
+}
+;[IN1, IN2, IN3].forEach(markdown => {
   describe(`wizards in markdown ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
     ''}`, function(this: Common.ISuite) {
     before(Common.before(this))

--- a/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md
+++ b/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md
@@ -1,8 +1,10 @@
 ---
 wizard:
+    description: WizardDescriptionInTopmatter
     steps:
         - Before you begin
-        - Prepare local Kubernetes cluster
+        - name: Prepare local Kubernetes cluster
+          description: TestDescription2
         - Install the Kubernetes CLI
         - Install the Knative CLI
         - Install the Knative "Quickstart" environment

--- a/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md
+++ b/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md
@@ -1,0 +1,11 @@
+---
+wizard:
+    steps:
+        - Before you begin
+        - Prepare local Kubernetes cluster
+        - Install the Kubernetes CLI
+        - Install the Knative CLI
+        - Install the Knative "Quickstart" environment
+---
+
+--8<-- "https://raw.githubusercontent.com/knative/docs/main/docs/getting-started/README.md"

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -167,7 +167,7 @@ body[kui-theme-style] {
   flex: 1;
   display: flex;
   justify-content: flex-start;
-  max-width: 960px;
+  max-width: $max-column-width;
 
   /* This helps with monaco-editor reactive width, e.g. when adding or removing splits */
   min-width: 0;

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
@@ -30,7 +30,7 @@ $margin-for-right-elements: calc(#{math.div(0.875 * $input-padding, $right-eleme
 
 @include Block {
   @include NotEditable {
-    max-width: 960px;
+    max-width: $max-column-width;
   }
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -17,6 +17,9 @@
 @use 'sass:math';
 @import '../ExpandableSection/mixins';
 
+/* For commentary, to avoid super wide lines of text in large windows.  */
+$max-column-width: 66em;
+
 /** Terminal font size */
 $terminal-font-size: 0.875rem;
 

--- a/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
@@ -39,7 +39,7 @@
   }
   @include WizardNav {
     width: auto;
-    min-width: 8rem;
+    min-width: 14rem;
     max-width: 16rem;
     position: unset;
   }

--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -1,12 +1,12 @@
 {
-  "label": "Notebooks",
+  "label": "Guidebooks",
   "submenu": [
     {
       "label": "Kui",
       "submenu": [
         { "notebook": "Welcome to Kui", "filepath": "/kui/welcome.md" },
-        { "notebook": "Notebook Playground", "filepath": "/kui/playground.md" },
-        { "notebook": "Make Your Own Notebook", "filepath": "/kui/make-notebook.md" }
+        { "notebook": "Guidebook Playground", "filepath": "/kui/playground.md" },
+        { "notebook": "Making a Guidebook", "filepath": "/kui/make-notebook.md" }
       ]
     },
     {

--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -24,6 +24,10 @@
         { "notebook": "Welcome to Iter8", "filepath": "/kui/iter8/welcome.md" },
         { "notebook": "Tutorial 1", "filepath": "/kui/iter8/tutorial1.md" }
       ]
+    },
+    {
+      "label": "Knative",
+      "submenu": [{ "notebook": "Getting Started", "filepath": "/kui/kubernetes/knative-getting-started.md" }]
     }
   ]
 }

--- a/plugins/plugin-kubectl/notebooks/knative-getting-started.md
+++ b/plugins/plugin-kubectl/notebooks/knative-getting-started.md
@@ -1,0 +1,14 @@
+---
+wizard:
+    steps:
+        - Before you begin
+        - Prepare local Kubernetes cluster
+        - Install the Kubernetes CLI
+        - Install the Knative CLI
+        - name: Install the Knative "Quickstart" environment
+          description: The kn quickstart plugin can quickly set up Knative against kind of minikube
+---
+
+<!-- This is a demonstration of including unmodified markdown content, and overlaying a wizard -->
+
+--8<-- "https://raw.githubusercontent.com/knative/docs/main/docs/getting-started/README.md"

--- a/plugins/plugin-kubectl/src/non-headless-preload.ts
+++ b/plugins/plugin-kubectl/src/non-headless-preload.ts
@@ -74,6 +74,7 @@ export default async (registrar: PreloadRegistrar) => {
   notebookVFS.cp(
     undefined,
     [
+      'plugin://plugin-kubectl/notebooks/knative-getting-started.md',
       'plugin://plugin-kubectl/notebooks/create-jobs.md',
       'plugin://plugin-kubectl/notebooks/create-jobs.json',
       'plugin://plugin-kubectl/notebooks/crud-operations.md',


### PR DESCRIPTION
[11.1.3 dd9257fbe] fix(plugins/plugin-client-common): saving code block responses is broken
 Date: Thu Jan 27 09:13:01 2022 -0500
 1 file changed, 7 insertions(+), 3 deletions(-)

[11.1.3 815c376e5] chore: some updates to improve consistency of terminology "guidebook" versus "notebook"
 Date: Thu Jan 27 09:24:10 2022 -0500
 5 files changed, 14 insertions(+), 14 deletions(-)

[11.1.3 9f87d6a28] feat(plugins/plugin-client-common): allow wizard steps to be specified in topmatter
 Date: Thu Jan 27 13:33:31 2022 -0500
 8 files changed, 335 insertions(+), 204 deletions(-)
 create mode 100644 plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
 create mode 100644 plugins/plugin-client-common/src/components/Content/Markdown/codeblocks/encoding.ts
 rewrite plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx (71%)
 create mode 100644 plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md

[11.1.3 f56232ea2] fix(plugins/plugin-client-common): guidebooks render poorly in big windows with large fonts
 Date: Thu Jan 27 14:28:54 2022 -0500
 4 files changed, 6 insertions(+), 3 deletions(-)

[11.1.3 9fd245d38] feat(plugins/plugin-client-common): allow topmatter wizard steps to define a step description
 Date: Thu Jan 27 14:47:53 2022 -0500
 4 files changed, 47 insertions(+), 17 deletions(-)

[11.1.3 f52061169] first draft of knative guidebook integration
 Author: Maria Camila Ruiz Cardenas <Maria.ruiz.cardenas@ibm.com>
 Date: Thu Jan 27 10:37:19 2022 -0500
 3 files changed, 19 insertions(+)
 create mode 100644 plugins/plugin-kubectl/notebooks/knative-getting-started.md