### PR TITLE
feat(plugins/plugin-client-common): show code block Run in offline cl…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
@@ -85,6 +85,7 @@ export default function code(
             optional={attributes.optional}
             response={response}
             status={statusConsideringReplay}
+            rawStatus={status}
             arg1={myCodeIdx}
             onResponse={spliceInCodeExecution}
             outputOnly={outputOnly}


### PR DESCRIPTION
…ients with sample output

Right now, we always hide the Run button for code blocks if offline clients. We do this, even if we have sample output. This PR adjusts this behavior so that we do show the Run button in this situation, but treat "running" as merely showing the sample output.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
