### PR TITLE
fix: Light theme does not get expected sepia filter for finished blocks

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -55,10 +55,8 @@
   @include NoInputColorBlocking;
 }
 
-@include FinishedBlock {
-  @include InputWrapperImmediate {
-    @include SepiaColors;
-  }
+@include SepiaBlockTarget {
+  @include SepiaColors;
 }
 
 @include Block {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -645,6 +645,16 @@ $action-hover-delay: 210ms;
   }
 }
 
+$sepia-filter: sepia(0.5) opacity(0.9) contrast(0.95) blur(0.25px);
 @mixin SepiaColors {
-  filter: sepia(0.5) opacity(0.9) contrast(0.95) blur(0.25px);
+  --kui--sepia-filter: #{$sepia-filter};
+  filter: var(--kui--sepia-filter);
+}
+
+@mixin SepiaBlockTarget {
+  @include FinishedBlock {
+    @include InputWrapperImmediate {
+      @content;
+    }
+  }
 }

--- a/plugins/plugin-core-themes/web/scss/common.scss
+++ b/plugins/plugin-core-themes/web/scss/common.scss
@@ -18,8 +18,10 @@
 @import '@kui-shell/plugin-client-common/web/scss/PatternFly/kui-alignment';
 @import '@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins';
 
+$invert-colors-filter: invert(100%);
+
 @mixin InvertColors {
-  filter: invert(100%);
+  filter: $invert-colors-filter;
 }
 
 @mixin InvertColorsForTerminal {

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -170,6 +170,9 @@ body[kui-theme='Light'] {
   @include StatusStripeWithDefaultColors {
     @include InvertColors;
   }
+  @include SepiaBlockTarget {
+    --kui--sepia-filter: #{$invert-colors-filter $sepia-filter};
+  }
   @include InputWrapper {
     @include InvertColors;
   }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
