### PR TITLE
fix(plugins/plugin-client-common): reduce saturation of tip headers

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Sidebar/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidebar/_index.scss
@@ -77,11 +77,6 @@ body[kui-theme-style='light'] {
   }
 }
 
-/* Sidebar width */
-@include Sidebar {
-  max-width: 15rem;
-}
-
 /* Coloring of bottom-aligned text */
 @include Sidebar {
   @include SidebarBottomAlignedContent {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -58,7 +58,7 @@
 @include Block {
   @include InputWrapper {
     border: $input-border;
-    border-radius: 6px;
+    border-radius: 1px;
     &[data-is-reedit] {
       border-color: $input-border-editing;
     }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -367,8 +367,8 @@ body[kui-theme-style='dark'] {
   }
 }
 
-$tip-toggle-opacity: 0.3;
-$tip-toggle-opacity-2: 0.9;
+$tip-toggle-opacity: 0.125;
+$tip-toggle-opacity-2: 0.6;
 
 @mixin GreenTip {
   $bgcolor: var(--color-base0B-rgb);
@@ -448,6 +448,9 @@ $tip-toggle-opacity-2: 0.9;
 }
 
 @mixin ParagraphBoundaryMargins {
+  & > pre:not(:first-child) {
+    margin-top: $inset;
+  }
   & > p:first-child {
     margin-top: 0;
   }

--- a/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
@@ -40,8 +40,8 @@
   }
   @include WizardNav {
     height: auto;
-    width: auto;
-    min-width: 14rem;
+    width: 16rem;
+    min-width: 16rem;
     max-width: 16rem;
     position: unset;
   }


### PR DESCRIPTION
we are using a pretty bold color right now, which is distracting. mkdocs uses a much less saturated color for the headers/button part of expandable sections.

this pr also reduces the border-radius on code blocks (6px -> 1px)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
