### PR TITLE
fix(plugins/plugin-client-common): use a left-right split for drilldo…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/LeftStrip.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/LeftStrip.scss
@@ -28,10 +28,9 @@
         }
 
         @include Split(3) {
-          @include Columns(4);
-          grid-template-areas:
-            'L1 T1 T1 T1'
-            'L1 T2 T2 T2';
+          @include Rows(1);
+          @include Columns(5);
+          grid-template-areas: 'L1 T1 T1 T2 T2';
         }
       }
     }
@@ -47,11 +46,9 @@
     }
 
     @include Split(3) {
-      @include Rows(2);
+      @include Rows(1);
       @include Columns(5);
-      grid-template-areas:
-        'L1 T1 T1 T1 T1'
-        'L1 T2 T2 T2 T2';
+      grid-template-areas: 'L1 T1 T1 T2 T2';
     }
 
     @include Split(4) {


### PR DESCRIPTION
…wn even with left strip

Right now, we are using a top-bottom split when we have two plain splits, and one left strip split. But this means that drilldowns from a table no longer have the nice side-by-side layout.

This PR changes that so that, even when we have a left strip, we still use the left-right side-by-side layout that we do without a left strip.

<img width="1392" alt="Screen Shot 2022-02-16 at 4 10 28 PM" src="https://user-images.githubusercontent.com/4741620/154358048-c5566d34-8bd8-4bd9-8821-70e0d267b038.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
