### PR TITLE
feat(plugins/plugin-client-common): allow splits created in guidebook…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -247,7 +247,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
   /** add welcome blocks at the top of scrollback */
   private scrollbackWithWelcome() {
-    const scrollback = this.scrollback()
+    const scrollback = this.scrollback(undefined, { createdBy: 'default' })
     const welcomeMax = this.props.config.showWelcomeMax
 
     if (this.props.sessionInit === 'Done' && this.props.config.loadingDone && welcomeMax !== undefined) {
@@ -296,8 +296,12 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
   }
 
   /** Create a split with the given position and coloration */
-  private makePositionedSplit(position: SplitPosition, inverseColors?: boolean) {
-    const split = this.scrollback(undefined, { position, inverseColors })
+  private makePositionedSplit(
+    position: SplitPosition,
+    opts: ScrollbackOptions = {},
+    inverseColors = position === 'left-strip'
+  ) {
+    const split = this.scrollback(undefined, Object.assign({}, opts, { position, inverseColors }))
 
     this.setState(curState => ({
       splits: curState.splits.concat([split])
@@ -329,7 +333,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       (position !== 'default'
         ? this.state.splits.find(_ => _.position === position)
         : this.state.splits.filter(_ => _.position === 'default')[count]) ||
-      this.makePositionedSplit(position, position === 'left-strip')
+      this.makePositionedSplit(position, { createdBy: 'kui' })
 
     if (split) {
       this.splice(split.uuid, curState => {
@@ -408,6 +412,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       tabRefFor: undefined,
       scrollableRef: undefined,
 
+      createdBy: opts.createdBy || 'user',
       position: opts.position || 'default',
       willToggleSplitPosition: undefined
     }
@@ -1467,6 +1472,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
             onRemove={scrollback.remove}
             onClear={scrollback.clear}
             onInvert={scrollback.invert}
+            createdBy={scrollback.createdBy}
             hasLeftStrip={this.props.hasLeftStrip}
             hasBottomStrip={this.props.hasBottomStrip}
             willToggleSplitPosition={

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollbackState.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollbackState.ts
@@ -22,52 +22,69 @@ import { BlockModel } from './Block/BlockModel'
 
 export type Cleaner = () => void
 
-export type ScrollbackOptions = NewSplitRequest['options']
-
-type ScrollbackState = ScrollbackOptions & {
-  uuid: string
-  blocks: BlockModel[]
-
-  /** Display as strip along the bottom */
-  position: SplitPosition
-  willToggleSplitPosition(): void
-
-  /** tab facade */
-  facade?: KuiTab
-
-  /** grab a ref to the active block, to help us maintain focus */
-  _activeBlock?: Block
-
-  /** Has the user clicked to focus on a block? */
-  focusedBlockIdx?: number
-
-  /** cleanup routines for this split */
-  cleaners: Cleaner[]
-
-  /** Remove this scrollback (memoized handler) */
-  remove: () => void
-
-  /** Clear the current list of blocks (memoized handler) */
-  clear: () => void
-
-  /** Invert colors (memoized handler) */
-  invert: () => void
-
-  /** Other memoized handlers (TODO: docs) */
-  onClick: (evt: React.MouseEvent<HTMLElement, MouseEvent>) => void
-  onMouseDown: (evt: React.MouseEvent<HTMLElement, MouseEvent>) => void
-  onFocus: (evt: React.FocusEvent) => void
-  onOutputRender: () => void
-  setActiveBlock: (c: Block) => void
-  willFocusBlock: (evt: React.SyntheticEvent) => void
-  willRemoveBlock: (evt: React.SyntheticEvent, idx?: number) => void
-  willUpdateCommand: (idx: number, command: string) => void
-
-  /** Reference for the entire Split */
-  tabRefFor(ref: HTMLElement): void
-
-  /** Reference for the scrollable part of the Split; helpful for scrollToTop/Bottom */
-  scrollableRef(ref: HTMLElement): void
+export type CreatedBy = {
+  /**
+   * How was this split created?
+   *
+   * - 'user' from user action e.g. by clicking the Split button or by
+   *   clicking on a Table row with a `drilldownTo=side-split` policy
+   *
+   * - 'kui' part of some kui automation e.g. as part of the splits
+   *    defined by a guidebook
+   *
+   * - 'default' this will usually mean the first split created in
+   *    every tab
+   */
+  createdBy: 'user' | 'kui' | 'default'
 }
+
+export type ScrollbackOptions = NewSplitRequest['options'] & Partial<CreatedBy>
+
+type ScrollbackState = ScrollbackOptions &
+  Required<CreatedBy> & {
+    uuid: string
+    blocks: BlockModel[]
+
+    /** Display as strip along the bottom */
+    position: SplitPosition
+    willToggleSplitPosition(): void
+
+    /** tab facade */
+    facade?: KuiTab
+
+    /** grab a ref to the active block, to help us maintain focus */
+    _activeBlock?: Block
+
+    /** Has the user clicked to focus on a block? */
+    focusedBlockIdx?: number
+
+    /** cleanup routines for this split */
+    cleaners: Cleaner[]
+
+    /** Remove this scrollback (memoized handler) */
+    remove: () => void
+
+    /** Clear the current list of blocks (memoized handler) */
+    clear: () => void
+
+    /** Invert colors (memoized handler) */
+    invert: () => void
+
+    /** Other memoized handlers (TODO: docs) */
+    onClick: (evt: React.MouseEvent<HTMLElement, MouseEvent>) => void
+    onMouseDown: (evt: React.MouseEvent<HTMLElement, MouseEvent>) => void
+    onFocus: (evt: React.FocusEvent) => void
+    onOutputRender: () => void
+    setActiveBlock: (c: Block) => void
+    willFocusBlock: (evt: React.SyntheticEvent) => void
+    willRemoveBlock: (evt: React.SyntheticEvent, idx?: number) => void
+    willUpdateCommand: (idx: number, command: string) => void
+
+    /** Reference for the entire Split */
+    tabRefFor(ref: HTMLElement): void
+
+    /** Reference for the scrollable part of the Split; helpful for scrollToTop/Bottom */
+    scrollableRef(ref: HTMLElement): void
+  }
 
 export default ScrollbackState

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
@@ -20,23 +20,26 @@ import { i18n } from '@kui-shell/core'
 import Icons from '../../spi/Icons'
 import Tooltip from '../../spi/Tooltip'
 import { MutabilityContext } from '../../Client/MutabilityContext'
+
+import { CreatedBy } from './ScrollbackState'
 import SplitPosition, { SplitPositionProps } from './SplitPosition'
 
 import '../../../../web/scss/components/Terminal/SplitHeader.scss'
 
 const strings = i18n('plugin-client-common')
 
-type Props = SplitPositionProps & {
-  onRemove(): void
-  onInvert(): void
-  onClear(): void
+type Props = SplitPositionProps &
+  CreatedBy & {
+    onRemove(): void
+    onInvert(): void
+    onClear(): void
 
-  /** Toggle whether we have a left or bottom strip split */
-  willToggleSplitPosition(): void
+    /** Toggle whether we have a left or bottom strip split */
+    willToggleSplitPosition(): void
 
-  /** Position of the enclosing Split */
-  position: SplitPosition
-}
+    /** Position of the enclosing Split */
+    position: SplitPosition
+  }
 
 /** Render a header for the given split */
 export default class SplitHeader extends React.PureComponent<Props> {
@@ -130,7 +133,7 @@ export default class SplitHeader extends React.PureComponent<Props> {
     return (
       <MutabilityContext.Consumer>
         {value =>
-          value.editable && (
+          (this.props.createdBy === 'user' || value.editable) && (
             <div className="kui--split-header flex-layout">
               <div className="flex-fill" />
               {this.invertButton()}


### PR DESCRIPTION
… to be closed

Right now, if a user clicks on a table row in a readonly tab, they cannot close the split that Kui creates for them!

This PR updates the logic that determines whether the SplitHeader is visible to take into account how the split was created. The distinctions are manifested in this type, which is part of the ScrollbackState

```typescript
export type CreatedBy = {
  /**
   * How was this split created?
   *
   * - 'user' from user action e.g. by clicking the Split button or by
   *   clicking on a Table row with a `drilldownTo=side-split` policy
   *
   * - 'kui' part of some kui automation e.g. as part of the splits
   *    defined by a guidebook
   *
   * - 'default' this will usually mean the first split created in
   *    every tab
   */
  createdBy: 'user' | 'kui' | 'default'
}
```

Thus, any split with a `createdBy=user` trait will have the SplitHeader.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
