### PR TITLE
feat(plugins/plugin-client-common): assign code blocks an ordinal exe…

### DIFF
--- a/packages/test/src/api/Markdown.ts
+++ b/packages/test/src/api/Markdown.ts
@@ -19,6 +19,9 @@ export default class Markdown {
   public readonly tabs = '.kui--markdown-tabs'
   public readonly tab = `${this.tabs} .kui--markdown-tab button`
 
+  private readonly _codeBlock = '.kui--code-block-in-markdown'
+  public readonly runButton = '.kui--block-action-run'
+
   public tipWithTitle(title: string) {
     return `${this.tip}[data-title="${title}"]`
   }
@@ -29,5 +32,9 @@ export default class Markdown {
 
   public tabWithTitle(title: string) {
     return `${this.tab}[data-title="${title}"]`
+  }
+
+  public codeBlock(index: number) {
+    return `${this._codeBlock}[data-code-index="${index}"]`
   }
 }

--- a/packages/test/src/api/Wizard.ts
+++ b/packages/test/src/api/Wizard.ts
@@ -20,6 +20,7 @@ export default class Wizard {
   private readonly _description = '.pf-c-wizard__description'
   private readonly _navItem = '.pf-c-wizard__nav-item'
   private readonly _navItemTitle = '.pf-c-wizard__nav-link'
+  public readonly isCurrentStep = 'pf-m-current'
   private readonly _navItemDescription = '.kui--wizard-nav-item-description'
   private readonly _navItemProgressStepper = '.kui--progress-stepper'
   private readonly _navItemProgressStep = '.kui--progress-step'
@@ -40,6 +41,10 @@ export default class Wizard {
 
   public navItem(idx: number) {
     return `${this.wizard} ${this._navItem}:nth-child(${idx + 1})`
+  }
+
+  public navItemSwitchToButton(idx: number) {
+    return `${this.navItem(idx)} > button`
   }
 
   public navItemTitle(idx: number) {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/CodeBlockEvents.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/CodeBlockEvents.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EventEmitter } from 'events'
+
+const events = new EventEmitter()
+
+export type ReadinessHandler = (readyForExecution: boolean) => void
+
+export function emitCodeBlockReadiness(codeBlockId: string, readyForExecution: boolean) {
+  events.emit(`/ready/broadcast/${codeBlockId}`, readyForExecution)
+}
+export function onCodeBlockReadiness(codeBlockId: string, handler: ReadinessHandler) {
+  events.on(`/ready/broadcast/${codeBlockId}`, handler)
+}
+export function offCodeBlockReadiness(codeBlockId: string, handler: ReadinessHandler) {
+  events.off(`/ready/broadcast/${codeBlockId}`, handler)
+}
+
+export function emitGetCodeBlockReadiness(codeBlockId: string, handler: ReadinessHandler) {
+  events.emit(`/ready/get/${codeBlockId}`, handler, codeBlockId)
+}
+export function onGetCodeBlockReadiness(
+  codeBlockId: string,
+  getHandler: (handler: ReadinessHandler, codeBlockId: string) => void
+) {
+  events.on(`/ready/get/${codeBlockId}`, getHandler)
+}
+export function offGetCodeBlockReadiness(
+  codeBlockId: string,
+  getHandler: (handler: ReadinessHandler, codeBlockId: string) => void
+) {
+  events.off(`/ready/get/${codeBlockId}`, getHandler)
+}

--- a/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
@@ -69,7 +69,7 @@ import {
   SearchIcon as Search,
   BellIcon as Notification,
   QuestionIcon as Unknown,
-  PlayCircleIcon as Play
+  PlayIcon as Play
 } from '@patternfly/react-icons'
 
 import { Props } from '..'

--- a/plugins/plugin-client-common/src/test/core/markdown-helpers.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown-helpers.ts
@@ -71,11 +71,11 @@ export async function checkBlockValidation(ctx: Common.ISuite, split: Position, 
 }
 
 export async function clickToExecuteBlock(this: Common.ISuite, split: Position, block: Block) {
-  const codeBlockSelector = `${split()} .kui--code-block-in-markdown[data-code-index="${block.index}"]`
+  const codeBlockSelector = `${split()} ${Selectors.Markdown.codeBlock(block.index)}`
   const codeBlock = await this.app.client.$(codeBlockSelector)
   await codeBlock.waitForDisplayed({ timeout: CLI.waitTimeout })
 
-  const runAction = await codeBlock.$('.kui--block-action-run')
+  const runAction = await codeBlock.$(Selectors.Markdown.runButton)
   await codeBlock.moveTo()
   await runAction.waitForDisplayed({ timeout: CLI.waitTimeout })
 

--- a/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter2.md
+++ b/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter2.md
@@ -1,0 +1,38 @@
+---
+wizard:
+    steps:
+        - AAA
+        - BBB
+        - CCC
+---
+
+# WizardTitle
+
+WizardDescription
+
+---
+
+## AAA
+
+AAAContent
+
+```bash
+echo 111
+```
+
+## BBB
+
+BBBContent
+
+```bash
+echo 222
+```
+
+## CCC
+
+CCCContent
+
+```bash
+echo 333
+```
+

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -66,9 +66,22 @@ $box-shadow-margin: 4px; /* room for box shadow */
   }
 }
 
+/** Prereqs not yet satisfied? */
+@mixin NotReady {
+  &:not([data-is-ready]) {
+    @content;
+  }
+}
+
 @mixin GrayAction {
   @include InputWrapper {
     --color-for-guidebook-block-actions: var(--color-text-02);
+  }
+}
+
+@mixin WarningAction {
+  @include InputWrapper {
+    --color-for-guidebook-block-actions: var(--color-red);
   }
 }
 
@@ -78,6 +91,11 @@ $box-shadow-margin: 4px; /* room for box shadow */
       display: none;
     }
   }
+}
+
+@mixin InvisibleActionExceptOnHoverThenWarning {
+  @include WarningAction;
+  @include InvisibleActionExceptOnHover;
 }
 
 body[kui-theme-style] {
@@ -626,7 +644,7 @@ pre {
 @include Commentary {
   @include Block {
     @include InputWrapper {
-      $action-size: 1.25;
+      $action-size: 1;
       --color-for-guidebook-block-actions: var(--color-brand-01);
       @include Spinner {
         padding: 0;
@@ -637,6 +655,10 @@ pre {
         font-size: $action-size + em;
         color: var(--color-for-guidebook-block-actions);
       }
+    }
+
+    @include NotReady {
+      @include InvisibleActionExceptOnHoverThenWarning;
     }
 
     @include Optional {


### PR DESCRIPTION
…cution order

This PR allows us generally to enable/disable or show/hide code block run buttons based on the ordering constraints implicit in a Wizard guidebook. For this PR, we show/hide the run buttons, with some varying tooltips and hover colors to indicate the state.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
