### PR TITLE
fix: update base tsconfig to avoid specifying webdriverio types

### DIFF
--- a/packages/builder/tsconfig-base.json
+++ b/packages/builder/tsconfig-base.json
@@ -14,7 +14,6 @@
     "declaration": true,
     "experimentalDecorators": true,
     "resolveJsonModule": true,
-    "types": ["node", "webdriverio/async"],
     "lib": ["dom", "esnext", "es6", "dom.iterable", "scripthost"]
   }
 }


### PR DESCRIPTION
I thought we needed these, but it turns out that the default behavior works ok.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
