### PR TITLE
fix(plugins/plugin-client-common): with sidebar open, drilling down c…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/LeftAndBottomComboStrips.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/LeftAndBottomComboStrips.scss
@@ -22,7 +22,7 @@
 @include KuiTabContainer {
   @include SidebarOpen {
     @include TopLevelTab {
-      @include HasOnlyLeftStrip {
+      @include HasLeftAndBottomStrips {
         @include Split(3) {
           @include Columns(4);
           grid-template-areas:


### PR DESCRIPTION
…an lead to bad split layout

It's fine when you close the sidebar.

This is due to a bug in LeftAndBottomComboStrips.scss
<img width="1392" alt="Screen Shot 2022-02-16 at 4 07 24 PM" src="https://user-images.githubusercontent.com/4741620/154357209-72548954-d9ea-4910-82db-776dc32bcf44.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
