### PR TITLE
feat(plugins/plugin-client-common): support for markdown `<mark>` and…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -28,6 +28,12 @@ const ReactMarkdown = React.lazy(() => import('react-markdown'))
 // GitHub Flavored Markdown plugin; see https://github.com/IBM/kui/issues/6563
 import gfm from 'remark-gfm'
 
+// ==foo== -> <mark>foo</mark>
+import hackMarks from './remark-mark'
+
+// ++ctrl+alt+delete++== -> <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>delete</kbd>
+import hackKeys from './remark-keys'
+
 import inlineSnippets from '../../../controller/snippets'
 
 import emojis from 'remark-emoji'
@@ -63,6 +69,7 @@ const remarkPlugins: (tab: KuiTab) => Options['remarkPlugins'] = (tab: KuiTab) =
   gfm,
   [frontmatter, ['yaml', 'toml']],
   [kuiFrontmatter, { tab }],
+
   emojis // [emojis, { emoticon: true }]
 ]
 
@@ -189,7 +196,6 @@ export default class Markdown extends React.PureComponent<Props, State> {
     if (filepath && execUUID) {
       const onSnapshot = async () => {
         const codeBlockResponses = this.codeBlockResponses()
-        console.error('!!!!!!!!', codeBlockResponses, this.props.codeBlockResponses, this.state.codeBlockResponses)
         if (codeBlockResponses.find(_ => _ !== undefined)) {
           const stats = (await this.repl.rexec<GlobStats[]>(`vfs ls ${encodeComponent(filepath)}`)).content
 
@@ -270,7 +276,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
    * syntax from pymdown (such as target=_blank for links).
    */
   private static hackSource(source: string) {
-    return hackIndentation(source)
+    return hackKeys(hackMarks(hackIndentation(source)))
       .trim()
       .replace(/\){target=[^}]+}/g, ')')
   }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/remark-keys.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/remark-keys.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const RE_KEY = /\+\+([^+]+)(\+([^+]+))*\+\+/g
+
+/**
+ * Allows us to support pymdown's `++ctrl+alt+delete` which they
+ * transform to HTML5 <kbd>...</kbd>.
+ */
+export default function plugin(markdownText: string) {
+  return markdownText.replace(RE_KEY, match => {
+    return (
+      '<span class="kui--markdown-keys">' +
+      match
+        .split(/\+/)
+        .filter(Boolean)
+        .map(_ => _.replace(/^"(.+)"$/, '$1'))
+        .map(_ => `<kbd class="kui--markdown-key--${_}">${_}</kbd>`)
+        .join('<span>+</span>') +
+      '</span>'
+    )
+  })
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const RE_MARK = /([^=])?==([^=]+)==([^=])/g
+
+/**
+ * Allows us to support pymdown's `==hello==` which they transform to
+ * HTML5 <mark>hello</mark> which seems to generally be presented with
+ * highlighter background.
+ */
+export default function plugin(markdownText: string) {
+  return markdownText.replace(RE_MARK, '$1<mark>$2</mark>$3')
+}

--- a/plugins/plugin-client-common/src/test/core/markdown/kbd.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/kbd.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename, dirname, join } from 'path'
+import { Common, CLI } from '@kui-shell/test'
+import { encodeComponent } from '@kui-shell/core'
+
+const ROOT = join(dirname(require.resolve('@kui-shell/plugin-client-common/tests/data/kbdtag1.md')), '..')
+
+const IN1 = {
+  input: join(ROOT, 'data/kbdtag1.md'),
+  kbds: ['.']
+}
+
+const IN2 = {
+  input: join(ROOT, 'data/kbdtag2.md'),
+  kbds: IN1.kbds
+}
+
+const IN3 = {
+  input: join(ROOT, 'data/kbdtag3.md'),
+  kbds: ['Ctrl', 'Alt', 'Delete']
+}
+;[IN1, IN2, IN3].forEach(markdown => {
+  describe(`kbd tags in markdown ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
+    ''}`, function(this: Common.ISuite) {
+    before(Common.before(this))
+    after(Common.after(this))
+
+    it(`should load markdown and show ${markdown.kbds.length} kbd tags`, async () => {
+      try {
+        await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
+        await this.app.client.waitUntil(async () => {
+          const kbds = await this.app.client.$$('kbd')
+          return kbds.length === markdown.kbds.length
+        })
+
+        await Promise.all(
+          markdown.kbds.map(async kbd => {
+            await this.app.client.waitUntil(async () => {
+              const kbds = await this.app.client.$$('kbd')
+              const texts = await Promise.all(kbds.map(_ => _.getText()))
+              return texts.includes(kbd)
+            })
+          })
+        )
+      } catch (err) {
+        await Common.oops(this, true)(err)
+      }
+    })
+  })
+})

--- a/plugins/plugin-client-common/src/test/core/markdown/mark.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/mark.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename, dirname, join } from 'path'
+import { Common, CLI } from '@kui-shell/test'
+import { encodeComponent } from '@kui-shell/core'
+
+const ROOT = join(dirname(require.resolve('@kui-shell/plugin-client-common/tests/data/marktag1.md')), '..')
+
+const IN1 = {
+  input: join(ROOT, 'data/marktag1.md'),
+  marks: ['Markymark']
+}
+
+const IN2 = {
+  input: join(ROOT, 'data/marktag2.md'),
+  marks: ['Morkymork', 'Markymark']
+}
+;[IN1, IN2].forEach(markdown => {
+  describe(`mark tags in markdown ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
+    ''}`, function(this: Common.ISuite) {
+    before(Common.before(this))
+    after(Common.after(this))
+
+    it(`should load markdown and show ${markdown.marks.length} mark tags`, async () => {
+      try {
+        await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
+        await this.app.client.waitUntil(async () => {
+          const marks = await this.app.client.$$('mark')
+          return marks.length === markdown.marks.length
+        })
+
+        await Promise.all(
+          markdown.marks.map(async mark => {
+            await this.app.client.waitUntil(async () => {
+              const marks = await this.app.client.$$('mark')
+              const texts = await Promise.all(marks.map(_ => _.getText()))
+              return texts.includes(mark)
+            })
+          })
+        )
+      } catch (err) {
+        await Common.oops(this, true)(err)
+      }
+    })
+  })
+})

--- a/plugins/plugin-client-common/tests/data/kbdtag1.md
+++ b/plugins/plugin-client-common/tests/data/kbdtag1.md
@@ -1,0 +1,3 @@
+++.++
+
+That should render as one `<kbd>.</kbd>` tag.

--- a/plugins/plugin-client-common/tests/data/kbdtag2.md
+++ b/plugins/plugin-client-common/tests/data/kbdtag2.md
@@ -1,0 +1,4 @@
+++"."++
+
+That should render as one `<kbd>.</kbd>` tag. Note that it is expected
+for the quotes to vanish.

--- a/plugins/plugin-client-common/tests/data/kbdtag3.md
+++ b/plugins/plugin-client-common/tests/data/kbdtag3.md
@@ -1,0 +1,4 @@
+++ctrl+alt+delete++
+
+That should render as three `<kbd/>` tags, and with the text rendered
+as capitalized.

--- a/plugins/plugin-client-common/tests/data/marktag1.md
+++ b/plugins/plugin-client-common/tests/data/marktag1.md
@@ -1,0 +1,5 @@
+==Markymark==
+
+That should render has a `<mark>...</mark>`. This file allows testing
+the case where the mark at the very start of the file. Do not change
+this.

--- a/plugins/plugin-client-common/tests/data/marktag2.md
+++ b/plugins/plugin-client-common/tests/data/marktag2.md
@@ -1,0 +1,6 @@
+==Morkymork==
+==Markymark==
+
+That should render has a `<mark>...</mark>`. This file allows testing
+the case where the mark at the very start of the file. Do not change
+the location of the MorkyMork tag.

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -24,6 +24,7 @@
 @import '../ExpandableSection/mixins';
 @import '../../Themes/mixins';
 @import 'BlockLinks';
+@import 'Keys';
 
 $marginTop: 0.5em;
 $box-shadow-margin: 4px; /* room for box shadow */

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Keys.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Keys.scss
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import 'mixins';
+
+@include Commentary {
+  kbd {
+    background-color: var(--color-base01);
+    border-radius: 0.1rem;
+    box-shadow: 0 0.1rem 0 0.05rem var(--color-base02), 0 0.1rem 0 var(--color-base02),
+      0 -0.1rem 0.2rem var(--color-base02) inset;
+    display: inline-block;
+    font-size: 0.75em;
+    padding: 0 0.6666666667em;
+    vertical-align: text-top;
+    word-break: break-word;
+  }
+
+  .kui--markdown-keys span {
+    color: var(--color-text-02);
+    padding: 0 0.2em;
+  }
+}
+
+@mixin SpecialKey($key) {
+  text-transform: capitalize;
+
+  &:before {
+    content: $key;
+    padding-right: 0.4em;
+  }
+}
+
+.kui--markdown-key--ctrl,
+.kui--markdown-key--control,
+.kui--markdown-key--Ctrl,
+.kui--markdown-key--Control {
+  @include SpecialKey('⌃');
+}
+
+.kui--markdown-key--alt,
+.kui--markdown-key--Alt {
+  @include SpecialKey('⎇');
+}
+
+.kui--markdown-key--del,
+.kui--markdown-key--Del,
+.kui--markdown-key--delete,
+.kui--markdown-key--Delete {
+  @include SpecialKey('⌦');
+}
+
+.kui--markdown-key--cmd,
+.kui--markdown-key--Cmd,
+.kui--markdown-key--command,
+.kui--markdown-key--Command {
+  @include SpecialKey('⌘');
+}


### PR DESCRIPTION
… `<kbd>` syntax

`<mark>` uses the `==` syntax from pymdown https://facelessuser.github.io/pymdown-extensions/extensions/mark/
`<kbd>` uses the `++` syntax from pymdown https://facelessuser.github.io/pymdown-extensions/extensions/keys/

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
