### PR TITLE
feat: `<Kui/>` component should automate more of guidebook mounting

### DIFF
--- a/packages/builder/bin/prescan.sh
+++ b/packages/builder/bin/prescan.sh
@@ -36,3 +36,12 @@ if [ -f ./node_modules/@kui-shell/builder/dist/bin/compile.js ]; then
     echo "compiling plugin registry $CLIENT_HOME"
     node ./node_modules/@kui-shell/builder/dist/bin/compile.js
 fi
+
+# generate the index.json in @kui-shell/client/notebooks/index.json
+if [ -d node_modules/@kui-shell/client/notebooks ]; then
+    echo "Generating client-guidebooks.json"
+    if [ ! -d node_modules/@kui-shell/build/ ]; then
+        mkdir node_modules/@kui-shell/build
+    fi
+    (echo -n "["; for file in node_modules/@kui-shell/client/notebooks/*.{md,json}; do echo -n "\"$(basename $file)\","; done; echo -n "]") | sed 's/\,]/]/' > node_modules/@kui-shell/build/client-guidebooks.json
+fi

--- a/packages/core/src/api/Client.ts
+++ b/packages/core/src/api/Client.ts
@@ -17,6 +17,8 @@
 import Debug from 'debug'
 const debug = Debug('core/api/client')
 
+import loadClientNotebooksMenuDefinition, { isMenu, isLeaf } from '../main/load'
+
 /** Is the current client running in offline/disconnected mode? */
 export function isOfflineClient(): boolean {
   try {
@@ -31,6 +33,10 @@ export function isOfflineClient(): boolean {
     debug('Client did not define an offline status, assuming not offline')
     return false
   }
+}
+
+export function isOffline() {
+  return isOfflineClient()
 }
 
 /** Is the current client running in readonly mode? */
@@ -49,6 +55,10 @@ export function isReadOnlyClient(): boolean {
   }
 }
 
+export function isReadOnly() {
+  return isReadOnlyClient()
+}
+
 /** Is the current client running in an executable mode? */
 export function isExecutableClient(): boolean {
   try {
@@ -63,6 +73,10 @@ export function isExecutableClient(): boolean {
     debug('Client did not define an executable status, assuming executable')
     return true
   }
+}
+
+export function isExecutable() {
+  return isExecutableClient()
 }
 
 export function hideReplayOutput(): boolean {
@@ -86,6 +100,68 @@ export function executeSequentially(): boolean {
       return false
     }
   } else {
+    return false
+  }
+}
+
+/** @return the model specified by `@kui-shell/client/config.d/notebooks.json` */
+export function guidebooksMenu() {
+  const model = loadClientNotebooksMenuDefinition()
+  if (model) {
+    return model.submenu
+  }
+}
+
+/** @return first guidebook from Client.guidebooksMenu() with an `open` property */
+export function firstOpenGuidebook(): string {
+  const scan = (menu: ReturnType<typeof guidebooksMenu>): string => {
+    for (let idx = 0; idx < menu.length; idx++) {
+      const item = menu[idx]
+      if (isLeaf(item) && item.open) {
+        return item.filepath
+      } else if (isMenu(item)) {
+        const found = scan(item.submenu)
+        if (found) {
+          return found
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  return scan(guidebooksMenu())
+}
+
+/** @return a list of guidebook filepaths that `@kui-shell/client` offers */
+export function clientGuidebooks(): string[] {
+  try {
+    const guidebooks = require('@kui-shell/build/client-guidebooks.json')
+    if (!Array.isArray(guidebooks) || !guidebooks.every(_ => typeof _ === 'string')) {
+      debug('Client did not properly define guidebooks', guidebooks)
+    } else {
+      return guidebooks
+    }
+  } catch (err) {
+    debug('Client did not define any guidebooks')
+    return []
+  }
+}
+
+/** @return whether to show the Sidebar onload */
+export function showGuidebooksSidebar(): boolean {
+  try {
+    return require('@kui-shell/client/config.d/client.json').showGuidebooksSidebar
+  } catch (err) {
+    return false
+  }
+}
+
+/** @return whether to present guidebooks one-at-a-time */
+export function singletonGuidebooks(): boolean {
+  try {
+    return require('@kui-shell/client/config.d/client.json').singletonGuidebooks
+  } catch (err) {
     return false
   }
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -28,3 +28,6 @@ export { Settings }
 
 import * as Capabilities from './Capabilities'
 export { Capabilities }
+
+import * as Client from './Client'
+export { Client }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -275,13 +275,19 @@ export {
 
 export { default as teeToFile } from './util/tee'
 
-// Client API
+// Client API these are deprecated, adn will be removed in kui
+// 12. Please use the Client.___ form instead
 export {
+  /** @deprecated @see Client.isOffline */
   isOfflineClient,
+  /** @deprecated @see Client.isReadonly */
   isReadOnlyClient,
+  /** @deprecated @see Client.isExecutable */
   isExecutableClient,
+  /** @deprecated @see Client.executeSequentially */
   executeSequentially,
+  /** @deprecated @see Client.hideReplayOutput */
   hideReplayOutput
-} from './api/client'
+} from './api/Client'
 
 export * from './api/window-events'

--- a/packages/core/src/main/load.ts
+++ b/packages/core/src/main/load.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface NotebookDefinitionMenuItem {
+  /** The title to use in the menu */
+  notebook: string
+
+  /** The VFS filepath to this notebook */
+  filepath: string
+
+  /** Open this guidebook, for auto-playing clients? (@see Client.firstOpenGuidebook()) */
+  open?: boolean
+}
+
+export interface SeparatorMenuItem {
+  type: 'separator'
+}
+
+type NotebookMenuItem = NotebooksMenu | NotebookDefinitionMenuItem | SeparatorMenuItem
+
+export function isMenu(item: NotebookMenuItem): item is NotebooksMenu {
+  const menu = item as NotebooksMenu
+  return typeof menu === 'object' && typeof menu.label === 'string' && Array.isArray(menu.submenu)
+}
+
+export function isLeaf(item: NotebookMenuItem): item is NotebookDefinitionMenuItem {
+  const leaf = item as NotebookDefinitionMenuItem
+  return typeof leaf === 'object' && typeof leaf.notebook === 'string' && typeof leaf.filepath === 'string'
+}
+
+export interface NotebooksMenu {
+  /** Name for this menu in the UI */
+  label: string
+
+  /** Entries of this menu */
+  submenu: NotebookMenuItem[]
+
+  /** Is this menu displayed as expanded? [Default: true] */
+  expanded?: boolean
+}
+
+/** @return the client's definition of a Notebooks menu */
+export default function loadClientNotebooksMenuDefinition(): NotebooksMenu {
+  try {
+    return require('@kui-shell/client/config.d/notebooks.json') as NotebooksMenu
+  } catch (err) {
+    return undefined
+  }
+}

--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -22,7 +22,8 @@ import { Menu, MenuItemConstructorOptions } from 'electron'
 import open from './open'
 import saveAsGuidebook from './save'
 import tellRendererToExecute from './tell'
-import { openNotebook, loadClientNotebooksMenuDefinition, clientNotebooksDefinitionToElectron } from './notebooks'
+import loadClientNotebooksMenuDefinition from './load'
+import { openNotebook, clientNotebooksDefinitionToElectron } from './notebooks'
 import { isOfflineClient, isReadOnlyClient } from '..'
 
 const isDev = false

--- a/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
@@ -106,7 +106,13 @@ export default class Sidebar extends React.PureComponent<Props, State> {
           {_.notebook}
         </NavItem>
       ) : isMenu(_) ? (
-        <NavExpandable key={idx} isExpanded title={_.label} className="kui--sidebar-nav-menu" data-title={_.label}>
+        <NavExpandable
+          key={idx}
+          isExpanded={_.expanded !== false}
+          title={_.label}
+          className="kui--sidebar-nav-menu"
+          data-title={_.label}
+        >
           {_.submenu.map(renderItem)}
         </NavExpandable>
       ) : (

--- a/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
@@ -15,7 +15,7 @@
  */
 
 type Guidebook = { notebook: string; filepath: string }
-type Menu = { label: string; submenu: MenuItem[] }
+type Menu = { label: string; submenu: MenuItem[]; expanded?: boolean }
 export type MenuItem = Guidebook | Menu | object
 
 export function isGuidebook(item: MenuItem): item is Guidebook {

--- a/plugins/plugin-client-common/src/mount.ts
+++ b/plugins/plugin-client-common/src/mount.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { Capabilities } from '@kui-shell/core'
-
-// This whole file is a hack until we fix the problem with
-// plugin-client-common importing notebookVFS from plugin-core-support (cyclic dependence)
-const guidebooks = [
+/**
+ * List of notebooks hosted by plugin-client-common
+ *
+ */
+export default [
   'plugin://plugin-client-common/notebooks/code-blocks.md',
   'plugin://plugin-client-common/notebooks/expandable-section.md',
   'plugin://plugin-client-common/notebooks/hints.md',
@@ -30,15 +30,3 @@ const guidebooks = [
   'plugin://plugin-client-common/notebooks/make-notebook.md',
   'plugin://plugin-client-common/notebooks/make-notebook.json'
 ]
-
-/**
- * Register the welcome notebook
- *
- */
-export default async () => {
-  // for now, we only need to do this in the proxy
-  if (Capabilities.inProxy()) {
-    const { notebookVFS } = await import('@kui-shell/plugin-core-support')
-    notebookVFS.cp(undefined, guidebooks, '/kui')
-  }
-}

--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -11,6 +11,7 @@
     },
     {
       "label": "Kubernetes",
+      "expanded": false,
       "submenu": [
         { "notebook": "Dashboard", "filepath": "/kui/kubernetes/dashboard1.md" },
         { "notebook": "CRUD Operations", "filepath": "/kui/kubernetes/crud-operations.md" },
@@ -20,6 +21,7 @@
     },
     {
       "label": "Iter8",
+      "expanded": false,
       "submenu": [
         { "notebook": "Welcome to Iter8", "filepath": "/kui/iter8/welcome.md" },
         { "notebook": "Tutorial 1", "filepath": "/kui/iter8/tutorial1.md" }
@@ -27,6 +29,7 @@
     },
     {
       "label": "Knative",
+      "expanded": false,
       "submenu": [
         { "notebook": "Getting Started", "filepath": "/kui/kubernetes/knative-getting-started.md" },
         {


### PR DESCRIPTION
This PR lays some groundwork that allows clients a more drop-in approach to provisioning guidebooks into a client.

1) Place the `.md` and `.json` files in your client's `notebooks/` directory
2) If you wish to have the guidebooks sidebar open by default, add `"showGuidebooksSidebar": true` to your config.d/client.json
3) If you wish Kui to operate in a mode where it shows a single guidebook at a time (rather that opening up Kui tabs for each opened guidebook), add `"singletonGuidebooks": true` to your config.d/client.json
4) (already the case before this PR): design your sidebar menu in config.d/notebooks.json
5) (new in this PR) if one of the leaf nodes in notebooks.json has `open: true`, then it will be autoplayed if you have also defined `singletonGuidebooks` and `showGuidebooksSidebar`

We will embody these into the KuiClientTemplate repo, for plugin-client-offline.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
