### PR TITLE
fix(plugins/plugin-client-common): when showing replayed output, use …

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/MutabilityContext.ts
+++ b/plugins/plugin-client-common/src/components/Client/MutabilityContext.ts
@@ -33,6 +33,8 @@ const offline: MutabilityState = { editable: false, executable: false }
 
 const notebookMode: MutabilityState = { editable: false, executable: true }
 
+export { offline as MutabilityStateOffline }
+
 // define initialization
 export function initializeState(): MutabilityState {
   if (isOfflineClient()) {

--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import Debug from 'debug'
 import React from 'react'
 import prettyPrintDuration from 'pretty-ms'
 import { Td } from '@patternfly/react-table'
@@ -39,6 +40,8 @@ import whenNothingIsSelected from '../../../util/selection'
 import { MutabilityContext, MutabilityState } from '../../Client/MutabilityContext'
 
 export type CellOnClickHandler = (evt: React.MouseEvent) => void
+
+const debug = Debug('plugin-client-common/Content/Table/TableCell')
 
 function XOR(a: boolean, b: boolean) {
   return (a || b) && !(a && b)
@@ -83,6 +86,7 @@ export function onClickForCell(
           opts.masquerade = row.onclick
           opts.data = row.onclickPrefetch
           handler = 'replay-content'
+          debug('Implementing table cell drilldown with replayed content', row.onclick)
         }
 
         if (drilldownTo === 'side-split' && !XOR(evt.metaKey, !!process.env.KUI_SPLIT_DRILLDOWN)) {


### PR DESCRIPTION
…prefetched drilldowns always

The original implementation of prefetch-replay-drilldown only used prefetched drilldown output in offline clients. We should do so in all clients, when we are showing sample output. For example, if we are presenting a sample output Table, and the user clicks on a table row, this should show the prefetched output that corresponds to the sample table model.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
