### PR TITLE
feat: allow markdown guidebooks to define code block metadata in topm…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
@@ -29,17 +29,26 @@ export interface WizardSteps {
   }
 }
 
-type KuiFrontmatter = Partial<WizardSteps> & {
-  /** Title of the Notebook */
-  title?: string
-
-  layoutCount?: Record<string, number>
-
-  /**
-   * A mapping that indicates which section (the `number` values) should be rendered in a given split position.
-   */
-  layout?: 'wizard' | Record<number | 'default', SplitPositionSpec>
+interface CodeBlocks {
+  codeblocks: {
+    match: string
+    language?: string
+    validate?: string
+  }[]
 }
+
+type KuiFrontmatter = Partial<WizardSteps> &
+  Partial<CodeBlocks> & {
+    /** Title of the Notebook */
+    title?: string
+
+    layoutCount?: Record<string, number>
+
+    /**
+     * A mapping that indicates which section (the `number` values) should be rendered in a given split position.
+     */
+    layout?: 'wizard' | Record<number | 'default', SplitPositionSpec>
+  }
 
 export function hasWizardSteps(frontmatter: KuiFrontmatter): frontmatter is KuiFrontmatter & Required<WizardSteps> {
   return (
@@ -48,6 +57,10 @@ export function hasWizardSteps(frontmatter: KuiFrontmatter): frontmatter is KuiF
     Array.isArray(frontmatter.wizard.steps) &&
     frontmatter.wizard.steps.length > 0
   )
+}
+
+export function hasCodeBlocks(frontmatter: KuiFrontmatter): frontmatter is KuiFrontmatter & Required<CodeBlocks> {
+  return frontmatter.codeblocks && Array.isArray(frontmatter.codeblocks) && frontmatter.codeblocks.length > 0
 }
 
 type SplitPosition = 'left' | 'bottom' | 'default' | 'wizard'

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Node } from 'hast'
+import { Code } from 'mdast'
+import { visit } from 'unist-util-visit'
+
+import { tryFrontmatter } from '../../frontmatter'
+import KuiFrontmatter, { hasCodeBlocks } from '../../KuiFrontmatter'
+
+function isCode(node: Node): node is Code {
+  return node.type === 'code' && typeof (node as Code).value === 'string'
+}
+
+/** Scan and process the `codeblocks` schema of the given `frontmatter` */
+export default function preprocessCodeBlocks(tree /*: Root */, frontmatter: KuiFrontmatter) {
+  if (hasCodeBlocks(frontmatter)) {
+    const codeblocks = frontmatter.codeblocks.map(_ => Object.assign({}, _, { match: new RegExp(_.match) }))
+
+    visit(tree, 'code', node => {
+      if (isCode(node)) {
+        const matched = codeblocks.find(_ => _.match.test(node.value))
+        if (matched) {
+          if (matched.language) {
+            // smash in a code block language (this would be the ```${language} part of the text)
+            node.lang = matched.language
+          }
+          if (matched.validate) {
+            // smash in validation logic; this is done in the
+            // topmatter of the code block, and parsed out by rehype-code-indexer
+            const { body, attributes } = tryFrontmatter(node.value)
+            attributes.validate = matched.validate
+            node.value = `
+---
+${require('js-yaml').dump(attributes)}
+---
+${body}
+`
+          }
+        }
+      }
+    })
+  }
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
@@ -22,6 +22,7 @@ import { visitParents } from 'unist-util-visit-parents'
 
 import { Tab } from '@kui-shell/core'
 
+import preprocessCodeBlocks from './components/code/remark-codeblocks-topmatter'
 import KuiFrontmatter, { hasWizardSteps, isValidPosition, isValidPositionObj } from './KuiFrontmatter'
 
 export function tryFrontmatter(
@@ -204,6 +205,7 @@ export function kuiFrontmatter(opts: { tab: Tab }) {
         setTimeout(() => opts.tab.setTitle(frontmatter.title))
       }
 
+      preprocessCodeBlocks(tree, frontmatter)
       preprocessWizardSteps(tree, frontmatter)
       extractSplitsAndSections(tree, frontmatter)
     }

--- a/plugins/plugin-client-common/tests/data/code-block1-base.md
+++ b/plugins/plugin-client-common/tests/data/code-block1-base.md
@@ -1,0 +1,11 @@
+Hello world
+
+```
+echo hi
+```
+
+Goodbye
+
+<!-- NOTE: this markdown intentionally has no language or validation,
+as we will overlay that in the topmatter in markdowns that include
+this one -->

--- a/plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter-via-snippet.md
+++ b/plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter-via-snippet.md
@@ -1,0 +1,8 @@
+---
+codeblocks:
+    - match: ^echo hi$
+      language: bash
+      validate: true
+---
+
+--8<-- "code-block1-base.md"

--- a/plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter.md
+++ b/plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter.md
@@ -1,0 +1,14 @@
+---
+codeblocks:
+    - match: ^echo hi$
+      language: bash
+      validate: true
+---
+
+Hello world
+
+```
+echo hi
+```
+
+Goodbye

--- a/plugins/plugin-client-common/tests/data/code-block1.md
+++ b/plugins/plugin-client-common/tests/data/code-block1.md
@@ -1,6 +1,9 @@
 Hello world
 
 ```bash
+---
+validate: true
+---
 echo hi
 ```
 

--- a/plugins/plugin-kubectl/notebooks/knative-getting-started.md
+++ b/plugins/plugin-kubectl/notebooks/knative-getting-started.md
@@ -1,13 +1,19 @@
 ---
+title: Knative &mdash; Getting Started
 wizard:
     description: Kubernetes-based platform to deploy and manage modern serverless workloads
     steps:
         - Before you begin
-        - Prepare local Kubernetes cluster
+        - name: Prepare local Kubernetes cluster
+          description: Using kind or minikube can help you isolate your Knative learning experiments.
         - Install the Kubernetes CLI
         - Install the Knative CLI
         - name: Install the Knative "Quickstart" environment
           description: The kn quickstart plugin can quickly set up Knative against kind of minikube
+codeblocks:
+    - language: bash
+      match: ^brew install kn$
+      validate: brew info kn
 ---
 
 --8<-- "https://raw.githubusercontent.com/knative/docs/main/docs/getting-started/README.md"


### PR DESCRIPTION
…atter

this also updates the knative guidebook to use that feature; and coincidentally adds a guidebook title to its metadata

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
