### PR TITLE
chore: remove unused dependences in nested package.json

### DIFF
--- a/plugins/plugin-kubectl/logs/package.json
+++ b/plugins/plugin-kubectl/logs/package.json
@@ -26,16 +26,7 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
-  "dependencies": {
-    "@kui-shell/core": "^8.0.6",
-    "@kui-shell/plugin-bash-like": "^8.0.6",
-    "@kui-shell/plugin-core-support": "^8.0.6",
-    "@kui-shell/plugin-editor": "^8.0.6",
-    "@IBM/kui": "*",
-    "ansi_up": "4.0.4",
-    "debug": "4.1.1",
-    "js-yaml": "4.1.0"
-  },
+  "dependencies": {},
   "krew": {
     "commandPrefix": "kubeui"
   },


### PR DESCRIPTION
THis should clear up a false positive dependabot alert for ansi_up

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
