### PR TITLE
Revert "chore: add remark-terms dependence (no other changes)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13430,11 +13430,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark-terms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/remark-terms/-/remark-terms-2.1.2.tgz",
-      "integrity": "sha512-1niSRiVokIion62xBJ+Jbe5kvH7P4ZnAMCNBSzgXHv9mCHFrHFk9N2+AeJ/LcPQjDtTXRg3dYtWpZtB8Y9rP8g=="
-    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -17755,7 +17750,7 @@
     },
     "packages/builder": {
       "name": "@kui-shell/builder",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -17779,7 +17774,7 @@
     },
     "packages/core": {
       "name": "@kui-shell/core",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/remote": "2.0.1",
@@ -17816,7 +17811,7 @@
     },
     "packages/proxy": {
       "name": "@kui-shell/proxy",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -17829,7 +17824,7 @@
     },
     "packages/react": {
       "name": "@kui-shell/react",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "17.0.2",
@@ -17838,7 +17833,7 @@
     },
     "packages/test": {
       "name": "@kui-shell/test",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17848,7 +17843,7 @@
     },
     "packages/webpack": {
       "name": "@kui-shell/webpack",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17925,7 +17920,7 @@
     },
     "plugins/plugin-bash-like": {
       "name": "@kui-shell/plugin-bash-like",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kui-shell/xterm-helpers": "1.0.1",
@@ -17967,12 +17962,12 @@
     },
     "plugins/plugin-carbon-themes": {
       "name": "@kui-shell/plugin-carbon-themes",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-client-common": {
       "name": "@kui-shell/plugin-client-common",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-charts": "6.34.1",
@@ -17991,7 +17986,6 @@
         "remark-emoji": "3.0.2",
         "remark-frontmatter": "4.0.1",
         "remark-gfm": "3.0.1",
-        "remark-terms": "2.1.2",
         "spinkit": "2.0.1",
         "string-similarity-coloring": "1.0.12",
         "tmp": "0.2.1",
@@ -18002,12 +17996,12 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-core-support": {
       "name": "@kui-shell/plugin-core-support",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/remote": "2.0.1",
@@ -18036,12 +18030,12 @@
     },
     "plugins/plugin-core-themes": {
       "name": "@kui-shell/plugin-core-themes",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-electron-components": {
       "name": "@kui-shell/plugin-electron-components",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/remote": "2.0.1"
@@ -18049,7 +18043,7 @@
     },
     "plugins/plugin-git": {
       "name": "@kui-shell/plugin-git",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "strip-ansi": "6.0.0"
@@ -18076,7 +18070,7 @@
     },
     "plugins/plugin-iter8": {
       "name": "@kui-shell/plugin-iter8",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "dependencies": {
         "apexcharts": "3.30.0",
         "js-yaml": "4.1.0",
@@ -18086,7 +18080,7 @@
     },
     "plugins/plugin-kubectl": {
       "name": "@kui-shell/plugin-kubectl",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kui-shell/jsonpath": "1.1.1",
@@ -18119,17 +18113,17 @@
     },
     "plugins/plugin-patternfly4-themes": {
       "name": "@kui-shell/plugin-patternfly4-themes",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-proxy-support": {
       "name": "@kui-shell/plugin-proxy-support",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-s3": {
       "name": "@kui-shell/plugin-s3",
-      "version": "11.1.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "common-path-prefix": "3.0.0",
@@ -18673,7 +18667,6 @@
         "remark-emoji": "3.0.2",
         "remark-frontmatter": "4.0.1",
         "remark-gfm": "3.0.1",
-        "remark-terms": "2.1.2",
         "spinkit": "2.0.1",
         "string-similarity-coloring": "1.0.12",
         "tmp": "0.2.1",
@@ -28482,11 +28475,6 @@
         "mdast-util-to-hast": "^12.1.0",
         "unified": "^10.0.0"
       }
-    },
-    "remark-terms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/remark-terms/-/remark-terms-2.1.2.tgz",
-      "integrity": "sha512-1niSRiVokIion62xBJ+Jbe5kvH7P4ZnAMCNBSzgXHv9mCHFrHFk9N2+AeJ/LcPQjDtTXRg3dYtWpZtB8Y9rP8g=="
     },
     "renderkid": {
       "version": "3.0.0",

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -37,7 +37,6 @@
     "remark-emoji": "3.0.2",
     "remark-frontmatter": "4.0.1",
     "remark-gfm": "3.0.1",
-    "remark-terms": "2.1.2",
     "spinkit": "2.0.1",
     "string-similarity-coloring": "1.0.12",
     "tmp": "0.2.1",


### PR DESCRIPTION
Reverts kubernetes-sigs/kui#8535

ugh, this remark plugin is not maintained, and broken with the latest release of react-markdown.