### PR TITLE
fix(plugins/plugin-client-common): only a few table columns are sortable

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/sort.ts
+++ b/plugins/plugin-client-common/src/components/Content/Table/sort.ts
@@ -45,7 +45,10 @@ function sortRowWithDir(rowA: Row, rowB: Row, key: string, cidx: number, directi
   if (key === 'SIZE') {
     return sortBySize(rowA, rowB, cidx, dir)
   } else {
-    return rowA.name.localeCompare(rowB.name) * dir
+    const isName = key === 'NAME'
+    const valA = isName ? rowA.name : rowA.attributes[cidx - 1].value
+    const valB = isName ? rowB.name : rowB.attributes[cidx - 1].value
+    return valA.localeCompare(valB) * dir
   }
 }
 
@@ -53,6 +56,7 @@ export default function sortRow(rowA: Row, rowB: Row, key: string, cidx: number,
   return sortRowWithDir(rowA, rowB, key.toUpperCase(), cidx, direction)
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function isSortableCol(key: string) {
-  return /NAME|SIZE|NAMESPACE|OBJECT/i.test(key.toUpperCase())
+  return true
 }


### PR DESCRIPTION
For some reason, we had hard-coded logic to allow sorting on only a few fixed column headers.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
