### PR TITLE
11.1.4

### DIFF
--- a/packages/builder/bin/prescan.sh
+++ b/packages/builder/bin/prescan.sh
@@ -36,3 +36,12 @@ if [ -f ./node_modules/@kui-shell/builder/dist/bin/compile.js ]; then
     echo "compiling plugin registry $CLIENT_HOME"
     node ./node_modules/@kui-shell/builder/dist/bin/compile.js
 fi
+
+# generate the index.json in @kui-shell/client/notebooks/index.json
+if [ -d node_modules/@kui-shell/client/notebooks ]; then
+    echo "Generating client-guidebooks.json"
+    if [ ! -d node_modules/@kui-shell/build/ ]; then
+        mkdir node_modules/@kui-shell/build
+    fi
+    (echo -n "["; for file in node_modules/@kui-shell/client/notebooks/*.{md,json}; do echo -n "\"$(basename $file)\","; done; echo -n "]") | sed 's/\,]/]/' > node_modules/@kui-shell/build/client-guidebooks.json
+fi

--- a/packages/core/src/api/Client.ts
+++ b/packages/core/src/api/Client.ts
@@ -17,6 +17,8 @@
 import Debug from 'debug'
 const debug = Debug('core/api/client')
 
+import loadClientNotebooksMenuDefinition, { isMenu, isLeaf } from '../main/load'
+
 /** Is the current client running in offline/disconnected mode? */
 export function isOfflineClient(): boolean {
   try {
@@ -31,6 +33,10 @@ export function isOfflineClient(): boolean {
     debug('Client did not define an offline status, assuming not offline')
     return false
   }
+}
+
+export function isOffline() {
+  return isOfflineClient()
 }
 
 /** Is the current client running in readonly mode? */
@@ -49,6 +55,10 @@ export function isReadOnlyClient(): boolean {
   }
 }
 
+export function isReadOnly() {
+  return isReadOnlyClient()
+}
+
 /** Is the current client running in an executable mode? */
 export function isExecutableClient(): boolean {
   try {
@@ -63,6 +73,10 @@ export function isExecutableClient(): boolean {
     debug('Client did not define an executable status, assuming executable')
     return true
   }
+}
+
+export function isExecutable() {
+  return isExecutableClient()
 }
 
 export function hideReplayOutput(): boolean {
@@ -86,6 +100,68 @@ export function executeSequentially(): boolean {
       return false
     }
   } else {
+    return false
+  }
+}
+
+/** @return the model specified by `@kui-shell/client/config.d/notebooks.json` */
+export function guidebooksMenu() {
+  const model = loadClientNotebooksMenuDefinition()
+  if (model) {
+    return model.submenu
+  }
+}
+
+/** @return first guidebook from Client.guidebooksMenu() with an `open` property */
+export function firstOpenGuidebook(): string {
+  const scan = (menu: ReturnType<typeof guidebooksMenu>): string => {
+    for (let idx = 0; idx < menu.length; idx++) {
+      const item = menu[idx]
+      if (isLeaf(item) && item.open) {
+        return item.filepath
+      } else if (isMenu(item)) {
+        const found = scan(item.submenu)
+        if (found) {
+          return found
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  return scan(guidebooksMenu())
+}
+
+/** @return a list of guidebook filepaths that `@kui-shell/client` offers */
+export function clientGuidebooks(): string[] {
+  try {
+    const guidebooks = require('@kui-shell/build/client-guidebooks.json')
+    if (!Array.isArray(guidebooks) || !guidebooks.every(_ => typeof _ === 'string')) {
+      debug('Client did not properly define guidebooks', guidebooks)
+    } else {
+      return guidebooks
+    }
+  } catch (err) {
+    debug('Client did not define any guidebooks')
+    return []
+  }
+}
+
+/** @return whether to show the Sidebar onload */
+export function showGuidebooksSidebar(): boolean {
+  try {
+    return require('@kui-shell/client/config.d/client.json').showGuidebooksSidebar
+  } catch (err) {
+    return false
+  }
+}
+
+/** @return whether to present guidebooks one-at-a-time */
+export function singletonGuidebooks(): boolean {
+  try {
+    return require('@kui-shell/client/config.d/client.json').singletonGuidebooks
+  } catch (err) {
     return false
   }
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -28,3 +28,6 @@ export { Settings }
 
 import * as Capabilities from './Capabilities'
 export { Capabilities }
+
+import * as Client from './Client'
+export { Client }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -275,13 +275,19 @@ export {
 
 export { default as teeToFile } from './util/tee'
 
-// Client API
+// Client API these are deprecated, adn will be removed in kui
+// 12. Please use the Client.___ form instead
 export {
+  /** @deprecated @see Client.isOffline */
   isOfflineClient,
+  /** @deprecated @see Client.isReadonly */
   isReadOnlyClient,
+  /** @deprecated @see Client.isExecutable */
   isExecutableClient,
+  /** @deprecated @see Client.executeSequentially */
   executeSequentially,
+  /** @deprecated @see Client.hideReplayOutput */
   hideReplayOutput
-} from './api/client'
+} from './api/Client'
 
 export * from './api/window-events'

--- a/packages/core/src/main/load.ts
+++ b/packages/core/src/main/load.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface NotebookDefinitionMenuItem {
+  /** The title to use in the menu */
+  notebook: string
+
+  /** The VFS filepath to this notebook */
+  filepath: string
+
+  /** Open this guidebook, for auto-playing clients? (@see Client.firstOpenGuidebook()) */
+  open?: boolean
+}
+
+export interface SeparatorMenuItem {
+  type: 'separator'
+}
+
+type NotebookMenuItem = NotebooksMenu | NotebookDefinitionMenuItem | SeparatorMenuItem
+
+export function isMenu(item: NotebookMenuItem): item is NotebooksMenu {
+  const menu = item as NotebooksMenu
+  return typeof menu === 'object' && typeof menu.label === 'string' && Array.isArray(menu.submenu)
+}
+
+export function isLeaf(item: NotebookMenuItem): item is NotebookDefinitionMenuItem {
+  const leaf = item as NotebookDefinitionMenuItem
+  return typeof leaf === 'object' && typeof leaf.notebook === 'string' && typeof leaf.filepath === 'string'
+}
+
+export interface NotebooksMenu {
+  /** Name for this menu in the UI */
+  label: string
+
+  /** Entries of this menu */
+  submenu: NotebookMenuItem[]
+
+  /** Is this menu displayed as expanded? [Default: true] */
+  expanded?: boolean
+}
+
+/** @return the client's definition of a Notebooks menu */
+export default function loadClientNotebooksMenuDefinition(): NotebooksMenu {
+  try {
+    return require('@kui-shell/client/config.d/notebooks.json') as NotebooksMenu
+  } catch (err) {
+    return undefined
+  }
+}

--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -22,7 +22,8 @@ import { Menu, MenuItemConstructorOptions } from 'electron'
 import open from './open'
 import saveAsGuidebook from './save'
 import tellRendererToExecute from './tell'
-import { openNotebook, loadClientNotebooksMenuDefinition, clientNotebooksDefinitionToElectron } from './notebooks'
+import loadClientNotebooksMenuDefinition from './load'
+import { openNotebook, clientNotebooksDefinitionToElectron } from './notebooks'
 import { isOfflineClient, isReadOnlyClient } from '..'
 
 const isDev = false

--- a/packages/test/src/api/Markdown.ts
+++ b/packages/test/src/api/Markdown.ts
@@ -16,6 +16,8 @@
 
 export default class Markdown {
   public readonly tip = '.kui--markdown-tip'
+  public readonly tabs = '.kui--markdown-tabs'
+  public readonly tab = `${this.tabs} .kui--markdown-tab button`
 
   public tipWithTitle(title: string) {
     return `${this.tip}[data-title="${title}"]`
@@ -23,5 +25,9 @@ export default class Markdown {
 
   public tipContent(baseSelector = this.tip) {
     return `${baseSelector} > div`
+  }
+
+  public tabWithTitle(title: string) {
+    return `${this.tab}[data-title="${title}"]`
   }
 }

--- a/plugins/plugin-client-common/notebook/src/load.ts
+++ b/plugins/plugin-client-common/notebook/src/load.ts
@@ -24,7 +24,7 @@ export async function loadNotebook(
 ): Promise<string | object> {
   try {
     if (/^https:/.test(filepath)) {
-      return (await REPL.rexec<(string | object)[]>(`_fetchfile ${encodeComponent(filepath)}`)).content[0]
+      return (await REPL.rexec<(string | object)[]>(`vfs _fetchfile ${encodeComponent(filepath)}`)).content[0]
     } else {
       //   --with-data says give us the file contents
       const fullpath = Util.absolute(Util.expandHomeDir(filepath))

--- a/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
@@ -131,11 +131,13 @@ export default class Sidebar extends React.PureComponent<Props, State> {
 
   public render() {
     return (
-      <PageSidebar
-        nav={this.props.isOpen && this.nav()}
-        isNavOpen={this.props.isOpen}
-        className="kui--tab-container-sidebar"
-      />
+      Array.isArray(this.props.guidebooks) && (
+        <PageSidebar
+          nav={this.props.isOpen && this.nav()}
+          isNavOpen={this.props.isOpen}
+          className="kui--tab-container-sidebar"
+        />
+      )
     )
   }
 }

--- a/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
@@ -106,7 +106,13 @@ export default class Sidebar extends React.PureComponent<Props, State> {
           {_.notebook}
         </NavItem>
       ) : isMenu(_) ? (
-        <NavExpandable key={idx} isExpanded title={_.label} className="kui--sidebar-nav-menu" data-title={_.label}>
+        <NavExpandable
+          key={idx}
+          isExpanded={_.expanded !== false}
+          title={_.label}
+          className="kui--sidebar-nav-menu"
+          data-title={_.label}
+        >
           {_.submenu.map(renderItem)}
         </NavExpandable>
       ) : (

--- a/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
@@ -15,7 +15,7 @@
  */
 
 type Guidebook = { notebook: string; filepath: string }
-type Menu = { label: string; submenu: MenuItem[] }
+type Menu = { label: string; submenu: MenuItem[]; expanded?: boolean }
 export type MenuItem = Guidebook | Menu | object
 
 export function isGuidebook(item: MenuItem): item is Guidebook {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
@@ -29,17 +29,26 @@ export interface WizardSteps {
   }
 }
 
-type KuiFrontmatter = Partial<WizardSteps> & {
-  /** Title of the Notebook */
-  title?: string
-
-  layoutCount?: Record<string, number>
-
-  /**
-   * A mapping that indicates which section (the `number` values) should be rendered in a given split position.
-   */
-  layout?: 'wizard' | Record<number | 'default', SplitPositionSpec>
+interface CodeBlocks {
+  codeblocks: {
+    match: string
+    language?: string
+    validate?: string
+  }[]
 }
+
+type KuiFrontmatter = Partial<WizardSteps> &
+  Partial<CodeBlocks> & {
+    /** Title of the Notebook */
+    title?: string
+
+    layoutCount?: Record<string, number>
+
+    /**
+     * A mapping that indicates which section (the `number` values) should be rendered in a given split position.
+     */
+    layout?: 'wizard' | Record<number | 'default', SplitPositionSpec>
+  }
 
 export function hasWizardSteps(frontmatter: KuiFrontmatter): frontmatter is KuiFrontmatter & Required<WizardSteps> {
   return (
@@ -48,6 +57,10 @@ export function hasWizardSteps(frontmatter: KuiFrontmatter): frontmatter is KuiF
     Array.isArray(frontmatter.wizard.steps) &&
     frontmatter.wizard.steps.length > 0
   )
+}
+
+export function hasCodeBlocks(frontmatter: KuiFrontmatter): frontmatter is KuiFrontmatter & Required<CodeBlocks> {
+  return frontmatter.codeblocks && Array.isArray(frontmatter.codeblocks) && frontmatter.codeblocks.length > 0
 }
 
 type SplitPosition = 'left' | 'bottom' | 'default' | 'wizard'

--- a/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
@@ -25,7 +25,7 @@ export interface WizardSteps {
      * heading in the markdown source. Optionally, a step description
      * may be overlaid
      */
-    steps: (string | { name: string; description: string })[]
+    steps: (string | { match?: string; name: string; description: string })[]
   }
 }
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/encoding.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/encoding.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import { CodeBlockResponse } from '.'
 import { isCodedError, isWatchable } from '@kui-shell/core'
-import { CodeBlockResponse } from '../components/code'
 
 function stringifyError(response: Error) {
   return { code: isCodedError(response) ? response.code : 1, message: response.message }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/encoding.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/encoding.ts
@@ -38,7 +38,9 @@ function reactRedactor(key: string, value: any) {
 export default function encodePriorResponses(responses: CodeBlockResponse[]): string {
   return JSON.stringify(
     responses.map(response => {
-      if (response.response.constructor === Error) {
+      if (typeof response === 'undefined') {
+        return response
+      } else if (response.response.constructor === Error) {
         return Object.assign({}, response, { response: stringifyError(response.response) })
       } else if (isWatchable(response.response)) {
         delete response.response.watch

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
@@ -18,13 +18,12 @@ import React from 'react'
 import { CodeProps } from 'react-markdown/lib/ast-to-react'
 import { KResponse, CommentaryResponse, getPrimaryTabId } from '@kui-shell/core'
 
-import { Props } from '../../Markdown'
-import { tryFrontmatter } from '../frontmatter'
+import { Props } from '../../../Markdown'
+import { tryFrontmatter } from '../../frontmatter'
 
-import Input from '../../../Views/Terminal/Block/Inputv2'
-// const Input = React.lazy(() => import('../Views/Terminal/Block/Inputv2'))
+import Input from '../../../../Views/Terminal/Block/Inputv2'
 
-const SimpleEditor = React.lazy(() => import('../../Editor/SimpleEditor'))
+const SimpleEditor = React.lazy(() => import('../../../Editor/SimpleEditor'))
 
 type CodeBlockResponse = CommentaryResponse['props']['codeBlockResponses'][0]
 export { CodeBlockResponse }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/rehype-code-indexer.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/rehype-code-indexer.ts
@@ -18,7 +18,7 @@ import { Parent } from 'unist'
 import { Element, Root } from 'hast'
 import { visitParents as visit } from 'unist-util-visit-parents'
 
-import { tryFrontmatter } from './frontmatter'
+import { tryFrontmatter } from '../../frontmatter'
 
 function isExecutableCodeBlock(language: string) {
   return /^(bash|sh|shell)$/.test(language)

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Node } from 'hast'
+import { Code } from 'mdast'
+import { visit } from 'unist-util-visit'
+
+import { tryFrontmatter } from '../../frontmatter'
+import KuiFrontmatter, { hasCodeBlocks } from '../../KuiFrontmatter'
+
+function isCode(node: Node): node is Code {
+  return node.type === 'code' && typeof (node as Code).value === 'string'
+}
+
+/** Scan and process the `codeblocks` schema of the given `frontmatter` */
+export default function preprocessCodeBlocks(tree /*: Root */, frontmatter: KuiFrontmatter) {
+  if (hasCodeBlocks(frontmatter)) {
+    const codeblocks = frontmatter.codeblocks.map(_ => Object.assign({}, _, { match: new RegExp(_.match) }))
+
+    visit(tree, 'code', node => {
+      if (isCode(node)) {
+        const matched = codeblocks.find(_ => _.match.test(node.value))
+        if (matched) {
+          if (matched.language) {
+            // smash in a code block language (this would be the ```${language} part of the text)
+            node.lang = matched.language
+          }
+          if (matched.validate) {
+            // smash in validation logic; this is done in the
+            // topmatter of the code block, and parsed out by rehype-code-indexer
+            const { body, attributes } = tryFrontmatter(node.value)
+            attributes.validate = matched.validate
+            node.value = `
+---
+${require('js-yaml').dump(attributes)}
+---
+${body}
+`
+          }
+        }
+      }
+    })
+  }
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
@@ -28,7 +28,9 @@ function isCode(node: Node): node is Code {
 /** Scan and process the `codeblocks` schema of the given `frontmatter` */
 export default function preprocessCodeBlocks(tree /*: Root */, frontmatter: KuiFrontmatter) {
   if (hasCodeBlocks(frontmatter)) {
-    const codeblocks = frontmatter.codeblocks.map(_ => Object.assign({}, _, { match: new RegExp(_.match) }))
+    const codeblocks = frontmatter.codeblocks.map(_ =>
+      Object.assign({}, _, { match: new RegExp(_.match.replace(/\./g, '\\.')) })
+    )
 
     visit(tree, 'code', node => {
       if (isCode(node)) {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
@@ -22,6 +22,7 @@ import { visitParents } from 'unist-util-visit-parents'
 
 import { Tab } from '@kui-shell/core'
 
+import preprocessCodeBlocks from './components/code/remark-codeblocks-topmatter'
 import KuiFrontmatter, { hasWizardSteps, isValidPosition, isValidPositionObj } from './KuiFrontmatter'
 
 export function tryFrontmatter(
@@ -204,6 +205,7 @@ export function kuiFrontmatter(opts: { tab: Tab }) {
         setTimeout(() => opts.tab.setTitle(frontmatter.title))
       }
 
+      preprocessCodeBlocks(tree, frontmatter)
       preprocessWizardSteps(tree, frontmatter)
       extractSplitsAndSections(tree, frontmatter)
     }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -39,15 +39,16 @@ import tip from './rehype-tip'
 import tabbed, { hackIndentation } from './rehype-tabbed'
 
 import components from './components'
-import codeIndexer from './code-indexer'
 import wizard from './components/Wizard/rehype-wizard'
+
 import { CodeBlockResponse } from './components/code'
+import codeIndexer from './components/code/rehype-code-indexer'
+import encodePriorResponses from './components/code/encoding'
 
 // react-markdown v6+ now require use of these to support html
 import rehypeRaw from 'rehype-raw'
 import rehypeSlug from 'rehype-slug'
 
-import encodePriorResponses from './codeblocks/encoding'
 import { kuiFrontmatter, tryFrontmatter } from './frontmatter'
 
 const rehypePlugins = (uuid: string): Options['rehypePlugins'] => [

--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -28,6 +28,12 @@ const ReactMarkdown = React.lazy(() => import('react-markdown'))
 // GitHub Flavored Markdown plugin; see https://github.com/IBM/kui/issues/6563
 import gfm from 'remark-gfm'
 
+// ==foo== -> <mark>foo</mark>
+import hackMarks from './remark-mark'
+
+// ++ctrl+alt+delete++== -> <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>delete</kbd>
+import hackKeys from './remark-keys'
+
 import inlineSnippets from '../../../controller/snippets'
 
 import emojis from 'remark-emoji'
@@ -63,6 +69,7 @@ const remarkPlugins: (tab: KuiTab) => Options['remarkPlugins'] = (tab: KuiTab) =
   gfm,
   [frontmatter, ['yaml', 'toml']],
   [kuiFrontmatter, { tab }],
+
   emojis // [emojis, { emoticon: true }]
 ]
 
@@ -189,7 +196,6 @@ export default class Markdown extends React.PureComponent<Props, State> {
     if (filepath && execUUID) {
       const onSnapshot = async () => {
         const codeBlockResponses = this.codeBlockResponses()
-        console.error('!!!!!!!!', codeBlockResponses, this.props.codeBlockResponses, this.state.codeBlockResponses)
         if (codeBlockResponses.find(_ => _ !== undefined)) {
           const stats = (await this.repl.rexec<GlobStats[]>(`vfs ls ${encodeComponent(filepath)}`)).content
 
@@ -270,7 +276,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
    * syntax from pymdown (such as target=_blank for links).
    */
   private static hackSource(source: string) {
-    return hackIndentation(source)
+    return hackKeys(hackMarks(hackIndentation(source)))
       .trim()
       .replace(/\){target=[^}]+}/g, ')')
   }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/index.ts
@@ -171,7 +171,7 @@ export function hackIndentation(source: string): string {
 
   const rewrite = source.split(/\n/).map(line => {
     const tabStartMatch = line.match(/^(\s*)===\s+".*"/)
-    const tipStartMatch = line.match(/^(\s*)[?!][?!][?!](\+?)\s+(tip|todo|bug|info|note|warning|success)/)
+    const tipStartMatch = line.match(/^(\s*)[?!][?!][?!](\+?)\s+(tip|todo|bug|info|note|warning|success|question)/)
     const startMatch = tabStartMatch || tipStartMatch
 
     const pop = (line: string, delta = 0) => {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tip/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tip/index.ts
@@ -18,8 +18,8 @@ import { i18n } from '@kui-shell/core'
 
 const strings = i18n('plugin-client-common', 'markdown')
 
-const RE_TIP = /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning|success)(\s+"(.+)"\s*)?(\n(.|[\n\r])*)?$/
-const RE_TIP_START = /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning|success)(\s+"(.+))?$/
+const RE_TIP = /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning|success|question)(\s+"(.+)"\s*)?(\n(.|[\n\r])*)?$/
+const RE_TIP_START = /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning|success|question)(\s+"(.+))?$/
 const RE_TIP_END = /^(.*)"\s*(\n(.|[\n\r])*)?$/
 
 export const START_OF_TIP = `<!-- ____KUI_START_OF_TIP____ -->`

--- a/plugins/plugin-client-common/src/components/Content/Markdown/remark-keys.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/remark-keys.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const RE_KEY = /\+\+([^+]+)(\+([^+]+))*\+\+/g
+
+/**
+ * Allows us to support pymdown's `++ctrl+alt+delete` which they
+ * transform to HTML5 <kbd>...</kbd>.
+ */
+export default function plugin(markdownText: string) {
+  return markdownText.replace(RE_KEY, match => {
+    return (
+      '<span class="kui--markdown-keys">' +
+      match
+        .split(/\+/)
+        .filter(Boolean)
+        .map(_ => _.replace(/^"(.+)"$/, '$1'))
+        .map(_ => `<kbd class="kui--markdown-key--${_}">${_}</kbd>`)
+        .join('<span>+</span>') +
+      '</span>'
+    )
+  })
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const RE_MARK = /([^=])?==([^=]+)==([^=])/g
+
+/**
+ * Allows us to support pymdown's `==hello==` which they transform to
+ * HTML5 <mark>hello</mark> which seems to generally be presented with
+ * highlighter background.
+ */
+export default function plugin(markdownText: string) {
+  return markdownText.replace(RE_MARK, '$1<mark>$2</mark>$3')
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-const RE_MARK = /([^=])?==([^=]+)==([^=])/g
-
 /**
  * Allows us to support pymdown's `==hello==` which they transform to
  * HTML5 <mark>hello</mark> which seems to generally be presented with
  * highlighter background.
  */
 export default function plugin(markdownText: string) {
-  return markdownText.replace(RE_MARK, '$1<mark>$2</mark>$3')
+  const RE_MARK_BASE = '==([^=]+)==([^=])'
+  const RE_MARK = new RegExp(`([^=])${RE_MARK_BASE}`, 'g')
+  const RE_MARK_AT_TOP = new RegExp(`^${RE_MARK_BASE}`, 'g')
+
+  return markdownText.replace(RE_MARK_AT_TOP, '<mark>$1</mark>$2').replace(RE_MARK, '$1<mark>$2</mark>$3')
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -234,7 +234,7 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
     return (
       this.state.startTime &&
       !this.state.endTime && (
-        <span className="kui--code-block-actions" data-align="top-right">
+        <span className="kui--code-block-actions" data-align="top-left">
           <Badge>
             <Timer startTime={this.state.startTime} endTime={this.state.endTime} status={this.state.execution} />
           </Badge>
@@ -249,7 +249,7 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
 
     if (execution === 'done' || execution === 'error') {
       return (
-        <div className="kui--code-block-actions flex-layout" data-align="top-right">
+        <div className="kui--code-block-actions flex-layout" data-align="top-left">
           <ProgressStepper className="kui--code-block-status">
             <ProgressStep title="" defaultStatus={execution === 'done' ? 'success' : 'error'} />
           </ProgressStepper>

--- a/plugins/plugin-client-common/src/controller/snippets.ts
+++ b/plugins/plugin-client-common/src/controller/snippets.ts
@@ -60,8 +60,10 @@ function toString(data: string | object) {
 /** Rewrite any relative image links to use the given basePath */
 function rerouteImageLinks(basePath: string, data: string) {
   return data.replace(
-    /\[(.+)\]\((.+)\)/g, // e.g. [linky](https://linky.com)
-    (_, p1, p2) => `[${p1}](${join(basePath, p2)})`
+    /\[([^\]]+)\]\(([^)]+)\)/g, // e.g. [linky](https://linky.com)
+    (_, p1, p2) => {
+      return `[${p1}](${isAbsolute(p2) ? p2 : join(basePath, p2)})`
+    }
   )
 }
 
@@ -89,7 +91,7 @@ export default function inlineSnippets(snippetBasePath?: string) {
           // fetches other files. We also may need to reroute relative
           // image links according to the given `basePath`.
           const recurse = (basePath: string, data: string) => {
-            return inlineSnippets(basePath)(rerouteImageLinks(basePath, toString(data)), snippetFileName, args)
+            return inlineSnippets(basePath)(rerouteImageLinks(basePath, data), snippetFileName, args)
           }
 
           const candidates = match[5]

--- a/plugins/plugin-client-common/src/controller/snippets.ts
+++ b/plugins/plugin-client-common/src/controller/snippets.ts
@@ -91,7 +91,13 @@ export default function inlineSnippets(snippetBasePath?: string) {
           // fetches other files. We also may need to reroute relative
           // image links according to the given `basePath`.
           const recurse = (basePath: string, data: string) => {
-            return inlineSnippets(basePath)(rerouteImageLinks(basePath, data), snippetFileName, args)
+            // Note: intentionally using `snippetBasePath` for the
+            // first argument, as this represents the "root" base
+            // path, either from the URL of the original filepath (we
+            // may be recursing here) or from the command line or from
+            // the topmatter of the original document. The second
+            // represents the current base path in the recursion.
+            return inlineSnippets(snippetBasePath)(rerouteImageLinks(basePath, data), snippetFileName, args)
           }
 
           const candidates = match[5]
@@ -104,7 +110,7 @@ export default function inlineSnippets(snippetBasePath?: string) {
             ? await loadNotebook(snippetFileName, args)
                 .then(data => recurse(snippetBasePath || dirname(snippetFileName), toString(data)))
                 .catch(err => {
-                  debug('Warning: could not fetch inlined content', snippetFileName, err)
+                  debug('Warning: could not fetch inlined content 1', snippetBasePath, snippetFileName, err)
                   return ''
                 })
             : (
@@ -116,7 +122,7 @@ export default function inlineSnippets(snippetBasePath?: string) {
                       loadNotebook(join(mySnippetBasePath, snippetFileName), args)
                         .then(data => recurse(mySnippetBasePath, toString(data)))
                         .catch(err => {
-                          debug('Warning: could not fetch inlined content', mySnippetBasePath, err)
+                          debug('Warning: could not fetch inlined content 2', mySnippetBasePath, mySnippetBasePath, err)
                           return ''
                         })
                     )
@@ -126,7 +132,7 @@ export default function inlineSnippets(snippetBasePath?: string) {
           if (!snippetData) {
             return line
           } else {
-            debug('successfully fetched inlined content')
+            debug('successfully fetched inlined content', snippetFileName)
 
             // for now, we completely strip off the topmatter from
             // snippets. TODO?

--- a/plugins/plugin-client-common/src/mount.ts
+++ b/plugins/plugin-client-common/src/mount.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { Capabilities } from '@kui-shell/core'
-
-// This whole file is a hack until we fix the problem with
-// plugin-client-common importing notebookVFS from plugin-core-support (cyclic dependence)
-const guidebooks = [
+/**
+ * List of notebooks hosted by plugin-client-common
+ *
+ */
+export default [
   'plugin://plugin-client-common/notebooks/code-blocks.md',
   'plugin://plugin-client-common/notebooks/expandable-section.md',
   'plugin://plugin-client-common/notebooks/hints.md',
@@ -30,15 +30,3 @@ const guidebooks = [
   'plugin://plugin-client-common/notebooks/make-notebook.md',
   'plugin://plugin-client-common/notebooks/make-notebook.json'
 ]
-
-/**
- * Register the welcome notebook
- *
- */
-export default async () => {
-  // for now, we only need to do this in the proxy
-  if (Capabilities.inProxy()) {
-    const { notebookVFS } = await import('@kui-shell/plugin-core-support')
-    notebookVFS.cp(undefined, guidebooks, '/kui')
-  }
-}

--- a/plugins/plugin-client-common/src/test/core/markdown/kbd.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/kbd.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename, dirname, join } from 'path'
+import { Common, CLI } from '@kui-shell/test'
+import { encodeComponent } from '@kui-shell/core'
+
+const ROOT = join(dirname(require.resolve('@kui-shell/plugin-client-common/tests/data/kbdtag1.md')), '..')
+
+const IN1 = {
+  input: join(ROOT, 'data/kbdtag1.md'),
+  kbds: ['.']
+}
+
+const IN2 = {
+  input: join(ROOT, 'data/kbdtag2.md'),
+  kbds: IN1.kbds
+}
+
+const IN3 = {
+  input: join(ROOT, 'data/kbdtag3.md'),
+  kbds: ['Ctrl', 'Alt', 'Delete']
+}
+;[IN1, IN2, IN3].forEach(markdown => {
+  describe(`kbd tags in markdown ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
+    ''}`, function(this: Common.ISuite) {
+    before(Common.before(this))
+    after(Common.after(this))
+
+    it(`should load markdown and show ${markdown.kbds.length} kbd tags`, async () => {
+      try {
+        await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
+        await this.app.client.waitUntil(async () => {
+          const kbds = await this.app.client.$$('kbd')
+          return kbds.length === markdown.kbds.length
+        })
+
+        await Promise.all(
+          markdown.kbds.map(async kbd => {
+            await this.app.client.waitUntil(async () => {
+              const kbds = await this.app.client.$$('kbd')
+              const texts = await Promise.all(kbds.map(_ => _.getText()))
+              return texts.includes(kbd)
+            })
+          })
+        )
+      } catch (err) {
+        await Common.oops(this, true)(err)
+      }
+    })
+  })
+})

--- a/plugins/plugin-client-common/src/test/core/markdown/mark.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/mark.ts
@@ -15,21 +15,39 @@
  */
 
 import { basename, dirname, join } from 'path'
-import { Common, CLI } from '@kui-shell/test'
 import { encodeComponent } from '@kui-shell/core'
+import { Common, CLI, Selectors } from '@kui-shell/test'
 
 const ROOT = join(dirname(require.resolve('@kui-shell/plugin-client-common/tests/data/marktag1.md')), '..')
 
-const IN1 = {
+interface Input {
+  input: string
+  marks: string[]
+  tabs?: string[]
+}
+
+const IN1: Input = {
   input: join(ROOT, 'data/marktag1.md'),
   marks: ['Markymark']
 }
 
-const IN2 = {
+const IN2: Input = {
   input: join(ROOT, 'data/marktag2.md'),
-  marks: ['Morkymork', 'Markymark']
+  marks: IN1.marks.concat(['Morkymork'])
 }
-;[IN1, IN2].forEach(markdown => {
+
+const IN3: Input = {
+  input: join(ROOT, 'data/marktag3.md'),
+  marks: IN2.marks,
+  tabs: ['Tab1Title', 'Tab2Title']
+}
+
+const IN4: Input = {
+  input: join(ROOT, 'data/marktag4.md'),
+  marks: IN3.marks.concat(['Mirkymirk']), // no 'Merkymerk' is it in Tab2, not yet rendered
+  tabs: IN3.tabs
+}
+;[IN1, IN2, IN3, IN4].forEach(markdown => {
   describe(`mark tags in markdown ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
     ''}`, function(this: Common.ISuite) {
     before(Common.before(this))
@@ -52,6 +70,16 @@ const IN2 = {
             })
           })
         )
+
+        if (markdown.tabs) {
+          await Promise.all(
+            markdown.tabs.map(tabTitle =>
+              this.app.client
+                .$(Selectors.Markdown.tabWithTitle(tabTitle))
+                .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+            )
+          )
+        }
       } catch (err) {
         await Common.oops(this, true)(err)
       }

--- a/plugins/plugin-client-common/src/test/core/markdown/mark.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/mark.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename, dirname, join } from 'path'
+import { Common, CLI } from '@kui-shell/test'
+import { encodeComponent } from '@kui-shell/core'
+
+const ROOT = join(dirname(require.resolve('@kui-shell/plugin-client-common/tests/data/marktag1.md')), '..')
+
+const IN1 = {
+  input: join(ROOT, 'data/marktag1.md'),
+  marks: ['Markymark']
+}
+
+const IN2 = {
+  input: join(ROOT, 'data/marktag2.md'),
+  marks: ['Morkymork', 'Markymark']
+}
+;[IN1, IN2].forEach(markdown => {
+  describe(`mark tags in markdown ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
+    ''}`, function(this: Common.ISuite) {
+    before(Common.before(this))
+    after(Common.after(this))
+
+    it(`should load markdown and show ${markdown.marks.length} mark tags`, async () => {
+      try {
+        await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
+        await this.app.client.waitUntil(async () => {
+          const marks = await this.app.client.$$('mark')
+          return marks.length === markdown.marks.length
+        })
+
+        await Promise.all(
+          markdown.marks.map(async mark => {
+            await this.app.client.waitUntil(async () => {
+              const marks = await this.app.client.$$('mark')
+              const texts = await Promise.all(marks.map(_ => _.getText()))
+              return texts.includes(mark)
+            })
+          })
+        )
+      } catch (err) {
+        await Common.oops(this, true)(err)
+      }
+    })
+  })
+})

--- a/plugins/plugin-client-common/src/test/core/wizards-in-markdown.ts
+++ b/plugins/plugin-client-common/src/test/core/wizards-in-markdown.ts
@@ -62,7 +62,7 @@ const IN3 = {
   description: 'WizardDescriptionInTopmatter',
   expectedSplitCount: 1,
   steps: [
-    { name: 'Before you begin', body: 'Before you can get started', description: '', codeBlocks: [] },
+    { name: 'TestRewritingOfStepName', body: 'Before you can get started', description: '', codeBlocks: [] },
     { name: 'Prepare local Kubernetes cluster', body: 'You can use', description: 'TestDescription2', codeBlocks: [] }
   ]
 }

--- a/plugins/plugin-client-common/tests/data/code-block1-base.md
+++ b/plugins/plugin-client-common/tests/data/code-block1-base.md
@@ -1,0 +1,11 @@
+Hello world
+
+```
+echo hi
+```
+
+Goodbye
+
+<!-- NOTE: this markdown intentionally has no language or validation,
+as we will overlay that in the topmatter in markdowns that include
+this one -->

--- a/plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter-via-snippet.md
+++ b/plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter-via-snippet.md
@@ -1,0 +1,8 @@
+---
+codeblocks:
+    - match: ^echo hi$
+      language: bash
+      validate: true
+---
+
+--8<-- "code-block1-base.md"

--- a/plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter.md
+++ b/plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter.md
@@ -1,0 +1,14 @@
+---
+codeblocks:
+    - match: ^echo hi$
+      language: bash
+      validate: true
+---
+
+Hello world
+
+```
+echo hi
+```
+
+Goodbye

--- a/plugins/plugin-client-common/tests/data/code-block1.md
+++ b/plugins/plugin-client-common/tests/data/code-block1.md
@@ -1,6 +1,9 @@
 Hello world
 
 ```bash
+---
+validate: true
+---
 echo hi
 ```
 

--- a/plugins/plugin-client-common/tests/data/kbdtag1.md
+++ b/plugins/plugin-client-common/tests/data/kbdtag1.md
@@ -1,0 +1,3 @@
+++.++
+
+That should render as one `<kbd>.</kbd>` tag.

--- a/plugins/plugin-client-common/tests/data/kbdtag2.md
+++ b/plugins/plugin-client-common/tests/data/kbdtag2.md
@@ -1,0 +1,4 @@
+++"."++
+
+That should render as one `<kbd>.</kbd>` tag. Note that it is expected
+for the quotes to vanish.

--- a/plugins/plugin-client-common/tests/data/kbdtag3.md
+++ b/plugins/plugin-client-common/tests/data/kbdtag3.md
@@ -1,0 +1,4 @@
+++ctrl+alt+delete++
+
+That should render as three `<kbd/>` tags, and with the text rendered
+as capitalized.

--- a/plugins/plugin-client-common/tests/data/marktag1.md
+++ b/plugins/plugin-client-common/tests/data/marktag1.md
@@ -1,0 +1,5 @@
+==Markymark==
+
+That should render has a `<mark>...</mark>`. This file allows testing
+the case where the mark at the very start of the file. Do not change
+this.

--- a/plugins/plugin-client-common/tests/data/marktag2.md
+++ b/plugins/plugin-client-common/tests/data/marktag2.md
@@ -1,0 +1,6 @@
+==Morkymork==
+==Markymark==
+
+That should render has a `<mark>...</mark>`. This file allows testing
+the case where the mark at the very start of the file. Do not change
+the location of the MorkyMork tag.

--- a/plugins/plugin-client-common/tests/data/marktag3.md
+++ b/plugins/plugin-client-common/tests/data/marktag3.md
@@ -1,0 +1,11 @@
+==Markymark==
+
+That should render has a `<mark>...</mark>`. This file allows testing
+the case where the mark at the very start of the file. Do not change
+this.
+
+==Morkymork==
+=== "Tab1Title"
+    Tab1Contents
+=== "Tab2Title"
+    Tab2Contents

--- a/plugins/plugin-client-common/tests/data/marktag4.md
+++ b/plugins/plugin-client-common/tests/data/marktag4.md
@@ -1,0 +1,14 @@
+=== "Tab1Title"
+    Tab1Contents
+    ==Markymark==
+=== "Tab2Title"
+    Tab2Contents
+    ==Merkymerk==
+==Mirkymirk==
+
+That should render has a `<mark>...</mark>`. This file allows testing
+the case where we mix tabs and marks, with some marks nested in the
+tabs, and the tabs at the very top of the file. Do not change that
+last part, as it is an important part of the test.
+
+==Morkymork==

--- a/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md
+++ b/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md
@@ -2,7 +2,8 @@
 wizard:
     description: WizardDescriptionInTopmatter
     steps:
-        - Before you begin
+        - match: Before you begin
+          name: TestRewritingOfStepName
         - name: Prepare local Kubernetes cluster
           description: TestDescription2
         - Install the Kubernetes CLI

--- a/plugins/plugin-client-common/web/scss/components/Sidebar/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidebar/_index.scss
@@ -41,11 +41,14 @@ body[kui-theme-style='light'] {
     flex: 1;
     display: flex;
     flex-direction: column;
+    overflow-y: hidden; /* !!! keep bottom-aligned content always in view */
   }
   @include SidebarNav {
     flex: 1;
+    overflow-y: auto; /* !!! keep bottom-aligned content always in view */
   }
   @include SidebarBottomAlignedContent {
+    margin-top: 1em;
     padding: 0 var(--pf-global--spacer--lg);
   }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -34,6 +34,17 @@ $box-shadow-margin: 4px; /* room for box shadow */
   }
 }
 
+@mixin CodeBlock {
+  .kui--code-block-in-markdown {
+    @content;
+  }
+}
+@mixin CodeBlockActions {
+  .kui--code-block-actions {
+    @content;
+  }
+}
+
 body[kui-theme-style] {
   @include TextContent {
     color: inherit;
@@ -292,12 +303,6 @@ body[kui-theme-style='light'] {
 }
 
 @include Commentary {
-  /* .marked-content {
-    pre {
-      margin: 0;
-    }
-  } */
-
   @include WizardHeader {
     margin-right: $box-shadow-margin; /* room for box shadow */
   }
@@ -305,6 +310,10 @@ body[kui-theme-style='light'] {
     font-size: 0.875rem;
     margin-right: $box-shadow-margin; /* room for box shadow */
   }
+  @include CodeBlock {
+    margin-right: $box-shadow-margin; /* room for box shadow */
+  }
+
   @include ExpandableSectionContent {
     margin-top: 1em;
     max-width: unset;
@@ -456,23 +465,20 @@ $tip-toggle-opacity-2: 0.9;
   }
 }
 
-@mixin CodeBlock {
-  .kui--code-block-in-markdown {
-    @content;
-  }
-}
-@mixin CodeBlockActions {
-  .kui--code-block-actions {
-    @content;
-  }
-}
-
 /** Markdown-rendered content not in a Commentary */
 pre {
   @include TextContent {
     font-size: inherit;
     p {
       white-space: pre-wrap;
+    }
+  }
+}
+@include Commentary {
+  @include TextContent {
+    p {
+      /* See the white-space: pre-wrap rule just above */
+      white-space: normal;
     }
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -17,6 +17,7 @@
 @import 'mixins';
 @import '../Card/mixins';
 @import '../Editor/mixins';
+@import '../Wizard/mixins';
 @import '../Sidecar/mixins';
 @import '../common/narrow-window';
 @import '../ProgressStepper/mixins';
@@ -25,6 +26,7 @@
 @import 'BlockLinks';
 
 $marginTop: 0.5em;
+$box-shadow-margin: 4px; /* room for box shadow */
 
 @mixin TextContent {
   .pf-c-content {
@@ -296,9 +298,12 @@ body[kui-theme-style='light'] {
     }
   } */
 
+  @include WizardHeader {
+    margin-right: $box-shadow-margin; /* room for box shadow */
+  }
   @include ExpandableSection {
     font-size: 0.875rem;
-    margin-right: 3px; /* room for box shadow */
+    margin-right: $box-shadow-margin; /* room for box shadow */
   }
   @include ExpandableSectionContent {
     margin-top: 1em;
@@ -476,7 +481,7 @@ pre {
 @include CodeBlock {
   &:hover {
     @include CodeBlockActions {
-      opacity: 1;
+      filter: none;
     }
   }
 
@@ -487,15 +492,17 @@ pre {
 @include CodeBlockActions {
   position: absolute;
 
+  &[data-align='top-left'],
+  &[data-align='top-right'] {
+    filter: grayscale(0.15) opacity(0.9);
+  }
   &[data-align='top-left'] {
-    left: -1em;
-    top: -1em;
-    opacity: 0.8;
+    left: -0.6875em;
+    top: -0.6875em;
   }
   &[data-align='top-right'] {
     right: -1em;
     top: -1em;
-    opacity: 0.8;
   }
 
   .kui--tag {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -356,54 +356,74 @@ body[kui-theme-style='dark'] {
     }
   }
 }
-@include MarkdownTip {
-  $tip-toggle-opacity: 0.3;
-  $tip-toggle-opacity-2: 0.9;
 
+$tip-toggle-opacity: 0.3;
+$tip-toggle-opacity-2: 0.9;
+
+@mixin GreenTip {
+  $bgcolor: var(--color-base0B-rgb);
+  --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+  @include ExpandableSectionToggle {
+    background-color: rgba($bgcolor, $tip-toggle-opacity);
+  }
+}
+
+@mixin YellowTip {
+  $bgcolor: var(--color-yellow-rgb);
+  --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+  @include ExpandableSectionToggle {
+    background-color: rgba($bgcolor, $tip-toggle-opacity);
+  }
+}
+
+@mixin BlueTip {
+  $bgcolor: var(--color-blue-rgb);
+  --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+  @include ExpandableSectionToggle {
+    background-color: rgba($bgcolor, $tip-toggle-opacity);
+  }
+}
+
+@mixin RedTip {
+  $bgcolor: var(--color-red-rgb);
+  --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
+  @include ExpandableSectionToggle {
+    background-color: rgba($bgcolor, $tip-toggle-opacity);
+  }
+}
+
+@include MarkdownTip {
   @include ExpandableSectionToggle {
     width: 100%;
     font-weight: 500;
     padding-top: 0.6875em;
     padding-bottom: 0.6875em;
     background-color: #e7f1fa;
+
+    /* Some expandable section toggles in markdown have long urls,
+   e.g. https://knative.dev/docs/getting-started/first-service/ */
+    word-break: break-all;
   }
   @include ExpandableSectionToggleText {
     color: var(--color-text-01);
   }
   @include MarkdownTipVariant(success) {
-    $bgcolor: var(--color-base0B-rgb);
-    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
-    @include ExpandableSectionToggle {
-      background-color: rgba($bgcolor, $tip-toggle-opacity);
-    }
+    @include GreenTip;
+  }
+  @include MarkdownTipVariant(question) {
+    @include GreenTip;
   }
   @include MarkdownTipVariant(warning) {
-    $bgcolor: var(--color-yellow-rgb);
-    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
-    @include ExpandableSectionToggle {
-      background-color: rgba($bgcolor, $tip-toggle-opacity);
-    }
+    @include YellowTip;
   }
   @include MarkdownTipVariant(todo) {
-    $bgcolor: var(--color-blue-rgb);
-    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
-    @include ExpandableSectionToggle {
-      background-color: rgba($bgcolor, $tip-toggle-opacity);
-    }
+    @include BlueTip;
   }
   @include MarkdownTipVariant(note) {
-    $bgcolor: var(--color-yellow-rgb);
-    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
-    @include ExpandableSectionToggle {
-      background-color: rgba($bgcolor, $tip-toggle-opacity);
-    }
+    @include YellowTip;
   }
   @include MarkdownTipVariant(bug) {
-    $bgcolor: var(--color-red-rgb);
-    --pf-c-expandable-section--m-display-lg--after--BackgroundColor: #{rgba($bgcolor, $tip-toggle-opacity-2)};
-    @include ExpandableSectionToggle {
-      background-color: rgba($bgcolor, $tip-toggle-opacity);
-    }
+    @include RedTip;
   }
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -270,7 +270,8 @@ body[kui-theme-style='light'] {
     }
 
     @include MarkdownMajorParagraph {
-      margin: 1.5em 0;
+      margin-top: 1.5em;
+      margin-bottom: 1.5em;
 
       &:first-child {
         margin-top: 0;
@@ -297,6 +298,7 @@ body[kui-theme-style='light'] {
 
   @include ExpandableSection {
     font-size: 0.875rem;
+    margin-right: 3px; /* room for box shadow */
   }
   @include ExpandableSectionContent {
     margin-top: 1em;

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -24,6 +24,7 @@
 @import '../ExpandableSection/mixins';
 @import '../../Themes/mixins';
 @import 'BlockLinks';
+@import 'Keys';
 
 $marginTop: 0.5em;
 $box-shadow-margin: 4px; /* room for box shadow */

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -271,6 +271,13 @@ body[kui-theme-style='light'] {
 
     @include MarkdownMajorParagraph {
       margin: 1.5em 0;
+
+      &:first-child {
+        margin-top: 0;
+      }
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     @include Block {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Keys.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Keys.scss
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import 'mixins';
+
+@include Commentary {
+  kbd {
+    background-color: var(--color-base01);
+    border-radius: 0.1rem;
+    box-shadow: 0 0.1rem 0 0.05rem var(--color-base02), 0 0.1rem 0 var(--color-base02),
+      0 -0.1rem 0.2rem var(--color-base02) inset;
+    display: inline-block;
+    font-size: 0.75em;
+    padding: 0 0.6666666667em;
+    vertical-align: text-top;
+    word-break: break-word;
+  }
+
+  .kui--markdown-keys span {
+    color: var(--color-text-02);
+    padding: 0 0.2em;
+  }
+}
+
+@mixin SpecialKey($key) {
+  text-transform: capitalize;
+
+  &:before {
+    content: $key;
+    padding-right: 0.4em;
+  }
+}
+
+.kui--markdown-key--ctrl,
+.kui--markdown-key--control,
+.kui--markdown-key--Ctrl,
+.kui--markdown-key--Control {
+  @include SpecialKey('⌃');
+}
+
+.kui--markdown-key--alt,
+.kui--markdown-key--Alt {
+  @include SpecialKey('⎇');
+}
+
+.kui--markdown-key--del,
+.kui--markdown-key--Del,
+.kui--markdown-key--delete,
+.kui--markdown-key--Delete {
+  @include SpecialKey('⌦');
+}
+
+.kui--markdown-key--cmd,
+.kui--markdown-key--Cmd,
+.kui--markdown-key--command,
+.kui--markdown-key--Command {
+  @include SpecialKey('⌘');
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -18,7 +18,7 @@
 @import '../ExpandableSection/mixins';
 
 /* For commentary, to avoid super wide lines of text in large windows.  */
-$max-column-width: 66em;
+$max-column-width: 77em;
 
 /** Terminal font size */
 $terminal-font-size: 0.875rem;

--- a/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
@@ -29,6 +29,7 @@
   @include WizardBody {
     padding-top: 0;
     padding-bottom: 0;
+    padding-right: 0;
   }
 
   .pf-c-wizard__outer-wrap {
@@ -38,6 +39,7 @@
     flex-direction: row;
   }
   @include WizardNav {
+    height: auto;
     width: auto;
     min-width: 14rem;
     max-width: 16rem;

--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -27,7 +27,16 @@
     },
     {
       "label": "Knative",
-      "submenu": [{ "notebook": "Getting Started", "filepath": "/kui/kubernetes/knative-getting-started.md" }]
+      "submenu": [
+        { "notebook": "Getting Started", "filepath": "/kui/kubernetes/knative-getting-started.md" },
+        {
+          "label": "Serving",
+          "submenu": [
+            { "notebook": "First Knative Service", "filepath": "/kui/kubernetes/knative-first-service.md" },
+            { "notebook": "Scaling to Zero", "filepath": "/kui/kubernetes/knative-first-autoscale.md" }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -11,6 +11,7 @@
     },
     {
       "label": "Kubernetes",
+      "expanded": false,
       "submenu": [
         { "notebook": "Dashboard", "filepath": "/kui/kubernetes/dashboard1.md" },
         { "notebook": "CRUD Operations", "filepath": "/kui/kubernetes/crud-operations.md" },
@@ -20,6 +21,7 @@
     },
     {
       "label": "Iter8",
+      "expanded": false,
       "submenu": [
         { "notebook": "Welcome to Iter8", "filepath": "/kui/iter8/welcome.md" },
         { "notebook": "Tutorial 1", "filepath": "/kui/iter8/tutorial1.md" }
@@ -27,6 +29,7 @@
     },
     {
       "label": "Knative",
+      "expanded": false,
       "submenu": [
         { "notebook": "Getting Started", "filepath": "/kui/kubernetes/knative-getting-started.md" },
         {

--- a/plugins/plugin-iter8/notebooks/tutorial1.md
+++ b/plugins/plugin-iter8/notebooks/tutorial1.md
@@ -1,6 +1,28 @@
 ---
 title: Iter8 &mdash; Getting Started
-layout: wizard
+wizard:
+    steps:
+        - Introduction
+        - match: 1. Install Iter8
+          name: Install the CLI
+          description: The iter8 CLI gives you an easy way to manage your experiments
+        - match: 2. Download experiment chart
+          name: Download experiment
+          description: You may craft an experiment by hand, or, as we do here, you may use iter8 to download a previously constructed experiment definition
+        - match: 3. Run experiment
+          name: Run experiment
+          description: Run load against the application, and monitor error rate and response time
+        - match: 4. Assert outcomes
+          name: Assert outcomes
+codeblocks:
+    - match: brew install iter8
+      validate: iter8 -v
+    - match: go install
+      validate: ${GOPATH-~/go}/bin go -v
+    - match: iter8 hub -e load-test
+      validate: "[[ -f /tmp/load-test/values.yaml ]] && [[ -f /tmp/load-test/Chart.yaml ]] || exit 1"
+    - match: iter8 run
+      validate: "[[ -f /tmp/load-test/experiment/values.yaml ]] || exit 1"
 ---
 
 # Iter8: Kubernetes Release Engineering
@@ -13,8 +35,6 @@ release velocity and business value with their apps/ML models while
 protecting end-user experience. Use Iter8 for SLO validation, A/B
 testing and progressive rollouts of K8s apps/ML models.
 
----
-
 ## Introduction
 
 This tutorial uses an [Iter8 experiment](concepts.md#what-is-an-iter8-experiment) to load test https://example.com and validate latency and error-related service level objectives (SLOs).
@@ -23,130 +43,4 @@ This tutorial uses an [Iter8 experiment](concepts.md#what-is-an-iter8-experiment
 >
 > An Iter8 experiment is a sequence of tasks that produce metrics-driven insights for your app/ML model versions, validates them, and optionally performs a rollout. Iter8 provides a set of pre-defined and customizable tasks.
 
----
-
-## Install the CLI: The iter8 CLI gives you an easy way to manage your experiments
-
-=== "Mac"
-
-    On macOS, [Homebrew](https://brew.sh) makes it easy to install the `iter8` CLI.
-
-    ```shell
-    ---
-    id: install-iter8-cli
-    validate: brew info iter8
-    ---
-    brew tap iter8-tools/iter8
-    brew install iter8
-    ```
-    
-=== "Go 1.16+"
-    Install Iter8 using [Go 1.16+](https://golang.org/) as follows.
-
-    ```shell
-    ---
-    id: install-iter8-cli
-    before: export PATH=~/${GOPATH-~/go}/bin:$PATH
-    validate: iter8 -v
-    ---
-    go install github.com/iter8-tools/iter8@latest
-    ```
-
-=== "Binaries"
-    Pre-compiled Iter8 binaries for many platforms are available [here](https://github.com/iter8-tools/iter8/releases). Uncompress the iter8-X-Y.tar.gz archive for your platform, and move the iter8 binary to any folder in your PATH.
-
----
-
-## Download experiment: You may craft an experiment by hand, or, as we do here, you may use iter8 to download a previously constructed experiment definition
-
-Download the `load-test` experiment folder from [Iter8 hub](../user-guide/topics/iter8hub.md) as follows.
-
-```shell
----
-id: download-load-test
-validate: "[[ -f /tmp/load-test/values.yaml ]] && [[ -f /tmp/load-test/Chart.yaml ]] || exit 1"
-status: done
----
-cd /tmp && iter8 hub -e load-test
-```
-
----
-
-## Run experiment: Run load against the application, and monitor error rate and response time
-
-[Iter8 experiments](concepts.md#what-is-an-iter8-experiment) are specified using the `experiment.yaml` file. The `iter8 run` command reads this file, runs the specified experiment, and writes the results of the experiment into the `result.yaml` file.
-
-Run the experiment you downloaded above as follows.
-
-```shell
----
-id: run-experiment
-validate: "[[ -f /tmp/load-test/experiment/values.yaml ]] || exit 1"
----
-cd /tmp/load-test && iter8 run --set url=https://example.com
-```
-
-??? note "Look inside experiment.yaml"
-
-    This experiment contains the [`gen-load-and-collect-metrics` task](../user-guide/tasks/collect.md) for generating load and collecting metrics, and the [`assess-app-versions` task](../user-guide/tasks/assess.md) for validating SLOs.
-
-    ```yaml
-    # task 1: generate HTTP requests for https://example.com and
-    # collect Iter8's built-in latency and error-related metrics
-    - task: gen-load-and-collect-metrics
-      with:
-        versionInfo:
-        - url: https://example.com
-    # task 2: validate if the app (hosted at https://example.com) satisfies 
-    # service level objectives (SLOs)
-    # this task uses the built-in metrics collected by task 1 for validation
-    - task: assess-app-versions
-      with:
-        SLOs:
-          # error rate must be 0
-        - metric: built-in/error-rate
-          upperLimit: 0
-          # 95th percentile latency must be under 100 msec
-        - metric: built-in/p95.0
-          upperLimit: 100
-    ```
-
-??? note "Iter8 and Helm"
-
-    If you are familiar with Helm, you probably noticed that the load-test folder resembles a Helm chart. This is because, Iter8 experiment charts are Helm charts under the covers. The iter8 run command used above combines the experiment chart with values to generate the experiments.yaml file, much like how Helm charts can be combined with values to produce Kubernetes manifests.
-
-## Assert outcomes
-
-Assert that the experiment completed without any failures and SLOs are satisfied
-
-```shell
----
-id: assert-success
----
-cd /tmp/load-test && iter8 assert -c completed -c nofailure -c slos
-```
-
-## Generate report
-
-Generate a report of the experiment in HTML or text formats as follows.
-
-=== "HTML"
-
-    ```shell
-    iter8 report -o html > report.html
-    # open report.html with a browser. In MacOS, you can use the command:
-    # open report.html
-    ```
-
-    ???+ note "The HTML report looks as follows"
-
-        ![HTML report](https://iter8.tools/0.8/getting-started/images/report.html.png)
-
-=== "Text"
-
-    ```shell
-    ---
-    id: generate-text-report
-    ---
-    cd /tmp/load-test && iter8 report -o text
-    ```
+--8<-- "https://raw.githubusercontent.com/iter8-tools/iter8/master/mkdocs/docs/getting-started/your-first-experiment.md"

--- a/plugins/plugin-kubectl/notebooks/knative-first-autoscale.md
+++ b/plugins/plugin-kubectl/notebooks/knative-first-autoscale.md
@@ -1,0 +1,9 @@
+---
+title: Knative &mdash; Scaling to Zero
+wizard:
+    steps:
+        - Scaling to Zero
+        - Run your Knative Service
+---
+
+--8<-- "https://raw.githubusercontent.com/knative/docs/main/docs/getting-started/first-autoscale.md"

--- a/plugins/plugin-kubectl/notebooks/knative-first-service.md
+++ b/plugins/plugin-kubectl/notebooks/knative-first-service.md
@@ -1,0 +1,10 @@
+---
+title: Knative &mdash; First Service
+wizard:
+    steps:
+        - Deploying your first Knative Service
+        - "Knative Service: \"Hello world!\""
+        - Ping your Knative Service
+---
+
+--8<-- "https://raw.githubusercontent.com/knative/docs/main/docs/getting-started/first-service.md"

--- a/plugins/plugin-kubectl/notebooks/knative-getting-started.md
+++ b/plugins/plugin-kubectl/notebooks/knative-getting-started.md
@@ -1,12 +1,18 @@
 ---
+title: Knative &mdash; Getting Started
 wizard:
     steps:
         - Before you begin
-        - Prepare local Kubernetes cluster
+        - name: Prepare local Kubernetes cluster
+          description: Using kind or minikube can help you isolate your Knative learning experiments.
         - Install the Kubernetes CLI
         - Install the Knative CLI
         - name: Install the Knative "Quickstart" environment
           description: The kn quickstart plugin can quickly set up Knative against kind of minikube
+codeblocks:
+    - language: bash
+      match: ^brew install kn$
+      validate: brew info kn
 ---
 
 <!-- This is a demonstration of including unmodified markdown content, and overlaying a wizard -->

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -129,6 +129,7 @@ interface FetchOptions<Data extends BodyData | BodyData[]> {
   data?: Data
   headers?: Record<string, string>
   method?: 'get' | 'put' | 'post' | 'delete'
+  tryFetchEvenInBrowser?: boolean
 }
 
 export async function _needle(
@@ -137,7 +138,7 @@ export async function _needle(
   opts?: FetchOptions<BodyData>,
   retryCount = 0
 ): Promise<{ statusCode: number; body: string | object }> {
-  if (!Capabilities.inBrowser()) {
+  if (!Capabilities.inBrowser() || (opts && opts.tryFetchEvenInBrowser)) {
     const method = (opts && opts.method) || 'get'
     const headers = Object.assign({ connection: 'keep-alive' }, opts.headers)
     debug('fetch via needle', method, headers, url)

--- a/plugins/plugin-kubectl/src/non-headless-preload.ts
+++ b/plugins/plugin-kubectl/src/non-headless-preload.ts
@@ -75,6 +75,8 @@ export default async (registrar: PreloadRegistrar) => {
     undefined,
     [
       'plugin://plugin-kubectl/notebooks/knative-getting-started.md',
+      'plugin://plugin-kubectl/notebooks/knative-first-service.md',
+      'plugin://plugin-kubectl/notebooks/knative-first-autoscale.md',
       'plugin://plugin-kubectl/notebooks/create-jobs.md',
       'plugin://plugin-kubectl/notebooks/create-jobs.json',
       'plugin://plugin-kubectl/notebooks/crud-operations.md',

--- a/plugins/plugin-patternfly4-themes/web/scss/common.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/common.scss
@@ -68,7 +68,9 @@ body.kui--patternfly4[kui-theme-style] {
   --pf-global--palette--gold-300: #f4c145;
   --pf-global--palette--gold-300-rgb: 244, 193, 69;
   --pf-global--palette--gold-400: #f0ab00;
+  --pf-global--palette--gold-400-rgb: 240, 171, 0;
   --pf-global--palette--gold-500: #c58c00;
+  --pf-global--palette--gold-500-rgb: 197, 140, 0;
   --pf-global--palette--gold-600: #795600;
   --pf-global--palette--gold-700: #3d2c00;
   --pf-global--palette--green-50: #f3faf2;

--- a/plugins/plugin-patternfly4-themes/web/scss/light.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/light.scss
@@ -64,7 +64,7 @@
   --color-base0D-rgb: var(--pf-global--palette--blue-400-rgb);
   --color-blue-rgb: var(--color-base0D-rgb);
 
-  --color-base0A-rgb: var(--pf-global--palette--orange-500-rgb);
+  --color-base0A-rgb: var(--pf-global--palette--gold-400-rgb);
   --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-background-03: var(--pf-global--palette--black-200);


### PR DESCRIPTION
[11.1.4 f99b23d67] fix: fetchfile controller refuses any in-browser fetch, even if CORS would allow it
 Date: Thu Jan 27 18:50:15 2022 -0500
 3 files changed, 29 insertions(+), 18 deletions(-)

[11.1.4 9ef67edbc] fix(plugins/plugin-patternfly4-themes): improve "warning" color in guidebooks for pf4-light theme
 Date: Fri Jan 28 14:48:35 2022 -0500
 2 files changed, 3 insertions(+), 1 deletion(-)

[11.1.4 cbe6bd32a] fix(plugins/plugin-client-common): markdown expandable sections can have double margins
 Date: Fri Jan 28 14:58:24 2022 -0500
 1 file changed, 7 insertions(+)

[11.1.4 e43ba159b] fix(plugins/plugin-client-common): a few small spacing tweaks to Guidebooks
 Date: Sat Jan 29 11:22:38 2022 -0500
 3 files changed, 6 insertions(+), 2 deletions(-)

[11.1.4 b4d5d2740] chore(plugins/plugin-client-common): clean up markdown code block source
 Date: Sat Jan 29 12:28:02 2022 -0500
 4 files changed, 9 insertions(+), 9 deletions(-)
 rename plugins/plugin-client-common/src/components/Content/Markdown/{codeblocks => components/code}/encoding.ts (96%)
 rename plugins/plugin-client-common/src/components/Content/Markdown/components/{code.tsx => code/index.tsx} (93%)
 rename plugins/plugin-client-common/src/components/Content/Markdown/{code-indexer.ts => components/code/rehype-code-indexer.ts} (98%)

[11.1.4 f286627f4] fix(plugins/plugin-client-common): another tweak for right-alignment of markdown
 Date: Sat Jan 29 13:12:02 2022 -0500
 2 files changed, 15 insertions(+), 8 deletions(-)
Auto-merging plugins/plugin-kubectl/notebooks/knative-getting-started.md

[11.1.4 720b18917] feat: allow markdown guidebooks to define code block metadata in topmatter
 Date: Sat Jan 29 14:12:47 2022 -0500
 10 files changed, 176 insertions(+), 19 deletions(-)
 create mode 100644 plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
 create mode 100644 plugins/plugin-client-common/tests/data/code-block1-base.md
 create mode 100644 plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter-via-snippet.md
 create mode 100644 plugins/plugin-client-common/tests/data/code-block1-validate-in-topmatter.md
[11.1.4 f4e0a8824] feat: when inlining guidebook snippets, rewrite relative image links
 Date: Sat Jan 29 19:11:50 2022 -0500
 7 files changed, 113 insertions(+), 166 deletions(-)
 rewrite plugins/plugin-iter8/notebooks/tutorial1.md (81%)

[11.1.4 4c059d85e] fix(plugins/plugin-client-common): snippet inliner image link rewriter does not handle two links on one line
 Date: Sat Jan 29 19:54:15 2022 -0500
 1 file changed, 5 insertions(+), 3 deletions(-)

[11.1.4 c9a090404] fix(plugins/plugin-client-common): recursive snippet inlining does not properly handle base path
 Date: Sun Jan 30 13:09:03 2022 -0500
 1 file changed, 10 insertions(+), 4 deletions(-)

[11.1.4 40ba36c04] feat(plugins/plugin-client-common): support for "question" tips in markdown
 Date: Sun Jan 30 13:34:41 2022 -0500
 3 files changed, 51 insertions(+), 31 deletions(-)

[11.1.4 00cd8307e] fix(plugins/plugin-client-common): avoid pre-wrap in guidebook paragraphs
 Date: Sun Jan 30 13:43:58 2022 -0500
 1 file changed, 23 insertions(+), 17 deletions(-)

[11.1.4 84082dae4] feat(plugins/plugin-client-common): support for markdown `<mark>` and `<kbd>` syntax
 Date: Sun Jan 30 15:14:22 2022 -0500
 12 files changed, 289 insertions(+), 2 deletions(-)
 create mode 100644 plugins/plugin-client-common/src/components/Content/Markdown/remark-keys.ts
 create mode 100644 plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
 create mode 100644 plugins/plugin-client-common/src/test/core/markdown/kbd.ts
 create mode 100644 plugins/plugin-client-common/src/test/core/markdown/mark.ts
 create mode 100644 plugins/plugin-client-common/tests/data/kbdtag1.md
 create mode 100644 plugins/plugin-client-common/tests/data/kbdtag2.md
 create mode 100644 plugins/plugin-client-common/tests/data/kbdtag3.md
 create mode 100644 plugins/plugin-client-common/tests/data/marktag1.md
 create mode 100644 plugins/plugin-client-common/tests/data/marktag2.md
 create mode 100644 plugins/plugin-client-common/web/scss/components/Terminal/Keys.scss

[11.1.4 970a5c2d4] fix(plugins/plugin-client-common): markdown mark tags sometimes confused with tabbed
 Date: Sun Jan 30 17:47:57 2022 -0500
 5 files changed, 69 insertions(+), 8 deletions(-)
 create mode 100644 plugins/plugin-client-common/tests/data/marktag3.md
 create mode 100644 plugins/plugin-client-common/tests/data/marktag4.md

[11.1.4 aa722e22c] doc: knative first-service and first-autoscale guidebooks
 Date: Sun Jan 30 18:07:23 2022 -0500
 4 files changed, 31 insertions(+), 1 deletion(-)
 create mode 100644 plugins/plugin-kubectl/notebooks/knative-first-autoscale.md
 create mode 100644 plugins/plugin-kubectl/notebooks/knative-first-service.md

[11.1.4 9addb0a58] fix(plugins/plugin-client-common): use inner scrolling of nav for sidebar
 Date: Sun Jan 30 18:12:21 2022 -0500
 1 file changed, 3 insertions(+)

[11.1.4 73ec8aa11] fix(plugins/plugin-client-common): if client does not define notebooks, Sidebar crashes on Escape
 Date: Sun Jan 30 18:46:55 2022 -0500
 1 file changed, 7 insertions(+), 5 deletions(-)

[11.1.4 4b40f55d8] fix(Plugins/plugin-client-common): saving guidebook fails with subset of responses
 Date: Mon Jan 31 10:30:10 2022 -0500
 1 file changed, 3 insertions(+), 1 deletion(-)

[11.1.4 e073fed23] feat: `<Kui/>` component should automate more of guidebook mounting
 Date: Mon Jan 31 10:29:12 2022 -0500
 13 files changed, 276 insertions(+), 67 deletions(-)
 rename packages/core/src/api/{client.ts => Client.ts} (56%)
 create mode 100644 packages/core/src/main/load.ts
 create mode 100644 plugins/plugin-client-common/src/mount.ts