### PR TITLE
11.2.4

### DIFF
--- a/packages/test/src/api/Markdown.ts
+++ b/packages/test/src/api/Markdown.ts
@@ -19,6 +19,9 @@ export default class Markdown {
   public readonly tabs = '.kui--markdown-tabs'
   public readonly tab = `${this.tabs} .kui--markdown-tab button`
 
+  private readonly _codeBlock = '.kui--code-block-in-markdown'
+  public readonly runButton = '.kui--block-action-run'
+
   public tipWithTitle(title: string) {
     return `${this.tip}[data-title="${title}"]`
   }
@@ -29,5 +32,9 @@ export default class Markdown {
 
   public tabWithTitle(title: string) {
     return `${this.tab}[data-title="${title}"]`
+  }
+
+  public codeBlock(index: number) {
+    return `${this._codeBlock}[data-code-index="${index}"]`
   }
 }

--- a/packages/test/src/api/Wizard.ts
+++ b/packages/test/src/api/Wizard.ts
@@ -24,6 +24,7 @@ export default class Wizard {
   private readonly _navItemProgressStepper = '.kui--progress-stepper'
   private readonly _navItemProgressStep = '.kui--progress-step'
   private readonly _body = '.pf-c-wizard__main-body'
+  private readonly _wizardProgressMeasure = '.pf-c-progress__measure'
 
   public withTitle(title: string) {
     return `${this.wizard} ${this.title}[aria-label="${title}"]`
@@ -59,5 +60,9 @@ export default class Wizard {
 
   public navItemProgressStep(navIdx: number, stepIdx: number) {
     return `${this.navItemProgressSteps(navIdx)}:nth-child(${stepIdx + 1})`
+  }
+
+  public get progressMeasure() {
+    return `${this.wizard} ${this._wizardProgressMeasure}`
   }
 }

--- a/packages/test/src/api/Wizard.ts
+++ b/packages/test/src/api/Wizard.ts
@@ -20,6 +20,7 @@ export default class Wizard {
   private readonly _description = '.pf-c-wizard__description'
   private readonly _navItem = '.pf-c-wizard__nav-item'
   private readonly _navItemTitle = '.pf-c-wizard__nav-link'
+  public readonly isCurrentStep = 'pf-m-current'
   private readonly _navItemDescription = '.kui--wizard-nav-item-description'
   private readonly _navItemProgressStepper = '.kui--progress-stepper'
   private readonly _navItemProgressStep = '.kui--progress-step'
@@ -40,6 +41,10 @@ export default class Wizard {
 
   public navItem(idx: number) {
     return `${this.wizard} ${this._navItem}:nth-child(${idx + 1})`
+  }
+
+  public navItemSwitchToButton(idx: number) {
+    return `${this.navItem(idx)} > button`
   }
 
   public navItemTitle(idx: number) {

--- a/plugins/plugin-client-common/i18n/code_en_US.json
+++ b/plugins/plugin-client-common/i18n/code_en_US.json
@@ -1,6 +1,5 @@
 {
   "Code Block": "Code Block",
-  "Optional Code Block": "Code Block *(this code block is optional)*",
 
   "xOfy": "{0} of {1}",
   "xOfyFailingz": "{0} of {2} ({1} failure)",
@@ -8,10 +7,11 @@
 
   "Completed tasks": "Completed tasks",
 
+  "status.optional": "This code block is optional :fontawesome-solid-dot-circle:",
   "status.blank": "Not yet executed",
-  "status.success": "Successfully executed",
+  "status.success": "Successfully executed :fontawesome-solid-check-circle:",
   "status.warning": "Warning",
-  "status.error": "Error in execution",
+  "status.error": "Error in execution :fontawesome-solid-exclamation-circle:",
   "status.pending": "Pending execution",
   "status.in-progress": "Processing...",
   "status.unknown": "Status unknown"

--- a/plugins/plugin-client-common/i18n/code_en_US.json
+++ b/plugins/plugin-client-common/i18n/code_en_US.json
@@ -1,7 +1,11 @@
 {
   "Code Block": "Code Block",
+  "Optional Code Block": "Code Block *(this code block is optional)*",
 
   "xOfy": "{0} of {1}",
+  "xOfyFailingz": "{0} of {2} ({1} failure)",
+  "xOfyFailingsz": "{0} of {2} ({1} failures)",
+
   "Completed tasks": "Completed tasks",
 
   "status.blank": "Not yet executed",

--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -54,7 +54,11 @@
   "concurrencyColdStartInDurationSplit": "{0}-way concurrency in cold starts with execution time {1}",
   "Copy": "Copy",
   "Rerun": "Rerun",
+
+  "Execute this command": "Execute this command",
   "Re-execute this command": "Re-execute this command",
+  "Execution of this command is optional": "Execution of this command is optional",
+
   "Insert Command": "Insert Command",
   "Split the terminal": "Split the terminal {0}",
   "Output has been pinned to a watch pane": "Output has been **pinned** to a watch pane",

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/CodeBlockProps.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/CodeBlockProps.ts
@@ -18,5 +18,26 @@ export default interface CodeBlockProps {
   id: string
   body: string
   language: string
+  optional?: boolean
   validate?: string
+
+  /**
+   * Is this a member of a group of choices? e.g. am I `A` in a choice
+   * to do either `A+B` or `C+D`?
+   */
+  choice?: {
+    /**
+     * This option names the group, to keep it distinct from other
+     * groups of choices.
+     */
+    group?: string
+
+    /**
+     * This option names that member. e.g. if the user can choose
+     * between doing either A-and-B or C-and-D, this identifies
+     * whether we are part ofth e first choice (A+B) or the second
+     * (C+D).
+     */
+    member?: string
+  }
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/README.md
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/README.md
@@ -1,0 +1,34 @@
+# Markdown Code Block Handling
+
+## Execution Ordering Constraints
+
+- markdown tabs represent an exclusive set of options
+  - code blocks within a tab must be executed sequentially
+- code blocks within a wizard step can be executed in any order
+- across wizard steps, the groups of code blocks in each step must be executed sequentially in the order of the wizard steps
+
+```
+  *************
+  Wizard Step 1
+      CodeA
+  *************
+
+  *************
+  Wizard Step 2
+
+  |Tab1 | | Tab 2 |
+    CodeB   CodeC
+            CodeD
+            CodeE
+  *************
+
+  *************
+  Wizard Step 3
+      CodeF
+  *************
+```
+
+Under those rules, a partial ordering of this markdown is:
+
+    CodeA -> CodeB                    -> CodeF
+         \-> CodeC -> CodeD -> CodeE  -/

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/dump.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/dump.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Re-serialize the given attributes and code block body */
+export default function dump(attributes: Record<string, any>, body: string) {
+  return `
+---
+${require('js-yaml').dump(attributes)}
+---
+${body}
+`
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This file defines a dependence structure over a set of code
+ * blocks. @see ./README.md for more detail.
+ *
+ * Given a set of code blocks. call `compile` to get a `Graph`. Given
+ * a Graph, you may ask for its `progress` towards completion, or, via
+ * `blocks`, ask for a linear dump back to the original set of code
+ * blocks.
+ *
+ */
+
+import CodeBlockProps from '../Wizard/CodeBlockProps'
+import { ProgressStepState } from '../../../ProgressStepper'
+
+type Status = ProgressStepState['status']
+
+/* map from choice group to selected choice member */
+type ChoicesMap = Record<CodeBlockProps['choice']['group'], CodeBlockProps['choice']['member']>
+
+interface Sequence {
+  sequence: Graph[]
+}
+
+interface Choice {
+  group: string
+
+  choices: {
+    member: string
+    graph: Sequence
+  }[]
+}
+
+interface Parallel {
+  parallel: Graph[]
+}
+
+export type Graph = Choice | Sequence | Parallel | CodeBlockProps
+
+function isChoice(graph: Graph): graph is Choice {
+  return Array.isArray((graph as Choice).choices)
+}
+
+function isSequence(graph: Graph): graph is Sequence {
+  return Array.isArray((graph as Sequence).sequence)
+}
+
+function isParallel(graph: Graph): graph is Parallel {
+  return Array.isArray((graph as Parallel).parallel)
+}
+
+export function sequence(parts: Graph[]): Sequence {
+  return {
+    sequence: parts
+  }
+}
+
+export function parallel(parts: Graph[]): Parallel {
+  return {
+    parallel: parts
+  }
+}
+
+function seq(block: CodeBlockProps): Sequence {
+  return sequence([block])
+}
+
+export function compile(blocks: CodeBlockProps[], ordering: 'sequence' | 'parallel' = 'parallel'): Graph {
+  let currentChoices: Choice
+  let currentChoice: CodeBlockProps['choice']
+
+  const parts: Graph[] = []
+
+  blocks.forEach(block => {
+    if (block.choice) {
+      if (!currentChoice || currentChoice.group !== block.choice.group) {
+        currentChoice = block.choice
+
+        currentChoices = {
+          group: block.choice.group,
+          choices: [
+            {
+              member: block.choice.member,
+              graph: seq(block)
+            }
+          ]
+        }
+
+        parts.push(currentChoices)
+      } else if (currentChoice.member === block.choice.member) {
+        // continuation of the current choice member
+        currentChoices.choices[currentChoices.choices.length - 1].graph.sequence.push(block)
+      } else {
+        // next member of the current choice group
+        currentChoice = block.choice
+        currentChoices.choices.push({
+          member: block.choice.member,
+          graph: seq(block)
+        })
+      }
+    } else {
+      parts.push(block)
+    }
+  })
+
+  return parts.length === 0
+    ? undefined
+    : parts.length === 1
+    ? parts[0]
+    : ordering === 'parallel'
+    ? parallel(parts)
+    : sequence(parts)
+}
+
+/**
+ * @return the current choice, which defaults to the first if we are
+ * not provided a set of user choices via the `choices` parameter. The
+ * decision to default to the first choice stems from a common origin
+ * UI, of presenting choices in a set of tabs; in a tabular UI,
+ * usually the first tab is open by default.
+ */
+function choose(graph: Choice, choices: 'default-path' | ChoicesMap = 'default-path'): Graph {
+  const selectedMember = choices !== 'default-path' ? choices[graph.group] : undefined
+
+  const choice = (selectedMember && graph.choices.find(_ => _.member === selectedMember)) || graph.choices[0]
+
+  return choice.graph
+}
+
+/** @return A linearized set of code blocks in the given `graph` */
+export function blocks(graph: Graph, choices: 'all' | 'default-path' | ChoicesMap = 'default-path'): CodeBlockProps[] {
+  const subblocks = (subgraph: Graph) => blocks(subgraph, choices)
+
+  if (!graph) {
+    return []
+  } else if (isSequence(graph)) {
+    return graph.sequence.flatMap(subblocks)
+  } else if (isParallel(graph)) {
+    return graph.parallel.flatMap(subblocks)
+  } else if (isChoice(graph)) {
+    if (choices === 'all') {
+      // return the union across all choices
+      return graph.choices.map(_ => _.graph).flatMap(subblocks)
+    } else {
+      // return the current/default selection
+      return subblocks(choose(graph, choices))
+    }
+    // } else if (graph.optional) { <-- if you want to exclude optional blocks from the MiniProgressStep UI
+    // return []
+  } else {
+    return [graph]
+  }
+}
+
+/** @return progress towards success of the given `graph` */
+export function progress(
+  graph: Graph,
+  statusMap?: Record<string, Status> /* map key is code block id */,
+  choices?: ChoicesMap
+): { nDone: number; nError: number; nTotal: number } {
+  const zero = { nDone: 0, nError: 0, nTotal: 0 }
+  const subprogress = (subgraph: Graph) => progress(subgraph, statusMap, choices)
+
+  if (!graph) {
+    return zero
+  } else if (isSequence(graph) || isParallel(graph)) {
+    // Sequence | Parallel => sum across parts
+    const parts = (isSequence(graph) ? graph.sequence : graph.parallel).map(subprogress)
+
+    return {
+      nDone: parts.reduce((N, part) => N + part.nDone, 0),
+      nError: parts.reduce((N, part) => N + part.nError, 0),
+      nTotal: parts.reduce((N, part) => N + part.nTotal, 0)
+    }
+  } else if (isChoice(graph)) {
+    // choice => consult choices? model, otherwise assume first choice (first tab is selected)
+    return subprogress(choose(graph, choices))
+  } else {
+    // individual code block
+
+    if (graph.optional) {
+      return zero
+    } else {
+      const status: Status = (statusMap && statusMap[graph.id]) || 'blank'
+
+      return {
+        nDone: status === 'success' ? 1 : 0,
+        nError: status === 'error' ? 1 : 0,
+        nTotal: 1
+      }
+    }
+  }
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
@@ -72,16 +72,16 @@ export default function code(
 
       return (
         <React.Fragment>
-          {attributes.id && <a id={`kui-link-${attributes.id}`} />}
           <Input
             readonly={false}
+            id={`kui-link-${blockId}`}
             className="kui--code-block-in-markdown"
             tab={mdprops.tab}
             value={body}
             watch={attributes.watch}
             language={language}
             blockId={blockId}
-            validate={attributes.validate === '$body' ? body : attributes.validate}
+            validate={attributes.validate}
             response={response}
             status={statusConsideringReplay}
             arg1={myCodeIdx}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
@@ -85,6 +85,7 @@ export default function code(
             optional={attributes.optional}
             response={response}
             status={statusConsideringReplay}
+            rawStatus={status}
             arg1={myCodeIdx}
             onResponse={spliceInCodeExecution}
             outputOnly={outputOnly}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
@@ -21,7 +21,7 @@ import { KResponse, CommentaryResponse, getPrimaryTabId } from '@kui-shell/core'
 import { Props } from '../../../Markdown'
 import { tryFrontmatter } from '../../frontmatter'
 
-import Input from '../../../../Views/Terminal/Block/Inputv2'
+import CodeBlock from '../../../../Views/Terminal/Block/Inputv2'
 
 const SimpleEditor = React.lazy(() => import('../../../Editor/SimpleEditor'))
 
@@ -72,7 +72,7 @@ export default function code(
 
       return (
         <React.Fragment>
-          <Input
+          <CodeBlock
             readonly={false}
             id={`kui-link-${blockId}`}
             className="kui--code-block-in-markdown"
@@ -82,6 +82,7 @@ export default function code(
             language={language}
             blockId={blockId}
             validate={attributes.validate}
+            optional={attributes.optional}
             response={response}
             status={statusConsideringReplay}
             arg1={myCodeIdx}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/remark-codeblocks-topmatter.ts
@@ -18,6 +18,7 @@ import { Node } from 'hast'
 import { Code } from 'mdast'
 import { visit } from 'unist-util-visit'
 
+import dump from './dump'
 import { tryFrontmatter } from '../../frontmatter'
 import KuiFrontmatter, { hasCodeBlocks } from '../../KuiFrontmatter'
 
@@ -53,12 +54,7 @@ export default function preprocessCodeBlocks(tree /*: Root */, frontmatter: KuiF
               attributes.validate = matched.validate
             }
 
-            node.value = `
----
-${require('js-yaml').dump(attributes)}
----
-${body}
-`
+            node.value = dump(attributes, body)
           }
         }
       }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
@@ -35,7 +35,7 @@ export default function div(uuid: string) {
     const count = props['data-kui-split-count'] ? parseInt(props['data-kui-split-count'], 10) : undefined
 
     if (isWizard(props)) {
-      return <Wizard {...props} />
+      return <Wizard uuid={uuid} {...props} />
     } else if (!position || (position === 'default' && count === 0 && !maximized && !placeholder)) {
       // don't create a split if a position wasn't indicated, or if
       // this is the first default-positioned section; if it is

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
@@ -83,7 +83,7 @@ function components(args: Args) {
   const components = Object.assign(
     {
       tip,
-      tabbed
+      tabbed: tabbed(args.uuid)
     },
     typedComponents(args)
   )

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/index.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { v4 } from 'uuid'
+
+import { Element } from 'hast'
 import { START_OF_TIP, END_OF_TIP } from '../rehype-tip'
 
 // const RE_TAB = /^(.|[\n\r])*===\s+"(.+)"\s*(\n(.|[\n\r])*)?$/
@@ -22,6 +25,10 @@ const RE_TAB = /^===\s+"([^"]+)"/
 const START_OF_TAB = `<!-- ____KUI_START_OF_TAB____ -->`
 const PUSH_TABS = `<!-- ____KUI_NESTED_TABS____ -->`
 const END_OF_TAB = `<!-- ____KUI_END_OF_TAB____ -->`
+
+export function isTab(elt: Element): boolean {
+  return elt.properties['data-kui-tab-index'] !== undefined
+}
 
 export default function plugin(/* options */) {
   return function transformer(tree) {
@@ -33,7 +40,10 @@ export default function plugin(/* options */) {
           type: 'element',
           tagName: 'tabbed',
           children: currentTabs,
-          properties: { depth: tabStack.length }
+          properties: {
+            depth: tabStack.length,
+            'data-kui-choice-group': v4()
+          }
         })
       }
 
@@ -110,7 +120,8 @@ export default function plugin(/* options */) {
                     // to join nested tabs together
                     properties: {
                       title: startMatch[1],
-                      depth: tabStack.length
+                      depth: tabStack.length,
+                      'data-kui-tab-index': currentTabs.length
                     },
                     children: rest ? [{ type: 'text', value: rest }] : [],
                     position

--- a/plugins/plugin-client-common/src/components/Content/MiniProgressStepper.tsx
+++ b/plugins/plugin-client-common/src/components/Content/MiniProgressStepper.tsx
@@ -93,7 +93,7 @@ ${this.props.body}
 
   public render() {
     return (
-      <Tooltip markdown={this.tooltipText} maxWidth="30rem">
+      <Tooltip markdown={this.tooltipText} maxWidth="30rem" position="bottom-start">
         <li className={['pf-c-progress-stepper__step', 'kui--progress-step', ...this.statusClass].join(' ')}>
           <div className="pf-c-progress-stepper__step-connector">
             <a className="kui--progress-step-status-icon-link" href={`#kui-link-${this.props.codeBlockId}`}>

--- a/plugins/plugin-client-common/src/components/Content/MiniProgressStepper.tsx
+++ b/plugins/plugin-client-common/src/components/Content/MiniProgressStepper.tsx
@@ -136,10 +136,11 @@ class MiniProgressStep extends React.PureComponent<MiniProps, ProgressStepState>
   }
 
   private get tooltipText() {
-    const title = this.props.optional ? strings('Optional Code Block') : strings('Code Block')
+    const title = strings('Code Block')
+    const status = this.status === 'blank' && this.props.optional ? 'optional' : this.status
 
     return `### ${title}
-#### Status: ${strings('status.' + this.status)}
+#### Status: ${strings('status.' + status)}
 
 \`\`\`${this.props.language || ''}
 ${this.props.body}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/CodeBlockEvents.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/CodeBlockEvents.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EventEmitter } from 'events'
+
+const events = new EventEmitter()
+
+export type ReadinessHandler = (readyForExecution: boolean) => void
+
+export function emitCodeBlockReadiness(codeBlockId: string, readyForExecution: boolean) {
+  events.emit(`/ready/broadcast/${codeBlockId}`, readyForExecution)
+}
+export function onCodeBlockReadiness(codeBlockId: string, handler: ReadinessHandler) {
+  events.on(`/ready/broadcast/${codeBlockId}`, handler)
+}
+export function offCodeBlockReadiness(codeBlockId: string, handler: ReadinessHandler) {
+  events.off(`/ready/broadcast/${codeBlockId}`, handler)
+}
+
+export function emitGetCodeBlockReadiness(codeBlockId: string, handler: ReadinessHandler) {
+  events.emit(`/ready/get/${codeBlockId}`, handler, codeBlockId)
+}
+export function onGetCodeBlockReadiness(
+  codeBlockId: string,
+  getHandler: (handler: ReadinessHandler, codeBlockId: string) => void
+) {
+  events.on(`/ready/get/${codeBlockId}`, getHandler)
+}
+export function offGetCodeBlockReadiness(
+  codeBlockId: string,
+  getHandler: (handler: ReadinessHandler, codeBlockId: string) => void
+) {
+  events.off(`/ready/get/${codeBlockId}`, getHandler)
+}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -58,6 +58,7 @@ interface Value {
 
 type Props<T1 = any, T2 = any, T3 = any> = Value &
   StreamingProps & {
+    id?: string
     className?: string
     tab: Tab
 
@@ -440,6 +441,7 @@ export default class Input<T1, T2, T3> extends StreamingConsumer<Props<T1, T2, T
       <MutabilityContext.Consumer>
         {mutability => (
           <li
+            id={this.props.id}
             className={`repl-block ${this.responseStatus()} ${this.props.className || ''}`}
             data-is-executable={mutability.executable}
             data-is-output-only={this.outputOnly || undefined}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -372,8 +372,12 @@ export default class CodeBlock<T1, T2, T3> extends StreamingConsumer<Props<T1, T
     )
   }
 
+  private get hasOutput() {
+    return this.props.response || this.hasStreamingOutput()
+  }
+
   private output() {
-    const content = (this.props.response || this.hasStreamingOutput()) && (
+    const content = this.hasOutput && (
       <div className="repl-output repl-result-has-content">
         <div className="result-vertical">
           <div className="repl-result">
@@ -468,6 +472,7 @@ export default class CodeBlock<T1, T2, T3> extends StreamingConsumer<Props<T1, T
             data-is-output-only={this.outputOnly || undefined}
             data-is-optional={this.props.optional || undefined}
             data-is-validated={this.state.validated || undefined}
+            data-is-sample-output={(this.hasOutput && this.state.execution === 'replayed') || undefined}
             {...dataProps}
           >
             {!this.outputOnly && this.input(mutability)}

--- a/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
@@ -69,7 +69,7 @@ import {
   SearchIcon as Search,
   BellIcon as Notification,
   QuestionIcon as Unknown,
-  PlayCircleIcon as Play
+  PlayIcon as Play
 } from '@patternfly/react-icons'
 
 import { Props } from '..'

--- a/plugins/plugin-client-common/src/controller/snippets.ts
+++ b/plugins/plugin-client-common/src/controller/snippets.ts
@@ -23,7 +23,7 @@ import { stripFrontmatter } from '../components/Content/Markdown/frontmatter-par
 
 const debug = Debug('plugin-client-common/markdown/snippets')
 
-const RE_SNIPPET = /^--(-*)8<--(-*)\s+"([^"]+)"(\s+"([^"]+)")?$/
+const RE_SNIPPET = /^--(-*)8<--(-*)\s+"([^"]+)"(\s+"([^"]+)")?\s*$/
 
 function isUrl(a: string) {
   return /^https?:/.test(a)

--- a/plugins/plugin-client-common/src/test/core/markdown-helpers.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown-helpers.ts
@@ -71,11 +71,11 @@ export async function checkBlockValidation(ctx: Common.ISuite, split: Position, 
 }
 
 export async function clickToExecuteBlock(this: Common.ISuite, split: Position, block: Block) {
-  const codeBlockSelector = `${split()} .kui--code-block-in-markdown[data-code-index="${block.index}"]`
+  const codeBlockSelector = `${split()} ${Selectors.Markdown.codeBlock(block.index)}`
   const codeBlock = await this.app.client.$(codeBlockSelector)
   await codeBlock.waitForDisplayed({ timeout: CLI.waitTimeout })
 
-  const runAction = await codeBlock.$('.kui--block-action-run')
+  const runAction = await codeBlock.$(Selectors.Markdown.runButton)
   await codeBlock.moveTo()
   await runAction.waitForDisplayed({ timeout: CLI.waitTimeout })
 

--- a/plugins/plugin-client-common/src/test/core/markdown-helpers.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown-helpers.ts
@@ -72,14 +72,16 @@ export async function checkBlockValidation(ctx: Common.ISuite, split: Position, 
 
 export async function clickToExecuteBlock(this: Common.ISuite, split: Position, block: Block) {
   const codeBlockSelector = `${split()} .kui--code-block-in-markdown[data-code-index="${block.index}"]`
-  await this.app.client.$(codeBlockSelector).then(_ => _.waitForDisplayed({ timeout: CLI.waitTimeout }))
+  const codeBlock = await this.app.client.$(codeBlockSelector)
+  await codeBlock.waitForDisplayed({ timeout: CLI.waitTimeout })
 
-  const runAction = await this.app.client.$(`${codeBlockSelector} .kui--block-action-run`)
+  const runAction = await codeBlock.$('.kui--block-action-run')
+  await codeBlock.moveTo()
   await runAction.waitForDisplayed({ timeout: CLI.waitTimeout })
 
   await runAction.click()
 
-  const result = await this.app.client.$(`${codeBlockSelector} ${Selectors._RESULT}`)
+  const result = await codeBlock.$(Selectors._RESULT)
   await result.waitForDisplayed({ timeout: CLI.waitTimeout })
 
   await this.app.client.waitUntil(async () => {

--- a/plugins/plugin-client-common/src/test/core/markdown/wizards.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/wizards.ts
@@ -43,7 +43,8 @@ const IN1 = {
   title: 'WizardTitle',
   description: 'WizardDescription',
   steps,
-  expectedSplitCount: 1
+  expectedSplitCount: 1,
+  expectedCodeBlockTasks: 3
 }
 
 // make sure we can display wizards in tabs with splits
@@ -52,7 +53,8 @@ const IN2 = {
   title: 'WizardTitleWithSplits',
   description: 'WizardDescriptionWithSplits',
   steps,
-  expectedSplitCount: 2
+  expectedSplitCount: 2,
+  expectedCodeBlockTasks: IN1.expectedCodeBlockTasks
 }
 
 // make sure we can display wizards in tabs with splits
@@ -61,6 +63,7 @@ const IN3 = {
   title: 'Getting Started with Knative',
   description: 'WizardDescriptionInTopmatter',
   expectedSplitCount: 1,
+  expectedCodeBlockTasks: 6,
   steps: [
     { name: 'TestRewritingOfStepName', body: 'This topic describes', description: '', codeBlocks: [] },
     { name: 'Before you begin', body: 'Before you can get started', description: 'TestDescription2', codeBlocks: [] }
@@ -102,6 +105,14 @@ const IN3 = {
         await Common.oops(this, true)(err)
       }
     })
+
+    it(`should show "n of ${markdown.expectedCodeBlockTasks}" in progress bar`, () =>
+      this.app.client.waitUntil(async () => {
+        const actualMeasureText = await this.app.client.$(Selectors.Wizard.progressMeasure).then(_ => _.getText())
+        const match = actualMeasureText.match(/of (\d+)/)
+
+        return match && parseInt(match[1], 10) === markdown.expectedCodeBlockTasks
+      }))
 
     it(`should have ${markdown.expectedSplitCount} splits`, () => ReplExpect.splitCount(markdown.expectedSplitCount))
 

--- a/plugins/plugin-client-common/tests/data/snippet1.md
+++ b/plugins/plugin-client-common/tests/data/snippet1.md
@@ -3,7 +3,9 @@
 
 aaa
 
---8<-- "snippeta.md"
+<!-- intentional trailing whitespace on line below!!! -->
+--8<-- "snippeta.md"  
+<!-- intentional trailing whitespace on the line above!!! -->
 
 bbb
 

--- a/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter2.md
+++ b/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter2.md
@@ -1,0 +1,38 @@
+---
+wizard:
+    steps:
+        - AAA
+        - BBB
+        - CCC
+---
+
+# WizardTitle
+
+WizardDescription
+
+---
+
+## AAA
+
+AAAContent
+
+```bash
+echo 111
+```
+
+## BBB
+
+BBBContent
+
+```bash
+echo 222
+```
+
+## CCC
+
+CCCContent
+
+```bash
+echo 333
+```
+

--- a/plugins/plugin-client-common/web/scss/components/ProgressStepper/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/ProgressStepper/_mixins.scss
@@ -26,6 +26,12 @@
   }
 }
 
+@mixin Optional {
+  &[data-optional] {
+    @content;
+  }
+}
+
 @mixin Connector {
   .pf-c-progress-stepper__step-connector {
     @content;
@@ -103,13 +109,5 @@
 @mixin Main {
   .pf-c-progress-stepper__step-main {
     @content;
-  }
-}
-
-@mixin MiniProgressStepper {
-  @include ProgressStepper {
-    &[data-mini] {
-      @content;
-    }
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -19,6 +19,7 @@
 @import '../Editor/mixins';
 @import '../Wizard/mixins';
 @import '../Sidecar/mixins';
+@import '../Tooltip/mixins';
 @import '../common/narrow-window';
 @import '../ProgressStepper/mixins';
 @import '../ExpandableSection/mixins';
@@ -40,6 +41,13 @@ $box-shadow-margin: 4px; /* room for box shadow */
     @content;
   }
 }
+
+@mixin NotShowingSampleOutput {
+  &:not([data-is-sample-output]) {
+    @content;
+  }
+}
+
 @mixin CodeBlockActions {
   .kui--code-block-actions {
     @content;
@@ -61,6 +69,14 @@ $box-shadow-margin: 4px; /* room for box shadow */
 @mixin GrayAction {
   @include InputWrapper {
     --color-for-guidebook-block-actions: var(--color-text-02);
+  }
+}
+
+@mixin InvisibleActionExceptOnHover {
+  &:not(:hover) {
+    @include BlockAction {
+      display: none;
+    }
   }
 }
 
@@ -632,9 +648,29 @@ pre {
 
     @include Validated {
       @include GrayAction;
+      @include InvisibleActionExceptOnHover;
     }
-    @include Successful {
-      @include GrayAction;
+
+    @include NotShowingSampleOutput {
+      @include Successful {
+        @include GrayAction;
+        @include InvisibleActionExceptOnHover;
+      }
     }
+  }
+}
+
+@include Tooltip {
+  i {
+    margin-left: 0.5em;
+  }
+  .fa-dot-circle {
+    color: var(--color-warning);
+  }
+  .fa-check-circle {
+    color: var(--color-ok);
+  }
+  .fa-exclamation-circle {
+    color: var(--color-error);
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -46,6 +46,24 @@ $box-shadow-margin: 4px; /* room for box shadow */
   }
 }
 
+@mixin Validated {
+  &[data-is-validated] {
+    @content;
+  }
+}
+
+@mixin Optional {
+  &[data-is-optional] {
+    @content;
+  }
+}
+
+@mixin GrayAction {
+  @include InputWrapper {
+    --color-for-guidebook-block-actions: var(--color-text-02);
+  }
+}
+
 body[kui-theme-style] {
   @include TextContent {
     color: inherit;
@@ -585,6 +603,38 @@ pre {
   @include TextContent {
     & > .marked-content > p {
       font-size: $terminal-font-size;
+    }
+  }
+}
+
+@include Commentary {
+  @include Block {
+    @include InputWrapper {
+      $action-size: 1.25;
+      --color-for-guidebook-block-actions: var(--color-brand-01);
+      @include Spinner {
+        padding: 0;
+        margin: 0;
+        width: calc(2em * $action-size);
+      }
+      @include BlockAction {
+        font-size: $action-size + em;
+        color: var(--color-for-guidebook-block-actions);
+      }
+    }
+
+    @include Optional {
+      &:not(:hover) {
+        filter: sepia(0.5) opacity(0.9) contrast(0.95) blur(0.25px);
+      }
+      @include GrayAction;
+    }
+
+    @include Validated {
+      @include GrayAction;
+    }
+    @include Successful {
+      @include GrayAction;
     }
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -66,9 +66,22 @@ $box-shadow-margin: 4px; /* room for box shadow */
   }
 }
 
+/** Prereqs not yet satisfied? */
+@mixin NotReady {
+  &:not([data-is-ready]) {
+    @content;
+  }
+}
+
 @mixin GrayAction {
   @include InputWrapper {
     --color-for-guidebook-block-actions: var(--color-text-02);
+  }
+}
+
+@mixin WarningAction {
+  @include InputWrapper {
+    --color-for-guidebook-block-actions: var(--color-red);
   }
 }
 
@@ -78,6 +91,11 @@ $box-shadow-margin: 4px; /* room for box shadow */
       display: none;
     }
   }
+}
+
+@mixin InvisibleActionExceptOnHoverThenWarning {
+  @include WarningAction;
+  @include InvisibleActionExceptOnHover;
 }
 
 body[kui-theme-style] {
@@ -626,7 +644,7 @@ pre {
 @include Commentary {
   @include Block {
     @include InputWrapper {
-      $action-size: 1.25;
+      $action-size: 1;
       --color-for-guidebook-block-actions: var(--color-brand-01);
       @include Spinner {
         padding: 0;
@@ -637,6 +655,10 @@ pre {
         font-size: $action-size + em;
         color: var(--color-for-guidebook-block-actions);
       }
+    }
+
+    @include NotReady {
+      @include InvisibleActionExceptOnHoverThenWarning;
     }
 
     @include Optional {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Notebook.scss
@@ -34,7 +34,7 @@ $margin-for-right-elements: calc(#{math.div(0.875 * $input-padding, $right-eleme
   }
 }
 
-/** These are special stylings for read only mode, for example, we don't wantt to show all block actions */
+/** These are special stylings for read only mode, for example, we don't want to show all block actions */
 @include Scrollback {
   @include FinishedBlock {
     @include NotEditableAndExecutable {
@@ -46,10 +46,6 @@ $margin-for-right-elements: calc(#{math.div(0.875 * $input-padding, $right-eleme
         @include Input {
           padding: #{0.875 * $input-padding} 0;
           padding-right: $input-padding;
-        }
-
-        @include Spinner {
-          margin: $margin-for-right-elements;
         }
 
         /** Adjust and always show timestamp */
@@ -77,11 +73,6 @@ $margin-for-right-elements: calc(#{math.div(0.875 * $input-padding, $right-eleme
             color: var(--color-gray);
           }
         }
-      }
-
-      @include BlockAction {
-        font-size: 1.375em;
-        color: var(--color-green);
       }
     }
   }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -373,6 +373,12 @@ $action-hover-delay: 210ms;
   }
 }
 
+@mixin Successful {
+  &.valid-response {
+    @content;
+  }
+}
+
 /** The InputWrapper for blocks that have no output */
 @mixin InputWrapperForEmptyBlock {
   @include FinishedBlock {

--- a/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+@import 'mixins';
 @import '../Editor/mixins';
 
 $color: var(--color-base00);
 $bgcolor: var(--color-base06);
 
-.kui--tooltip {
+@include Tooltip {
   color: $color;
   background-color: $bgcolor;
 

--- a/plugins/plugin-client-common/web/scss/components/Tooltip/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tooltip/_mixins.scss
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@mixin Tooltip {
+  .kui--tooltip {
+    @content;
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/Wizard/MiniProgressStepper.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/MiniProgressStepper.scss
@@ -20,8 +20,38 @@
 $small: 0.5rem;
 $regular: 0.75rem;
 
+$blank-color: var(--color-blue-rgb);
+$hover-color: var(--color-table-border3);
+$error-color: var(--color-error);
+$success-color: var(--pf-global--primary-color--100);
+$complete-color: var(--color-ok);
+
+@mixin MiniProgressStepper {
+  @include ProgressStepper {
+    &[data-mini] {
+      @content;
+    }
+  }
+}
+
+@mixin Complete {
+  &[data-is-complete='true'] {
+    @content;
+  }
+}
+
+@mixin Incomplete {
+  &[data-is-complete='false'] {
+    @content;
+  }
+}
+
 @include MiniProgressStepper {
   --pf-c-progress-stepper__step-icon--Width: #{$regular};
+
+  height: 1.125rem;
+  display: flex;
+  align-items: center;
 
   @include Spinner {
     --sk-color: var(--color-yellow);
@@ -48,7 +78,7 @@ $regular: 0.75rem;
     width: auto;
     font-size: $regular;
     &:hover {
-      background-color: var(--color-table-border3);
+      background-color: $hover-color;
     }
   }
 
@@ -65,17 +95,52 @@ $regular: 0.75rem;
         border: none;
       }
     }
-    @include Success {
+  }
+}
+
+@include MiniProgressStepper {
+  @include Complete {
+    @include ProgressStep {
       @include Icon {
         &:not(:hover) {
-          background-color: var(--pf-global--primary-color--100);
+          background-color: $complete-color;
         }
       }
     }
-    @include Blank {
-      @include Icon {
-        &:not(:hover) {
-          background-color: rgba(var(--color-blue-rgb), 0.2);
+  }
+}
+
+@include MiniProgressStepper {
+  @include Incomplete {
+    @include ProgressStep {
+      @include Success {
+        @include Icon {
+          &:not(:hover) {
+            background-color: $success-color;
+          }
+        }
+      }
+      @include Error {
+        @include Icon {
+          &:not(:hover) {
+            background-color: $error-color;
+          }
+        }
+      }
+      @include Blank {
+        --opacity: 0.15;
+        @include Optional {
+          @include Icon {
+            &:not(:hover) {
+              --opacity: 0.05;
+              border: 1px dotted $hover-color;
+            }
+          }
+        }
+        @include Icon {
+          &:not(:hover) {
+            background-color: rgba($blank-color, var(--opacity));
+          }
         }
       }
     }

--- a/plugins/plugin-client-common/web/scss/components/Wizard/MiniProgressStepper.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/MiniProgressStepper.scss
@@ -31,10 +31,6 @@ $regular: 0.75rem;
     align-items: center;
     height: $regular;
   }
-  @include Icon {
-    width: auto;
-    font-size: $regular;
-  }
   @include ConnectorUI {
     --pf-c-progress-stepper__step-connector--before--Left: 50%;
     --pf-c-progress-stepper__step-connector--before--Top: 50%;
@@ -43,6 +39,20 @@ $regular: 0.75rem;
 
   @include ProgressStep {
     display: block; /* Rather than `contents`, so we can wrap a Tooltip */
+  }
+  @include IconLink {
+    display: block; /* Rather than `contents`, so we can wrap a Tooltip */
+  }
+
+  @include Icon {
+    width: auto;
+    font-size: $regular;
+    &:hover {
+      background-color: var(--color-table-border3);
+    }
+  }
+
+  @include ProgressStep {
     @include Icon {
       border-width: 0;
       border-radius: 0;
@@ -57,12 +67,16 @@ $regular: 0.75rem;
     }
     @include Success {
       @include Icon {
-        background-color: var(--pf-global--primary-color--100);
+        &:not(:hover) {
+          background-color: var(--pf-global--primary-color--100);
+        }
       }
     }
     @include Blank {
       @include Icon {
-        background-color: rgba(var(--color-blue-rgb), 0.2);
+        &:not(:hover) {
+          background-color: rgba(var(--color-blue-rgb), 0.2);
+        }
       }
     }
   }

--- a/plugins/plugin-kubectl/notebooks/knative-getting-started.md
+++ b/plugins/plugin-kubectl/notebooks/knative-getting-started.md
@@ -21,6 +21,8 @@ codeblocks:
       validate: brew info kn
     - match: ^brew install knative-sandbox/kn-plugins/quickstart$
       validate: kn quickstart --help
+    - match: brew upgrade
+      optional: true
     - match: kn quickstart --help
       optional: true
 ---


### PR DESCRIPTION
[11.2.4 1330e3a59] fix(plugins/plugin-client-common): wizard mini progress UI lacks hover effect
 Date: Wed Feb 9 19:46:39 2022 -0500
 2 files changed, 21 insertions(+), 7 deletions(-)

[11.2.4 12e0ce1fc] fix(plugins/plugin-client-common): snippet inliner fails for lines with trailing whitespace
 Date: Thu Feb 10 11:32:56 2022 -0500
 2 files changed, 4 insertions(+), 2 deletions(-)

[11.2.4 fba4115a3] fix(plugins/plugin-client-common): snippet inliner fails in reroute links
 Date: Thu Feb 10 12:12:59 2022 -0500
 1 file changed, 43 insertions(+), 28 deletions(-)

[11.2.4 715729c8b] feat(plugins/plugin-client-common): initial support for code block ordering
 Date: Thu Feb 10 11:46:40 2022 -0500
 20 files changed, 666 insertions(+), 122 deletions(-)
 create mode 100644 plugins/plugin-client-common/src/components/Content/Markdown/components/code/README.md
 create mode 100644 plugins/plugin-client-common/src/components/Content/Markdown/components/code/dump.ts
 create mode 100644 plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts

[11.2.4 2e4fa5a95] feat(plugins/plugin-client-common): more clearly distinguish optional and already-executed code blocks
 Date: Sat Feb 12 12:48:24 2022 -0500
 6 files changed, 113 insertions(+), 32 deletions(-)

[11.2.4 a4e9c28fa] fix(plugins/plugin-client-common): hide except on hover play button for validated code blocks
 Date: Sat Feb 12 13:25:23 2022 -0500
 8 files changed, 80 insertions(+), 12 deletions(-)
 create mode 100644 plugins/plugin-client-common/web/scss/components/Tooltip/_mixins.scss

[11.2.4 b75ffbfc8] feat(plugins/plugin-client-common): assign code blocks an ordinal execution order
 Date: Sat Feb 12 20:23:24 2022 -0500
 13 files changed, 452 insertions(+), 144 deletions(-)
 create mode 100644 plugins/plugin-client-common/src/components/Views/Terminal/Block/CodeBlockEvents.ts
 create mode 100644 plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter2.md

[11.2.4 dbf88772d] feat(plugins/plugin-client-common): show code block Run in offline clients with sample output
 Date: Mon Feb 14 09:57:06 2022 -0500
 2 files changed, 50 insertions(+), 26 deletions(-)