### PR TITLE
fix(plugins/plugin-client-common): monaco line number gutter can look…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
@@ -174,7 +174,7 @@ export default class SimpleEditor extends React.Component<Props, State> {
           Object.assign(
             {
               showLineNumbers: nLines > 1,
-              lineNumbersMinChars: nLines.toString().length
+              lineNumbersMinChars: nLines.toString().length + 1
             },
             providedOptions
           )


### PR DESCRIPTION
… weird

The numbers sometimes overwrite themselves, when using SimpleEditor. This is because we are forcing monaco to use a `lineNumbersMinChars` of our choosing, and we are missing a +1 to allow for some grace that apparently monaco needs.
<img width="627" alt="Screen Shot 2022-02-15 at 6 14 11 PM" src="https://user-images.githubusercontent.com/4741620/154165785-50d3c3e2-4781-477d-a5c8-f88bd8d1f6a0.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
