### PR TITLE
feat(plugins/plugin-client-common): allow wizard header to be collapsed

### DIFF
--- a/packages/test/src/api/Wizard.ts
+++ b/packages/test/src/api/Wizard.ts
@@ -16,8 +16,8 @@
 
 export default class Wizard {
   public readonly wizard = '.kui--wizard'
-  private readonly title = '.pf-c-wizard__title'
-  private readonly _description = '.pf-c-wizard__description'
+  private readonly title = '.kui--wizard-header-title'
+  private readonly _description = '.kui--wizard-header-description'
   private readonly _navItem = '.pf-c-wizard__nav-item'
   private readonly _navItemTitle = '.pf-c-wizard__nav-link'
   public readonly isCurrentStep = 'pf-m-current'

--- a/plugins/plugin-client-common/web/scss/components/Wizard/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/_index.scss
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import 'mixins';
+@import '../Terminal/mixins';
+
+@include Wizard {
+  display: flex;
+  flex-direction: column;
+
+  @include CollapsedHeader {
+    @include WizardHeader {
+      padding: 1.75em;
+      @include WizardDescription {
+        font-size: $terminal-font-size;
+        max-height: 2em;
+        max-width: $max-column-width;
+        overflow: hidden;
+
+        .paragraph {
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+      }
+    }
+
+    @include WizardTitle {
+      font-size: var(--pf-global--FontSize--xl);
+      margin-bottom: 0.5em;
+    }
+  }
+}
+
+@include WizardHeaderActionButtons {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+}
+
+@include WizardHeader {
+  position: relative;
+  padding: 2em;
+}
+
+@include WizardTitle {
+  font-size: var(--pf-global--FontSize--3xl);
+  margin-bottom: 1em;
+}

--- a/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
@@ -20,14 +20,38 @@
   }
 }
 
+@mixin WizardTitle {
+  .kui--wizard-header-title {
+    @content;
+  }
+}
+
 @mixin WizardHeader {
-  .pf-c-wizard__header {
+  .kui--wizard-header {
+    @content;
+  }
+}
+
+@mixin CollapsedHeader {
+  &[data-collapsed-header] {
+    @content;
+  }
+}
+
+@mixin WizardHeaderActionButtons {
+  .kui--wizard-header-action-buttons {
     @content;
   }
 }
 
 @mixin WizardDescription {
-  .pf-c-wizard__description {
+  .kui--wizard-header-description {
+    @content;
+  }
+}
+
+@mixin WizardMainContent {
+  .kui--wizard-main-content {
     @content;
   }
 }


### PR DESCRIPTION
1) hide description
2) reduce font size and margins a bit

Ideally, it would be nice to pin this content and let the wizard content scroll. Given the current DOM structure, where the markdown is rendered deeply inside of Blocks etc.... this will be too hard for this PR. So let's start with at least allowing the user to reduce the amount of space taken up by the wizard header.
<img width="1392" alt="wizard header collapse" src="https://user-images.githubusercontent.com/4741620/154543777-8c75f601-7c1a-44e8-a827-751931d5dd10.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
