### PR TITLE
fix(plugins/plugin-client-common): tip-after-tip in markdown fails to…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -279,6 +279,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
     return hackKeys(hackMarks(hackIndentation(source)))
       .trim()
       .replace(/\){target=[^}]+}/g, ')')
+      .replace(/{draggable=(false|true)}/g, '')
   }
 
   /** We got a code block response from execution in this session */

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/index.ts
@@ -151,10 +151,6 @@ export default function plugin(/* options */) {
   }
 }
 
-function XOR(a: boolean, b: boolean) {
-  return (a || b) && !(a && b)
-}
-
 /**
  * pymdown uses indentation to define tab content; remark-parse seems
  * to turn these into <pre> blocks before we get control; hack it for
@@ -213,7 +209,7 @@ export function hackIndentation(source: string): string {
       const endMarker = tabStartMatch ? END_OF_TAB : END_OF_TIP
 
       const possibleEndTab =
-        indentDepth === thisIndentDepth && XOR(currentEndMarker === END_OF_TIP, endMarker === END_OF_TIP)
+        (indentDepth === thisIndentDepth && currentEndMarker === END_OF_TIP) || endMarker === END_OF_TIP
           ? pop(line, 0)
           : !(inTab && indentDepth > thisIndentDepth)
           ? ''

--- a/plugins/plugin-client-common/src/test/core/markdown/tip.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/tip.ts
@@ -29,7 +29,23 @@ const IN2 = {
   input: join(ROOT, 'data', 'tip-no-title.md'),
   tips: [{ title: 'Warning', content: 'YYYY' }]
 }
-;[IN1, IN2].forEach(markdown => {
+
+const IN3 = {
+  input: join(ROOT, 'data', 'tip-after-tip.md'),
+  tips: [
+    { title: 'Warning', content: 'XXXX' },
+    {
+      title: 'TTTT',
+      content: `YYYY
+ZZZZ`
+    }
+  ]
+}
+const IN4 = {
+  input: join(ROOT, 'data', 'tip-after-tip-in-tab.md'),
+  tips: IN3.tips
+}
+;[IN1, IN2, IN3, IN4].forEach(markdown => {
   describe(`markdown expandable section ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
     ''}`, function(this: Common.ISuite) {
     before(Common.before(this))

--- a/plugins/plugin-client-common/tests/data/tip-after-tip-in-tab.md
+++ b/plugins/plugin-client-common/tests/data/tip-after-tip-in-tab.md
@@ -1,0 +1,9 @@
+=== "Tab1"
+    !!! warning
+        XXXX
+
+???+ question "TTTT"
+    YYYY
+
+    ZZZZ
+

--- a/plugins/plugin-client-common/tests/data/tip-after-tip.md
+++ b/plugins/plugin-client-common/tests/data/tip-after-tip.md
@@ -1,0 +1,8 @@
+!!! warning
+    XXXX
+
+???+ question "TTTT"
+    YYYY
+
+    ZZZZ
+


### PR DESCRIPTION
… render second tip

Also includes a workaround for mis-rendered `{draggable=false}`


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
