### PR TITLE
fix(plugins/plugin-kubectl): `oc login` requires a Kui reload for cha…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/proxy/index.ts
+++ b/plugins/plugin-kubectl/src/controller/client/proxy/index.ts
@@ -72,6 +72,9 @@ function stopProxy(this: State) {
 
     // unregister onQuit handler
     unregisterOnQuit(this.onQuitHandler)
+
+    // DO NOT DO THIS, otherwise support for different contexts across Kui tabs will break:
+    // offKubectlConfigChangeEvents(this.onQuitHandler)
   } catch (err) {
     console.error('Error stopping kubectl proxy', err)
   }
@@ -86,6 +89,9 @@ function registerOnQuit(state: Omit<State, 'onQuitHandler'>): State {
   try {
     const onQuitHandler = stopProxy.bind(state)
     onQuit(onQuitHandler)
+
+    // DO NOT DO THIS, otherwise support for different contexts across Kui tabs will break:
+    // onKubectlConfigChangeEvents(onQuitHandler)
     return Object.assign(state, { onQuitHandler })
   } catch (err) {
     console.error('Error registering kubectl proxy onQuit', err)

--- a/plugins/plugin-kubectl/src/controller/kubectl/contexts.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/contexts.ts
@@ -125,9 +125,13 @@ export function getCurrentDefaultContextName({ REPL, parsedOptions }: ContextArg
 }
 
 /** @return the relevant namespace for the given args/command line */
-export async function getCurrentDefaultNamespace(args: ContextArgs): Promise<string> {
-  const contextName = await getCurrentDefaultContextName(args)
-  if (currentDefaultNamespaceCache[contextName]) {
+export async function getCurrentDefaultNamespace(
+  args: ContextArgs,
+  context?: string,
+  noCache = false
+): Promise<string> {
+  const contextName = context || (await getCurrentDefaultContextName(args))
+  if (!noCache && currentDefaultNamespaceCache[contextName]) {
     return currentDefaultNamespaceCache[contextName]
   }
 

--- a/plugins/plugin-kubectl/src/test/k8s/contexts.ts
+++ b/plugins/plugin-kubectl/src/test/k8s/contexts.ts
@@ -46,10 +46,12 @@ Common.localDescribe('kubectl context switching', function(this: Common.ISuite) 
     })
   )
 
+  const timeout = { timeout: CLI.waitTimeout }
+
   synonyms.forEach(kubectl => {
     /** delete the given namespace */
     const deleteIt = (name: string, context: string, kubeconfig: string) => {
-      it(`should delete the namespace ${name} via ${kubectl}`, () => {
+      it(`should delete, outside of Kui, the namespace ${name} via ${kubectl}`, () => {
         execSync(`kubectl delete namespace ${name} --context ${context} --kubeconfig ${kubeconfig}`)
       })
     }
@@ -244,7 +246,7 @@ Common.localDescribe('kubectl context switching', function(this: Common.ISuite) 
       it('should create a new tab via command', () =>
         CLI.command('tab new', this.app)
           .then(() => this.app.client.$(Selectors.TAB_SELECTED_N(2)))
-          .then(_ => _.waitForDisplayed())
+          .then(_ => _.waitForDisplayed(timeout))
           .then(() => CLI.waitForSession(this)) // should have an active repl
           .catch(Common.oops(this, true)))
     }
@@ -253,7 +255,7 @@ Common.localDescribe('kubectl context switching', function(this: Common.ISuite) 
       it(`switch back to first tab via command`, () =>
         CLI.command('tab switch 1', this.app)
           .then(() => this.app.client.$(Selectors.TAB_SELECTED_N(1)))
-          .then(_ => _.waitForDisplayed())
+          .then(_ => _.waitForDisplayed(timeout))
           .catch(Common.oops(this, true)))
     }
 
@@ -261,7 +263,7 @@ Common.localDescribe('kubectl context switching', function(this: Common.ISuite) 
       it(`switch back to the second tab tab via command`, () =>
         CLI.command('tab switch 2', this.app)
           .then(() => this.app.client.$(Selectors.TAB_SELECTED_N(2)))
-          .then(_ => _.waitForDisplayed())
+          .then(_ => _.waitForDisplayed(timeout))
           .catch(Common.oops(this, true)))
     }
 
@@ -357,10 +359,11 @@ Common.localDescribe('kubectl context switching', function(this: Common.ISuite) 
     listPodsAndExpectOne('nginx')
 
     deleteIt(ns, initialContext, initialKubeConfig)
-    it(`should expect ${ns} to be offline in tab  2`, async () => {
+
+    it(`should expect ${ns} to be offline in tab 2`, async () => {
       try {
         const offlineBadge = nsWatcherBadgeInTab2.replace(Status.Online, Status.Offline)
-        await this.app.client.$(offlineBadge).then(_ => _.waitForExist())
+        await this.app.client.$(offlineBadge).then(_ => _.waitForExist(timeout))
       } catch (err) {
         return Common.oops(this, true)(err)
       }
@@ -370,7 +373,7 @@ Common.localDescribe('kubectl context switching', function(this: Common.ISuite) 
     it(`should expect ${ns2} to be offline in tab 1`, async () => {
       try {
         const offlineBadge = ns2WatcherBadgeInTab1.replace(Status.Online, Status.Offline)
-        await this.app.client.$(offlineBadge).then(_ => _.waitForExist())
+        await this.app.client.$(offlineBadge).then(_ => _.waitForExist(timeout))
       } catch (err) {
         return Common.oops(this, true)(err)
       }


### PR DESCRIPTION
…nges to take effect

Two interrelated issues here:
1) the kubectl proxy that Kui manages is not being restarted
2) the CurrentContext and CurrentNamespace UIs do not update to reflect the change in context and namespace

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
