### PR TITLE
doc: add "Knative -" prefix to some of the knative guidebook titles

### DIFF
--- a/plugins/plugin-kubectl/notebooks/knative-eventing-components.md
+++ b/plugins/plugin-kubectl/notebooks/knative-eventing-components.md
@@ -1,5 +1,5 @@
 ---
-title: Eventing Components
+title: Knaive &mdash; Eventing Components
 description: Eventing components
 layout:
     1: left

--- a/plugins/plugin-kubectl/notebooks/knative-introducing-eventing.md
+++ b/plugins/plugin-kubectl/notebooks/knative-introducing-eventing.md
@@ -1,5 +1,5 @@
 ---
-title: Introducing Eventing
+title: Knaive &mdash; Introducing Eventing
 layout:
     1: left
 ---

--- a/plugins/plugin-kubectl/notebooks/knative-traffic-splitting.md
+++ b/plugins/plugin-kubectl/notebooks/knative-traffic-splitting.md
@@ -1,5 +1,5 @@
 ---
-title: Traffic Splitting
+title: Knaive &mdash; Traffic Splitting
 layout:
     1: left
     default: wizard


### PR DESCRIPTION
To make the titles more consistent.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
