### PR TITLE
fix: fetchfile controller refuses any in-browser fetch, even if CORS …

### DIFF
--- a/plugins/plugin-client-common/notebook/src/load.ts
+++ b/plugins/plugin-client-common/notebook/src/load.ts
@@ -24,7 +24,7 @@ export async function loadNotebook(
 ): Promise<string | object> {
   try {
     if (/^https:/.test(filepath)) {
-      return (await REPL.rexec<(string | object)[]>(`_fetchfile ${encodeComponent(filepath)}`)).content[0]
+      return (await REPL.rexec<(string | object)[]>(`vfs _fetchfile ${encodeComponent(filepath)}`)).content[0]
     } else {
       //   --with-data says give us the file contents
       const fullpath = Util.absolute(Util.expandHomeDir(filepath))

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -129,6 +129,7 @@ interface FetchOptions<Data extends BodyData | BodyData[]> {
   data?: Data
   headers?: Record<string, string>
   method?: 'get' | 'put' | 'post' | 'delete'
+  tryFetchEvenInBrowser?: boolean
 }
 
 export async function _needle(
@@ -137,7 +138,7 @@ export async function _needle(
   opts?: FetchOptions<BodyData>,
   retryCount = 0
 ): Promise<{ statusCode: number; body: string | object }> {
-  if (!Capabilities.inBrowser()) {
+  if (!Capabilities.inBrowser() || (opts && opts.tryFetchEvenInBrowser)) {
     const method = (opts && opts.method) || 'get'
     const headers = Object.assign({ connection: 'keep-alive' }, opts.headers)
     debug('fetch via needle', method, headers, url)


### PR DESCRIPTION
…would allow it

We should just try the network request, and let the browser fail it for us, rather than trying to be smart, here.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
