### PR TITLE
fix(plugins/plugin-client-common): sidebar nav expansions not persisted

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
@@ -16,11 +16,11 @@
 
 import React from 'react'
 import { encodeComponent, i18n, pexecInCurrentTab } from '@kui-shell/core'
-import { PageSidebar } from '@patternfly/react-core'
+import { PageSidebar, PageSidebarProps } from '@patternfly/react-core'
 
 import CommonProps from './props/Common'
 import BrandingProps from './props/Branding'
-import GuidebookProps, { isGuidebook, isMenu, MenuItem } from './props/Guidebooks'
+import GuidebookProps, { isGuidebook, Guidebook, isMenu, MenuItem } from './props/Guidebooks'
 
 import '../../../web/scss/components/Sidebar/_index.scss'
 
@@ -44,7 +44,7 @@ type Props = Pick<CommonProps, 'noTopTabs'> &
     toggleOpen(): void
   }
 
-interface State {
+type State = Pick<PageSidebarProps, 'nav'> & {
   /** in noTopTabs mode, we indicate selected guidebook in the NavItem below */
   currentGuidebook?: string
 }
@@ -54,11 +54,13 @@ export default class Sidebar extends React.PureComponent<Props, State> {
 
   public constructor(props: Props) {
     super(props)
-    this.state = {}
+    this.state = {
+      nav: this.nav() // pre-render to help with persistence of isExpanded state
+    }
   }
 
   private get currentGuidebook() {
-    return this.state.currentGuidebook
+    return this.state ? this.state.currentGuidebook : undefined
   }
 
   private readonly onKeyup = (evt: KeyboardEvent) => {
@@ -76,12 +78,34 @@ export default class Sidebar extends React.PureComponent<Props, State> {
     this.cleaners.forEach(_ => _())
   }
 
-  private nav() {
+  /** e.g. product version */
+  private footer() {
+    return (
+      this.props.productName &&
+      this.props.version && (
+        <div className="kui--tab-container-sidebar-other flex-layout">
+          <span className="flex-fill sub-text">{strings('Toggle via <Esc>')}</span>
+          <span className="inline-flex flex-align-end semi-bold">v{this.props.version}</span>
+        </div>
+      )
+    )
+  }
+
+  /** User has clicked to select a given Guidebook */
+  private onSelect(_: Guidebook) {
+    const quiet = !this.props.noTopTabs
+    pexecInCurrentTab(`${this.props.guidebooksCommand || 'replay'} ${encodeComponent(_.filepath)}`, undefined, quiet)
+
+    this.setState({ currentGuidebook: _.notebook })
+  }
+
+  /** Render the menu structure of the sidebar */
+  private menu() {
     // helps deal with isActive; if we don't have a currentGuidebook,
     // use the first one (for now)
     let first = !this.currentGuidebook
 
-    const renderItem = (_: MenuItem, idx) => {
+    const renderItem = (_: MenuItem, idx: number) => {
       const thisIsTheFirstNavItem = isGuidebook(_) && first
       if (thisIsTheFirstNavItem) {
         first = false
@@ -92,26 +116,18 @@ export default class Sidebar extends React.PureComponent<Props, State> {
           key={idx}
           data-title={_.notebook}
           className="kui--sidebar-nav-item"
+          onClick={this.onSelect.bind(this, _)}
           isActive={this.props.indicateActiveItem && (_.notebook === this.currentGuidebook || thisIsTheFirstNavItem)}
-          onClick={() => {
-            const quiet = !this.props.noTopTabs
-            pexecInCurrentTab(
-              `${this.props.guidebooksCommand || 'replay'} ${encodeComponent(_.filepath)}`,
-              undefined,
-              quiet
-            )
-            this.setState({ currentGuidebook: _.notebook })
-          }}
         >
           {_.notebook}
         </NavItem>
       ) : isMenu(_) ? (
         <NavExpandable
           key={idx}
-          isExpanded={_.expanded !== false}
           title={_.label}
-          className="kui--sidebar-nav-menu"
           data-title={_.label}
+          className="kui--sidebar-nav-menu"
+          isExpanded={_.expanded !== false}
         >
           {_.submenu.map(renderItem)}
         </NavExpandable>
@@ -121,28 +137,36 @@ export default class Sidebar extends React.PureComponent<Props, State> {
     }
 
     return (
-      <React.Suspense fallback={<div />}>
-        <Nav className="kui--tab-container-sidebar-nav">
-          <NavList>{this.props.guidebooks.map(renderItem)}</NavList>
-        </Nav>
-        {this.props.productName && this.props.version && (
-          <div className="kui--tab-container-sidebar-other flex-layout">
-            <span className="flex-fill sub-text">{strings('Toggle via <Esc>')}</span>
-            <span className="inline-flex flex-align-end semi-bold">v{this.props.version}</span>
-          </div>
-        )}
-      </React.Suspense>
+      Array.isArray(this.props.guidebooks) && (
+        <React.Suspense fallback={<div />}>
+          <Nav className="kui--tab-container-sidebar-nav">
+            <NavList>{this.props.guidebooks.map(renderItem)}</NavList>
+          </Nav>
+        </React.Suspense>
+      )
+    )
+  }
+
+  /**
+   * This is the entirety of the contents of the sidebar. The method
+   * is named `nav` because that is what the PatternFly component
+   * calls the corresponding property.
+   */
+  private nav() {
+    return (
+      Array.isArray(this.props.guidebooks) && (
+        <React.Fragment>
+          {this.menu()}
+          {this.footer()}
+        </React.Fragment>
+      )
     )
   }
 
   public render() {
     return (
-      Array.isArray(this.props.guidebooks) && (
-        <PageSidebar
-          nav={this.props.isOpen && this.nav()}
-          isNavOpen={this.props.isOpen}
-          className="kui--tab-container-sidebar"
-        />
+      this.state.nav && (
+        <PageSidebar nav={this.state.nav} isNavOpen={this.props.isOpen} className="kui--tab-container-sidebar" />
       )
     )
   }

--- a/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-type Guidebook = { notebook: string; filepath: string }
+export type Guidebook = { notebook: string; filepath: string }
 type Menu = { label: string; submenu: MenuItem[]; expanded?: boolean }
 export type MenuItem = Guidebook | Menu | object
 


### PR DESCRIPTION
When you close then re-open the Sidebar, any nav items you may have expanded are now back to their initial state.

This PR also does a small bit of code cleanup in Sidebar.tsx.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
