### PR TITLE
fix(plugins/plugin-client-common): markdown with non-tab/tip indentat…

### DIFF
--- a/packages/test/src/api/Markdown.ts
+++ b/packages/test/src/api/Markdown.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { ISuite } from './common'
+import { OUTPUT_LAST } from './selectors'
+
 export default class Markdown {
   public readonly tip = '.kui--markdown-tip'
   public readonly tabs = '.kui--markdown-tabs'
@@ -21,6 +24,10 @@ export default class Markdown {
 
   private readonly _codeBlock = '.kui--code-block-in-markdown'
   public readonly runButton = '.kui--block-action-run'
+
+  public getText(ctx: ISuite) {
+    return ctx.app.client.$(OUTPUT_LAST).then(_ => _.getText())
+  }
 
   public tipWithTitle(title: string) {
     return `${this.tip}[data-title="${title}"]`

--- a/plugins/plugin-client-common/src/test/core/markdown/tab-after-tip-in-tab.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/tab-after-tip-in-tab.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ok } from 'assert'
+import { basename, dirname, join } from 'path'
+import { encodeComponent } from '@kui-shell/core'
+import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+
+const ROOT = join(dirname(require.resolve('@kui-shell/plugin-client-common/tests/data/tab-after-tip-in-tab1.md')), '..')
+
+const IN1 = {
+  input: join(ROOT, 'data', 'tab-after-tip-in-tab1.md'),
+  tips: [{ title: 'XXXX', content: 'YYYY' }],
+  textToBeFound: 'YYYY',
+  textNotToBeFound: 'AAAA' // we don't want the second tab's text to be shown on initial render!
+}
+
+const IN2 = {
+  input: join(ROOT, 'data', 'tab-after-tip-in-tab2.md'),
+  tips: IN1.tips,
+  textToBeFound: 'Bullet1',
+  textNotToBeFound: IN1.textNotToBeFound
+}
+;[IN1, IN2].forEach(markdown => {
+  describe(`markdown tab after tip in tab ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
+    ''}`, function(this: Common.ISuite) {
+    before(Common.before(this))
+    after(Common.after(this))
+
+    markdown.tips.forEach(tip => {
+      it(`should load the markdown and show tab after tip in tab with title=${tip.title}`, async () => {
+        try {
+          await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app).then(
+            ReplExpect.okWithString(markdown.textToBeFound)
+          )
+
+          const allText = await Selectors.Markdown.getText(this)
+          ok(allText.indexOf(markdown.textNotToBeFound) < 0)
+
+          const tipSelector = Selectors.Markdown.tipWithTitle(tip.title)
+          const tipElement = await this.app.client.$(tipSelector)
+          await tipElement.waitForExist({ timeout: CLI.waitTimeout })
+
+          const content = await this.app.client.$(Selectors.Markdown.tipContent(tipSelector))
+          await content.waitForExist({ timeout: CLI.waitTimeout })
+
+          await this.app.client.waitUntil(
+            async () => {
+              const actualText = await content.getText()
+              return actualText === tip.content
+            },
+            { timeout: CLI.waitTimeout }
+          )
+        } catch (err) {
+          await Common.oops(this, true)(err)
+        }
+      })
+    })
+  })
+})

--- a/plugins/plugin-client-common/tests/data/tab-after-tip-in-tab1.md
+++ b/plugins/plugin-client-common/tests/data/tab-after-tip-in-tab1.md
@@ -1,0 +1,8 @@
+=== "Tab1"
+    !!! warning "XXXX"
+        YYYY
+
+=== "Tab2"
+    AAAA
+
+    BBBB

--- a/plugins/plugin-client-common/tests/data/tab-after-tip-in-tab2.md
+++ b/plugins/plugin-client-common/tests/data/tab-after-tip-in-tab2.md
@@ -1,0 +1,10 @@
+=== "Tab1"
+    - Bullet1
+        !!! warning "XXXX"
+            YYYY
+
+=== "Tab2"
+    AAAA
+
+    BBBB
+


### PR DESCRIPTION
…ion formats poorly

e.g. a tab after tip inside a tab, where the tip itself is indented not due being in a tab or tip, sigh

see plugins/plugin-client-common/tests/data/tab-after-tip-in-tab2.md for an example of this

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
