### PR TITLE
fix(plugins/plugin-client-common): avoid pre-wrap in guidebook paragr…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -34,6 +34,17 @@ $box-shadow-margin: 4px; /* room for box shadow */
   }
 }
 
+@mixin CodeBlock {
+  .kui--code-block-in-markdown {
+    @content;
+  }
+}
+@mixin CodeBlockActions {
+  .kui--code-block-actions {
+    @content;
+  }
+}
+
 body[kui-theme-style] {
   @include TextContent {
     color: inherit;
@@ -292,12 +303,6 @@ body[kui-theme-style='light'] {
 }
 
 @include Commentary {
-  /* .marked-content {
-    pre {
-      margin: 0;
-    }
-  } */
-
   @include WizardHeader {
     margin-right: $box-shadow-margin; /* room for box shadow */
   }
@@ -305,6 +310,10 @@ body[kui-theme-style='light'] {
     font-size: 0.875rem;
     margin-right: $box-shadow-margin; /* room for box shadow */
   }
+  @include CodeBlock {
+    margin-right: $box-shadow-margin; /* room for box shadow */
+  }
+
   @include ExpandableSectionContent {
     margin-top: 1em;
     max-width: unset;
@@ -436,23 +445,20 @@ body[kui-theme-style='dark'] {
   }
 }
 
-@mixin CodeBlock {
-  .kui--code-block-in-markdown {
-    @content;
-  }
-}
-@mixin CodeBlockActions {
-  .kui--code-block-actions {
-    @content;
-  }
-}
-
 /** Markdown-rendered content not in a Commentary */
 pre {
   @include TextContent {
     font-size: inherit;
     p {
       white-space: pre-wrap;
+    }
+  }
+}
+@include Commentary {
+  @include TextContent {
+    p {
+      /* See the white-space: pre-wrap rule just above */
+      white-space: normal;
     }
   }
 }


### PR DESCRIPTION
…aphs

bug in the css

Also, add the box shadow margin hack to code blocks, to further the right-alignment work.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
