### PR TITLE
fix: fixes for inverted colors in dark themes

### DIFF
--- a/plugins/plugin-carbon-themes/web/scss/carbon-gray90.scss
+++ b/plugins/plugin-carbon-themes/web/scss/carbon-gray90.scss
@@ -30,16 +30,7 @@ body[kui-theme='Carbon Gray90'][kui-theme-style] {
   @include charts-dark;
   @include colors-dark;
 
-  @include ScrollbackInvertedColors {
-    @include colors-light;
-    @include Reset;
-    --color-text-02: #565656;
-
-    @include Sidecar {
-      @include carbon-inverted;
-      @include Reset;
-    }
-  }
+  @include InvertDarkToLightGenerally;
 
   --color-confirm-danger: #da1e28;
 

--- a/plugins/plugin-carbon-themes/web/scss/colors.scss
+++ b/plugins/plugin-carbon-themes/web/scss/colors.scss
@@ -93,7 +93,7 @@
   --color-base01: #e0e0e0;
   --color-base02: #dcdcdc;
   --color-base03: #c6c6c6;
-  --color-base04: #f2f4f8;
+  --color-base04: #8d8d8d;
   --color-base05: #50565b;
   --color-base06: #171717;
   --color-base07: #fff;

--- a/plugins/plugin-client-common/web/scss/Lightweight/_index.scss
+++ b/plugins/plugin-client-common/web/scss/Lightweight/_index.scss
@@ -71,14 +71,6 @@ $row-height: 1.5em;
     }
   }
 
-  @include NonNotebookTab {
-    @include NotFocusedSplit {
-      @include ScrollbackBlockList {
-        filter: opacity(87.5%);
-      }
-    }
-  }
-
   @include TableHeadCell {
     --table-head-background-color: transparent;
     height: $row-height;

--- a/plugins/plugin-client-common/web/scss/Themes/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/Themes/_mixins.scss
@@ -75,3 +75,15 @@
     @content;
   }
 }
+
+$invert-colors-filter: invert(0.1);
+
+@mixin InvertColors {
+  filter: $invert-colors-filter;
+}
+
+@mixin InvertDarkToLightGenerally {
+  @include InvertedColors {
+    @include InvertColors;
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -463,7 +463,7 @@ body[kui-theme-style='dark'] {
   }
 }
 
-$tip-toggle-opacity: 0.175;
+$tip-toggle-opacity: 0.25;
 $tip-toggle-opacity-2: 0.6;
 
 @mixin GreenTip {
@@ -519,6 +519,9 @@ $tip-toggle-opacity-2: 0.6;
     /* Some expandable section toggles in markdown have long urls,
    e.g. https://knative.dev/docs/getting-started/first-service/ */
     word-break: break-all;
+  }
+  @include ExpandableSectionToggle {
+    color: var(--color-text-01);
   }
   @include ExpandableSectionToggleText {
     color: var(--color-text-01);

--- a/plugins/plugin-core-themes/web/scss/common.scss
+++ b/plugins/plugin-core-themes/web/scss/common.scss
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
+@import '@kui-shell/plugin-client-common/web/scss/Themes/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/Lightweight/index';
 @import '@kui-shell/plugin-client-common/web/scss/PatternFly/kui-alignment';
-@import '@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins';
-
-$invert-colors-filter: invert(100%);
-
-@mixin InvertColors {
-  filter: $invert-colors-filter;
-}
 
 @mixin InvertColorsForTerminal {
-  @include ScrollbackInvertedColors {
-    @include InvertColors;
-  }
+  @include InvertDarkToLightGenerally;
 }

--- a/plugins/plugin-patternfly4-themes/web/scss/common.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/common.scss
@@ -64,7 +64,9 @@ body.kui--patternfly4[kui-theme-style] {
   --pf-global--palette--cyan-700: #000f0f;
   --pf-global--palette--gold-50: #fdf7e7;
   --pf-global--palette--gold-100: #f9e0a2;
+  --pf-global--palette--gold-100-rgb: 249, 224, 162;
   --pf-global--palette--gold-200: #f6d173;
+  --pf-global--palette--gold-200-rgb: 246, 209, 115;
   --pf-global--palette--gold-300: #f4c145;
   --pf-global--palette--gold-300-rgb: 244, 193, 69;
   --pf-global--palette--gold-400: #f0ab00;

--- a/plugins/plugin-patternfly4-themes/web/scss/dark.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/dark.scss
@@ -75,7 +75,7 @@
   --color-base0D-rgb: var(--pf-global--palette--blue-300-rgb);
   --color-blue-rgb: var(--color-base0D-rgb);
 
-  --color-base0A-rgb: var(--pf-global--palette--gold-300-rgb);
+  --color-base0A-rgb: var(--pf-global--palette--gold-200-rgb);
   --color-yellow-rgb: var(--color-base0A-rgb);
 
   --color-light-red: var(--pf-global--palette--red-200);

--- a/plugins/plugin-patternfly4-themes/web/scss/light.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/light.scss
@@ -87,9 +87,9 @@
   --color-error-cell-text: var(--color-base00);
 }
 
-@mixin InvertDarkToLightGenerally {
+/* @mixin InvertDarkToLightGenerally {
   @include InvertedColors {
     @include pf-t-light;
     @include LightColors;
   }
-}
+} */


### PR DESCRIPTION
Right now, we are generally using dark-to-light inversion for kui--inverted-color-context elements. This does not seem to be in spirit with dark themes.

## Proposed Update
<img width="1392" alt="invert update" src="https://user-images.githubusercontent.com/4741620/154822786-b94ee4a8-f991-428e-be70-6f19bae840e2.png">


## Prior Behavior

<img width="1392" alt="invert pre update" src="https://user-images.githubusercontent.com/4741620/154822791-92769f87-301b-475b-89c6-51cba3cd933a.png">



<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
