### PR TITLE
feat: improve consistency of input element coloring between guidebook…

### DIFF
--- a/packages/test/src/api/cli.ts
+++ b/packages/test/src/api/cli.ts
@@ -40,7 +40,11 @@ export const grabFocus = async (
 ) => {
   return app.client
     .$(currentPrompt)
-    .then(_ => _.click())
+    .then(_ =>
+      _.moveTo()
+        .catch(() => true)
+        .then(() => _.click())
+    )
     .then(() => app.client.$(currentPromptBlock))
     .then(_ => _.waitForEnabled())
     .catch(err => {

--- a/plugins/plugin-carbon-themes/web/scss/carbon-gray10.scss
+++ b/plugins/plugin-carbon-themes/web/scss/carbon-gray10.scss
@@ -21,6 +21,7 @@
 @import 'inverted';
 @import '@kui-shell/plugin-client-common/web/scss/components/Wizard/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/Sidecar/mixins';
+@import '@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/StatusStripe/mixins';
 
 body[kui-theme='Carbon Gray10'] {
@@ -31,6 +32,10 @@ body[kui-theme='Carbon Gray10'] {
 
   @include Sidecar {
     @include carbon-inverted;
+  }
+  @include InputWrapper {
+    @include carbon-inverted;
+    --color-sidecar-background-02: var(--color-base00);
   }
   @include StatusStripeWithDefaultColors {
     @include carbon-inverted;

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/FancyPipeline.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/FancyPipeline.tsx
@@ -56,7 +56,7 @@ export default class FancyPipeline extends React.PureComponent<Props> {
             {pidx > 0 && this.pipe('|')}
             {pipePart.map((word, widx) =>
               widx === 0 ? (
-                <span key={widx} className="color-base0D">
+                <span key={widx} className="color-base0C">
                   {word}
                 </span>
               ) : (

--- a/plugins/plugin-client-common/web/css/static/repl.scss
+++ b/plugins/plugin-client-common/web/css/static/repl.scss
@@ -62,7 +62,7 @@
 }
 .repl-input .repl-input-element,
 .repl-input-like {
-  --color-caret: var(--color-support-01);
+  --color-caret: var(--color-base0A);
   color: var(--color-text-01);
   background: transparent;
   flex: 1;

--- a/plugins/plugin-client-common/web/scss/Themes/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/Themes/_mixins.scss
@@ -60,6 +60,10 @@
   --color-ui-05: var(--color-base04);
   --color-ui-06: var(--color-base02);
 
+  --color-ok: var(--color-green);
+  --color-error: var(--color-red);
+  --color-warning: var(--color-base09);
+
   --color-repl-background: var(--color-ui-01);
 
   --color-yellow-sidecar: var(--color-yellow);

--- a/plugins/plugin-client-common/web/scss/components/Table/Events.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/Events.scss
@@ -73,8 +73,6 @@ $inter-message-spacing: 0.1875rem;
 /* applies to tables and grids */
 .kui--data-table-wrapper {
   .kui--data-table-footer-messages {
-    color: var(--color-text-01);
-    background-color: var(--color-stripe-02);
     line-height: initial;
 
     .kui--data-table-footer-message {

--- a/plugins/plugin-client-common/web/scss/components/Table/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/PatternFly.scss
@@ -21,7 +21,7 @@
 } */
 
 @include Table {
-  --pf-c-table--BackgroundColor: var(--pf-c-card--BackgroundColor);
+  --pf-c-table--BackgroundColor: transparent;
   border-collapse: collapse;
 
   @include TableHeadCell {

--- a/plugins/plugin-client-common/web/scss/components/Table/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/_mixins.scss
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@import '../Card/mixins';
+
 $bgcolor: transparent;
 $border-radius: 2px 4px;
 
@@ -49,8 +51,10 @@ $grid-cell-hover-filter: saturate(2) brightness(1.25);
 }
 
 @mixin TableCard {
-  .kui--table-card {
-    @content;
+  @include Card {
+    &.kui--table-card {
+      @content;
+    }
   }
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Table/tables.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/tables.scss
@@ -160,3 +160,7 @@ body[kui-theme-style] {
 body[kui-theme-style='dark'] .kui--radio-table-row.kui--inverted-color-context.bx--structured-list-row--selected {
   background-color: var(--color-sidecar-background);
 }
+
+@include TableCard {
+  background-color: var(--color-base00);
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -33,7 +33,7 @@
 @include Input {
   &::placeholder {
     opacity: 0.3;
-    font-size: $terminal-font-size;
+    font-size: calc($terminal-font-size * 12 / 14);
     color: var(--color-text-02);
   }
 }
@@ -55,10 +55,22 @@
   @include NoInputColorBlocking;
 }
 
+@include FinishedBlock {
+  @include InputWrapperImmediate {
+    @include SepiaColors;
+  }
+}
+
+@include Block {
+  @include InputWrapper {
+    font-size: calc($terminal-font-size * 12 / 14);
+  }
+}
+
 @include Block {
   @include InputWrapper {
     border: $input-border;
-    border-radius: 1px;
+    border-radius: 1px / 2px;
     &[data-is-reedit] {
       border-color: $input-border-editing;
     }
@@ -101,7 +113,7 @@
 
   @include Block {
     @include Context {
-      padding: calc(#{$inset} / 0.875 + 1px) 0;
+      padding: $inset 0;
       align-items: flex-start;
     }
 
@@ -143,7 +155,7 @@
 
     @include NotOutputOnly {
       @include BlockOutput {
-        margin-top: 0.5em;
+        margin-top: 0.25rem;
       }
     }
 
@@ -247,7 +259,7 @@
     & {
       @include InputWrapper {
         align-items: stretch;
-        padding-left: 0.5em;
+        padding-left: $inset;
         position: relative; /* for repl-block-actions' position: absolute */
         .repl-input-element,
         .kui--repl-input-element-nbsp {
@@ -278,9 +290,6 @@
       }
     }
   }
-  .kui--repl-block-right-element {
-    font-size: 0.6875em;
-  }
 }
 
 @include SideBySide {
@@ -298,7 +307,7 @@ body[kui-theme-style] .kui--repl-block-right-element {
 @mixin timestamp-like {
   margin: math.div($inset, $right-element-font-size-factor);
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   transition-delay: $action-hover-delay;
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -77,7 +77,7 @@ $box-shadow-margin: 4px; /* room for box shadow */
 
 @mixin Sepia {
   &:not(:hover) {
-    filter: sepia(0.5) opacity(0.9) contrast(0.95) blur(0.25px);
+    @include SepiaColors;
   }
 }
 
@@ -418,7 +418,6 @@ body[kui-theme-style='light'] {
   }
 
   @include ExpandableSectionContent {
-    margin-top: 1em;
     max-width: unset;
 
     & > .paragraph {
@@ -500,7 +499,16 @@ $tip-toggle-opacity-2: 0.6;
   }
 }
 
+@include SampleOutput {
+  @include ExpandableSectionContentElement {
+    margin-top: 0;
+  }
+}
+
 @include MarkdownTip {
+  @include ExpandableSectionContentElement {
+    margin-top: 1em;
+  }
   @include ExpandableSectionToggle {
     width: 100%;
     font-weight: 500;

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -24,10 +24,10 @@ $max-column-width: 77em;
 $terminal-font-size: 0.875rem;
 
 /** Inset of the <input> element w.r.t. the bordered/backgrounded region */
-$inset: 0.5em;
+$inset: 1em;
 
 /** Font size of e.g. timestamp */
-$right-element-font-size-factor: 0.875;
+$right-element-font-size-factor: math.div(11, 12);
 $right-element-font-size: $right-element-font-size-factor + em;
 
 /** Sizing for Block action buttons */
@@ -37,9 +37,9 @@ $action-width: 2em;
 /** Color to indicate focused block */
 $focus-color: var(--color-brand-01);
 
-$input-bg: var(--color-base01);
+$input-bg: var(--color-sidecar-background-02);
 $input-bg-inverted: var(--color-sidecar-background-02);
-$input-border: 1px solid rgba(150, 150, 150, 0.2);
+$input-border: 1px solid rgba(150, 150, 150, 0.075);
 $input-border-editing: var(--color-brand-03);
 
 /** This is the left-hand border that defines each block region */
@@ -368,6 +368,25 @@ $action-hover-delay: 210ms;
   }
 }
 
+/** Same as InputWrapper, but as an immediate descendant of Block, not
+  part of some outer-enclosing Block such as might happen with a
+  guidebook replay */
+@mixin InputWrapperImmediate {
+  > {
+    @include BlockInput {
+      > {
+        @include ContextAndInput {
+          > {
+            @include InputWrapper {
+              @content;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 @mixin Successful {
   &.valid-response {
     @content;
@@ -608,6 +627,12 @@ $action-hover-delay: 210ms;
   }
 }
 
+@mixin NotShowingSampleOutput {
+  &:not([data-is-sample-output]) {
+    @content;
+  }
+}
+
 @mixin SampleOutput {
   .kui--sample-output {
     @content;
@@ -618,4 +643,8 @@ $action-hover-delay: 210ms;
   .kui--admonition {
     @content;
   }
+}
+
+@mixin SepiaColors {
+  filter: sepia(0.5) opacity(0.9) contrast(0.95) blur(0.25px);
 }

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -19,6 +19,7 @@
 @import '@kui-shell/plugin-client-common/web/scss/Themes/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/Wizard/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/Sidecar/mixins';
+@import '@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/StatusStripe/mixins';
 
 /* inverted sidecar */
@@ -167,6 +168,9 @@ body[kui-theme='Light'] {
 
   /** An inverted StatusStripe looks better in this theme */
   @include StatusStripeWithDefaultColors {
+    @include InvertColors;
+  }
+  @include InputWrapper {
     @include InvertColors;
   }
   @include CommentaryEditor {

--- a/plugins/plugin-kubectl/src/test/k8s1/aaa-get-namespaces-with-watch-via-table.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/aaa-get-namespaces-with-watch-via-table.ts
@@ -23,6 +23,7 @@ import {
 } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
 const wdescribe = !process.env.USE_WATCH_PANE ? describe : xdescribe
+const timeout = { timeout: CLI.waitTimeout }
 
 /** name of the namespace */
 const nsName: string = create()
@@ -119,22 +120,22 @@ const watchNS = function(this: Common.ISuite, kubectl: string) {
         const deleteBadge = await waitForOffline(await CLI.command(`${kubectl} delete ns ${nsNameForIter}`, this.app))
 
         // the create and delete badges had better still exist
-        await this.app.client.$(createBadge).then(_ => _.waitForExist())
-        await this.app.client.$(deleteBadge).then(_ => _.waitForExist())
+        await this.app.client.$(createBadge).then(_ => _.waitForExist(timeout))
+        await this.app.client.$(deleteBadge).then(_ => _.waitForExist(timeout))
 
         // the "online" badge from the watch had better *NOT* exist after the delete
         // (i.e. we had better actually be watching!)
         await this.app.client.$(watchBadge).then(_ => _.waitForExist({ timeout: 20000, reverse: true }))
 
         // and, conversely, that watch had better eventually show Offline
-        await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist())
+        await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist(timeout))
 
         // create again
         await waitForOnline(await CLI.command(`${kubectl} create ns ${nsNameForIter}`, this.app))
 
         // the "online" badge from the watch had better now exist again after the create
         // (i.e. we had better actually be watching!)
-        await this.app.client.$(watchBadge).then(_ => _.waitForExist())
+        await this.app.client.$(watchBadge).then(_ => _.waitForExist(timeout))
 
         // and, conversely, that watch had better NOT show Offline
         await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist({ timeout: 20000, reverse: true }))
@@ -147,7 +148,7 @@ const watchNS = function(this: Common.ISuite, kubectl: string) {
         await this.app.client.$(watchBadge).then(_ => _.waitForExist({ timeout: 20000, reverse: true }))
 
         // and, conversely, that watch had better eventually show Offline
-        await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist())
+        await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist(timeout))
 
         // hit the pause watcher button in get -w
         await this.app.client.$(Selectors.WATCH_LIVE_BUTTON(testWatch.count)).then(_ => _.click())
@@ -155,12 +156,12 @@ const watchNS = function(this: Common.ISuite, kubectl: string) {
         // create again
         await waitForOnline(await CLI.command(`${kubectl} create ns ${nsNameForIter}`, this.app))
         // get -w should stay red
-        await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist())
+        await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist(timeout))
         // hit the resume watcher button in get -w
         await this.app.client.$(Selectors.WATCH_OFFLINE_BUTTON(testWatch.count)).then(_ => _.click())
         await this.app.client.$(Selectors.WATCH_LIVE_BUTTON(testWatch.count))
         // get -w should be green
-        await this.app.client.$(watchBadge).then(_ => _.waitForExist())
+        await this.app.client.$(watchBadge).then(_ => _.waitForExist(timeout))
       } catch (err) {
         await Common.oops(this, true)(err)
       }

--- a/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
@@ -20,6 +20,7 @@
 @import 'light';
 @import '@kui-shell/plugin-client-common/web/scss/components/Wizard/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/StatusStripe/mixins';
+@import '@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins';
 
 body.kui--patternfly4[kui-theme='PatternFly4 Light'][kui-theme-style] {
   @include LightColors;
@@ -29,6 +30,10 @@ body.kui--patternfly4[kui-theme='PatternFly4 Light'][kui-theme-style] {
 
   /** An inverted StatusStripe looks better in this theme */
   @include StatusStripeWithDefaultColors {
+    @include InvertLightToDark;
+  }
+  @include InputWrapper {
+    @include InvertLightToDarkForSidecar;
     @include InvertLightToDark;
   }
   @include CommentaryEditor {


### PR DESCRIPTION
…s and plain terminals

Guidebooks use an inverted color scheme for input elements, but the plain terminal does not. This PR updates plain terminals, in light themes, to do so, too.

## Proposal
<img width="1223" alt="inverted prompts in plain terminals v2" src="https://user-images.githubusercontent.com/4741620/154356500-d6fcb03b-494b-40dd-b636-d87d647a910f.png">

## Current Design

<img width="1224" alt="not inverted prompts in plain terminals" src="https://user-images.githubusercontent.com/4741620/154344182-b518d202-de0e-4246-91f7-229564c48d07.png">




<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
