### PR TITLE
feat(plugins/plugin-client-common): wizard mini progress should use o…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/MiniProgressStepper.tsx
+++ b/plugins/plugin-client-common/src/components/Content/MiniProgressStepper.tsx
@@ -18,8 +18,9 @@ import React from 'react'
 import { i18n, pexecInCurrentTab } from '@kui-shell/core'
 
 import Tooltip from '../spi/Tooltip'
+import Spinner from '../Views/Terminal/Block/Spinner'
 import { emitLinkUpdate, subscribeToLinkUpdates, unsubscribeToLinkUpdates } from './LinkStatus'
-import { ProgressStepState, statusFromStatusVector, statusToClassName, statusToIcon } from './ProgressStepper'
+import { ProgressStepState, statusFromStatusVector, statusToClassName } from './ProgressStepper'
 
 import '../../../web/scss/components/Wizard/MiniProgressStepper.scss'
 
@@ -76,7 +77,7 @@ export class MiniProgressStep extends React.PureComponent<MiniProps, ProgressSte
   }
 
   private icon() {
-    return this.status === 'in-progress' ? statusToIcon(this.status) : <React.Fragment />
+    return this.status === 'in-progress' ? <Spinner /> : <React.Fragment />
   }
 
   private get tooltipText() {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Spinner.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Spinner.tsx
@@ -22,6 +22,8 @@
 import React from 'react'
 import 'spinkit/spinkit.min.css'
 
+import '../../../../../web/scss/components/Terminal/Spinner.scss'
+
 interface Props {
   className?: string
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_index.scss
@@ -26,4 +26,3 @@
 @import 'Playground';
 @import 'Scrollback';
 @import 'SourceRef';
-@import 'Spinner';

--- a/plugins/plugin-client-common/web/scss/components/Wizard/MiniProgressStepper.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/MiniProgressStepper.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@import '../Terminal/mixins';
 @import '../ProgressStepper/mixins';
 
 $small: 0.5rem;
@@ -21,6 +22,10 @@ $regular: 0.75rem;
 
 @include MiniProgressStepper {
   --pf-c-progress-stepper__step-icon--Width: #{$regular};
+
+  @include Spinner {
+    --sk-color: var(--color-yellow);
+  }
 
   @include Connector {
     align-items: center;


### PR DESCRIPTION
…ur Spinner component

this works better in a grid ui than the patternfly circular loop spinner

the yellow square here, which animates in the same way that the normal kui repl spinner does.

<img width="1392" alt="Screen Shot 2022-02-09 at 4 25 12 PM" src="https://user-images.githubusercontent.com/4741620/153292669-4ed213ef-5fda-4817-9536-5b7abf71dbc0.png">



<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
