### PR TITLE
feat(plugins/plugin-client-common): add support for :badge-warning-op…

### DIFF
--- a/plugins/plugin-client-common/i18n/code_en_US.json
+++ b/plugins/plugin-client-common/i18n/code_en_US.json
@@ -7,7 +7,7 @@
 
   "Completed tasks": "Completed tasks",
 
-  "status.optional": "This code block is optional :fontawesome-solid-dot-circle:",
+  "status.optional": ":badge-warning-optional:",
   "status.blank": "Not yet executed",
   "status.success": "Successfully executed :fontawesome-solid-check-circle:",
   "status.warning": "Warning",

--- a/plugins/plugin-client-common/notebooks/icons.md
+++ b/plugins/plugin-client-common/notebooks/icons.md
@@ -1,0 +1,15 @@
+=== "Badges"
+
+    :badge-ok-good: :badge-warning-maybe: :badge-error-nope:
+
+=== "Fontawesome Icons"
+
+    https://fontawesome.com/v5/search?m=free
+
+    :fontawesome-solid-check-circle: :fontawesome-solid-adjust: :fontawesome-solid-angry:
+
+=== "Material Design Icons"
+
+    https://materialdesignicons.com/
+
+    :material-account-key: :material-arrow-down-bold-circle: :material-cookie-alert:

--- a/plugins/plugin-client-common/notebooks/playground.md
+++ b/plugins/plugin-client-common/notebooks/playground.md
@@ -17,6 +17,16 @@ layout:
     commentary --send playground \# Welcome to the Kui Playground :rocket:\n\nAuthor your own Kui Guidebook, using markdown! You can edit this example, using the editor to the left, or explore the other tabs in this playground.
     ```
 
+=== "Code Blocks"
+    ```bash
+    ---
+    execute: now
+    maximize: true
+    outputOnly: true
+    ---
+    commentary --send playground -f /kui/code-blocks.md
+    ```
+
 === "Hints"
     ```bash
     ---
@@ -27,14 +37,14 @@ layout:
     commentary --send playground -f /kui/hints.md
     ```
 
-=== "Tips"
+=== "Icons"
     ```bash
     ---
     execute: now
     maximize: true
     outputOnly: true
     ---
-    commentary --send playground -f /kui/expandable-section.md
+    commentary --send playground -f /kui/icons.md
     ```
 
 === "Tabs"
@@ -47,14 +57,14 @@ layout:
     commentary --send playground -f /kui/tabs.md
     ```
 
-=== "Code Blocks"
+=== "Tips"
     ```bash
     ---
     execute: now
     maximize: true
     outputOnly: true
     ---
-    commentary --send playground -f /kui/code-blocks.md
+    commentary --send playground -f /kui/expandable-section.md
     ```
 
 === "Wizards"

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
@@ -19,6 +19,7 @@ import { Components } from 'react-markdown'
 
 import _a from './a'
 import p from './p'
+import tag from './tag'
 import _div from './div'
 import _img from './img'
 import tabbed from './tabbed'
@@ -83,6 +84,7 @@ function components(args: Args) {
   const components = Object.assign(
     {
       tip,
+      tag,
       tabbed: tabbed(args.uuid)
     },
     typedComponents(args)

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/tag.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/tag.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Kubernetes Authors
+ * Copyright 2022 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,11 @@
  */
 
 import React from 'react'
-import { Badge } from '@patternfly/react-core'
 
-import Props from '../model'
+import { Props as TagProps } from '../../../spi/Tag'
+const Tag = React.lazy(() => import('../../../spi/Tag'))
 
-import '../../../../../web/scss/components/Tag/Tag.scss'
-
-export default function PatternFlyTag(props: Props) {
-  const color =
-    props.type === 'ok'
-      ? 'green-background'
-      : props.type === 'error'
-      ? 'red-background'
-      : props.type === 'warning'
-      ? 'yellow-background'
-      : 'gray-background'
-  return <Badge {...props} className={['kui--tag', color, props.spanclassname].join(' ')} />
+export default function tag(props: { variant?: TagProps['type']; children: TagProps['children'] }) {
+  console.error('!!!!!!', props)
+  return <Tag type={props.variant} {...props} />
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-icons.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-icons.ts
@@ -32,7 +32,7 @@ export default function plugin() {
     // match[1]: provider (material, fontawesome, ...)
     // match[2]: variant (e.g. -solid for fontawesome solid)
     // match[3]: icon name
-    const RE_ICON = /:(material|fontawesome)(-solid)?-([^:]+):/g
+    const RE_ICON = /:(badge|material|fontawesome)(-solid|-ok|-warning|-error)?-([^:]+):/g
 
     visit(ast, 'text', function() {
       // ugh, typescript bug
@@ -52,17 +52,22 @@ export default function plugin() {
         }
 
         children.push(
-          u('element', {
-            tagName: provider === 'fontawesome' ? 'i' : 'span',
-            properties: {
-              className:
-                provider === 'material'
-                  ? `kui--markdown-icon mdi mdi-${icon}`
-                  : provider === 'fontawesome'
-                  ? `kui--markdown-icon fa${variant ? variant[1] : 's'} fa-${icon}`
-                  : undefined
-            }
-          })
+          u(
+            'element',
+            {
+              tagName: provider === 'badge' ? 'tag' : provider === 'fontawesome' ? 'i' : 'span',
+              properties: {
+                variant: variant ? variant.slice(1) : undefined,
+                className:
+                  provider === 'material'
+                    ? `kui--markdown-icon mdi mdi-${icon}`
+                    : provider === 'fontawesome'
+                    ? `kui--markdown-icon fa${variant ? variant[1] : 's'} fa-${icon}`
+                    : undefined
+              }
+            },
+            provider === 'badge' ? [u('text', icon)] : undefined
+          )
         )
 
         curIndex = match.index + matched.length

--- a/plugins/plugin-client-common/src/mount.ts
+++ b/plugins/plugin-client-common/src/mount.ts
@@ -21,6 +21,7 @@
 export default [
   'plugin://plugin-client-common/notebooks/code-blocks.md',
   'plugin://plugin-client-common/notebooks/expandable-section.md',
+  'plugin://plugin-client-common/notebooks/icons.md',
   'plugin://plugin-client-common/notebooks/hints.md',
   'plugin://plugin-client-common/notebooks/tabs.md',
   'plugin://plugin-client-common/notebooks/welcome.md',

--- a/plugins/plugin-client-common/web/scss/components/Tag/Tag.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tag/Tag.scss
@@ -30,19 +30,18 @@
 .kui--tag {
   &.pf-c-badge {
     &.yellow-background {
-      background-color: var(--color-yellow);
+      --pf-c-badge--BackgroundColor: var(--color-yellow);
       color: var(--color-base00);
     }
     &.red-background {
-      background-color: var(--color-red);
-      color: var(--color-base07);
+      --pf-c-badge--BackgroundColor: var(--color-red);
     }
     &.green-background {
-      background-color: var(--color-green);
+      --pf-c-badge--BackgroundColor: var(--color-green);
       color: var(--color-base00);
     }
     &.bx--tag--warm-gray {
-      background-color: var(--color-yellow-sidecar);
+      --pf-c-badge--BackgroundColor: var(--color-yellow-sidecar);
       color: var(--color-base00);
     }
   }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -615,6 +615,10 @@ pre {
 
     @include CardBody {
       padding: 0;
+
+      @include CardBody {
+        padding: var(--pf-c-card--first-child--PaddingTop);
+      }
     }
   }
   @include MarkdownTip {


### PR DESCRIPTION
…tional: style of markdown

```
:badge-(ok|warning|error)-badgeText:
```

See plugins/plugin-client-common/notebooks/icons.md

<img width="917" alt="Screen Shot 2022-02-21 at 11 38 42 AM" src="https://user-images.githubusercontent.com/4741620/154995907-8ba2be0e-e89a-4acc-8e5e-52f97e91aa6e.png">

<img width="926" alt="Screen Shot 2022-02-21 at 11 37 45 AM" src="https://user-images.githubusercontent.com/4741620/154995813-5a9988bf-02d0-4472-bb71-fa312141daef.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
