### PR TITLE
fix(Plugins/plugin-client-common): saving guidebook fails with subset…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/encoding.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/encoding.ts
@@ -38,7 +38,9 @@ function reactRedactor(key: string, value: any) {
 export default function encodePriorResponses(responses: CodeBlockResponse[]): string {
   return JSON.stringify(
     responses.map(response => {
-      if (response.response.constructor === Error) {
+      if (typeof response === 'undefined') {
+        return response
+      } else if (response.response.constructor === Error) {
         return Object.assign({}, response, { response: stringifyError(response.response) })
       } else if (isWatchable(response.response)) {
         delete response.response.watch


### PR DESCRIPTION
… of responses

e.g. if the guidebook has 4 code blocks, and you are saving 3 or those 4, but the 4th has yet to be executed

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
