### PR TITLE
fix(plugins/plugin-client-common): use sepia tone also for validated …

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -73,6 +73,12 @@ $box-shadow-margin: 4px; /* room for box shadow */
   }
 }
 
+@mixin Sepia {
+  &:not(:hover) {
+    filter: sepia(0.5) opacity(0.9) contrast(0.95) blur(0.25px);
+  }
+}
+
 @mixin GrayAction {
   @include InputWrapper {
     --color-for-guidebook-block-actions: var(--color-text-02);
@@ -662,13 +668,12 @@ pre {
     }
 
     @include Optional {
-      &:not(:hover) {
-        filter: sepia(0.5) opacity(0.9) contrast(0.95) blur(0.25px);
-      }
+      @include Sepia;
       @include GrayAction;
     }
 
     @include Validated {
+      @include Sepia;
       @include GrayAction;
       @include InvisibleActionExceptOnHover;
     }


### PR DESCRIPTION
…blocks
<img width="1392" alt="sepia validated" src="https://user-images.githubusercontent.com/4741620/154087534-c17c4a5f-713d-4b1d-a17e-dad445fbeb49.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
