### PR TITLE
fix(plugins/plugin-client-common): when including snippets, ignore tr…

### DIFF
--- a/plugins/plugin-client-common/src/controller/snippets.ts
+++ b/plugins/plugin-client-common/src/controller/snippets.ts
@@ -54,7 +54,7 @@ function isAbsolute(uri: string): boolean {
 }
 
 function toString(data: string | object) {
-  return typeof data === 'string' ? data : JSON.stringify(data)
+  return (typeof data === 'string' ? data : JSON.stringify(data)).replace(/\n$/, '')
 }
 
 /** Rewrite any relative image links to use the given basePath */


### PR DESCRIPTION
…ailing newlines

This semantics is not specified in the pymdown docs: https://facelessuser.github.io/pymdown-extensions/extensions/snippets/
But seems to be the case.

It probably makes sense to ignore trailing newlines. this lets you control the paragraph spacing in the parent document.
Precisely for cases like using a snippet to bring in an svg icon, where you want the icon adjoined into a single paragraph with the icon link content

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
