### PR TITLE
fix(plugins/plugin-client-common): markdown tables can have odd ellipsis

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/table.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/table.tsx
@@ -39,7 +39,15 @@ export function tr(props: TableRowProps) {
 }
 
 export function th(props: TableCellProps) {
-  return <Th className={props.className}>{props.children}</Th>
+  // hmm, without modifier=wrap, PatternFly (or is it electron
+  // 13?)... if the td content is narrower than the th content, they
+  // seem to favor favor ellipsis for that wider column header. This
+  // looks especially bad if the td content is quite narrow.
+  return (
+    <Th className={props.className} modifier="wrap">
+      {props.children}
+    </Th>
+  )
 }
 
 export function td(props: TableCellProps) {


### PR DESCRIPTION
In cases where the `<td/>` content is far narrower than the corresponding `<th/>` for that column, PatternFly (or is it Electron 13?) seems to favor ellipsis for the column header. This looks looks particularly bad if the td is quite narrow.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
