### PR TITLE
feat: allow for guidebooks to have a "normal" split with a terminal

### DIFF
--- a/packages/core/src/models/TabLayoutModificationResponse.ts
+++ b/packages/core/src/models/TabLayoutModificationResponse.ts
@@ -53,6 +53,13 @@ export type NewSplitRequest = {
 
     /** Swap the positions of the given two splits */
     swap?: { a: number; b: number }
+
+    /**
+     * Force this new split to have (or not) an active input,
+     * independent of what the default behavior would otherwis
+     * say?
+     */
+    hasActiveInput?: boolean
   }
 }
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
@@ -86,8 +86,8 @@ export function hasCodeBlocks(frontmatter: KuiFrontmatter): frontmatter is KuiFr
   return frontmatter.codeblocks && Array.isArray(frontmatter.codeblocks) && frontmatter.codeblocks.length > 0
 }
 
-type SplitPosition = 'left' | 'bottom' | 'default' | 'wizard'
-type SplitPositionObj = { position: SplitPosition; placeholder?: string; maximized?: boolean | 'true' | 'false' }
+type SplitPosition = 'left' | 'bottom' | 'default' | 'wizard' | 'terminal'
+type SplitPositionObj = { position: SplitPosition; placeholder?: string; maximized?: boolean; inverseColors?: boolean }
 type SplitPositionSpec = SplitPosition | SplitPositionObj
 
 export type PositionProps = {
@@ -97,13 +97,21 @@ export type PositionProps = {
 export function isValidPosition(position: SplitPositionSpec): position is SplitPosition {
   return (
     typeof position === 'string' &&
-    (position === 'default' || position === 'left' || position === 'bottom' || position === 'wizard')
+    (position === 'default' ||
+      position === 'left' ||
+      position === 'bottom' ||
+      position === 'wizard' ||
+      position === 'terminal')
   )
+}
+
+export function isNormalSplit(position: SplitPosition) {
+  return position === 'default' || position === 'terminal'
 }
 
 export function isValidPositionObj(position: SplitPositionSpec): position is SplitPositionObj {
   const pos = position as SplitPositionObj
-  return typeof pos === 'object' && typeof pos.position === 'string'
+  return typeof pos === 'object' && isValidPosition(pos.position)
 }
 
 export default KuiFrontmatter

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
@@ -48,7 +48,7 @@ function typedComponents(args: Args): Components {
   const { mdprops, repl, uuid, codeBlockResponses, spliceInCodeExecution } = args
 
   const a = _a(mdprops, uuid, repl)
-  const div = _div(uuid)
+  const div = _div(mdprops, uuid)
   const img = _img(mdprops)
   const code = _code(mdprops, uuid, codeBlockResponses, spliceInCodeExecution)
   const heading = _heading(uuid)

--- a/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
@@ -23,7 +23,7 @@ import { visitParents } from 'unist-util-visit-parents'
 import { Tab } from '@kui-shell/core'
 
 import preprocessCodeBlocks from './components/code/remark-codeblocks-topmatter'
-import KuiFrontmatter, { hasWizardSteps, isValidPosition, isValidPositionObj } from './KuiFrontmatter'
+import KuiFrontmatter, { hasWizardSteps, isNormalSplit, isValidPosition, isValidPositionObj } from './KuiFrontmatter'
 
 export { tryFrontmatter } from './frontmatter-parser'
 
@@ -154,12 +154,12 @@ function extractSplitsAndSections(tree /*: Root */, frontmatter: KuiFrontmatter)
     // text to place in empty sections
     const placeholder = isValidPositionObj(positionAsGiven) ? positionAsGiven.placeholder : undefined
 
-    const maximized =
-      isValidPositionObj(positionAsGiven) &&
-      (positionAsGiven.maximized === true || positionAsGiven.maximized === 'true')
+    const maximized = isValidPositionObj(positionAsGiven) && positionAsGiven.maximized === true
+    const inverseColors = isValidPositionObj(positionAsGiven) && positionAsGiven.inverseColors === true
 
-    const count = frontmatter.layoutCount[position] || 0
-    frontmatter.layoutCount[position] = count + 1
+    const positionForCount = isNormalSplit(position) ? 'default' : position
+    const count = frontmatter.layoutCount[positionForCount] || 0
+    frontmatter.layoutCount[positionForCount] = count + 1
 
     return u(
       'subtree',
@@ -167,6 +167,7 @@ function extractSplitsAndSections(tree /*: Root */, frontmatter: KuiFrontmatter)
         data: {
           hProperties: {
             'data-kui-split': position,
+            'data-kui-inverseColors': inverseColors.toString(),
             'data-kui-maximized': maximized.toString(),
             'data-kui-split-count': count,
             'data-kui-placeholder': placeholder

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitInjector.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitInjector.ts
@@ -17,6 +17,21 @@
 import React from 'react'
 import SplitPosition from './SplitPosition'
 
+export interface InjectorOptions {
+  /** @deprecated */
+  maximized?: boolean
+
+  /** Use inverse colors in the split? */
+  inverseColors?: boolean
+
+  /**
+   * Force this new split to have (or not) an active input,
+   * independent of what the default behavior would otherwis
+   * say?
+   */
+  hasActiveInput?: boolean
+}
+
 /**
  * Inject the given React `node` in the given `SplitPosition`. Use the
  * given `uuid` to determine whether we have already injected this
@@ -28,7 +43,24 @@ type Injector = (
   node: React.ReactNode,
   position: SplitPosition,
   count: number,
-  maximized?: boolean
+  opts?: InjectorOptions
 ) => void
 
-export default React.createContext<Injector>(undefined)
+/** Update the properties of an existing split */
+type Modifier = (
+  /** id of split to modify */
+  uuid: string,
+
+  /** The actual content */
+  node: React.ReactNode,
+
+  /** Modification options */
+  opts: InjectorOptions
+) => React.ReactNode
+
+interface InjectProvider {
+  inject: Injector
+  modify: Modifier
+}
+
+export default React.createContext<InjectProvider>(undefined)

--- a/plugins/plugin-client-common/src/test/core/markdown/terminal.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/terminal.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename, dirname, join } from 'path'
+import { encodeComponent } from '@kui-shell/core'
+import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+
+const timeout = { timeout: CLI.waitTimeout }
+const ROOT = join(dirname(require.resolve('@kui-shell/plugin-client-common/tests/data/terminal1.md')), '..')
+
+interface Input {
+  input: string
+  splits: {
+    text: string
+    isTerminal?: boolean
+    inverseColors?: boolean
+  }[]
+}
+
+const IN1: Input = {
+  input: join(ROOT, 'data/terminal1.md'),
+  splits: [{ text: 'XXXX', isTerminal: true }, { text: 'YYYY' }]
+}
+
+const IN2: Input = {
+  input: join(ROOT, 'data/terminal2.md'),
+  splits: [{ text: IN1.splits[0].text }, { text: IN1.splits[1].text, isTerminal: true }]
+}
+
+const IN3: Input = {
+  input: join(ROOT, 'data/terminal3.md'),
+  splits: [IN2.splits[0], { text: IN2.splits[1].text, isTerminal: true, inverseColors: true }]
+}
+;[IN1, IN2, IN3].forEach(markdown => {
+  describe(`terminals in markdown ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
+    ''}`, function(this: Common.ISuite) {
+    before(Common.before(this))
+    after(Common.after(this))
+
+    it(`should load markdown and show expected terminal split configuration`, async () => {
+      try {
+        await CLI.command(`replay ${encodeComponent(markdown.input)}`, this.app)
+
+        await Promise.all(
+          markdown.splits.map(async (split, idx) => {
+            const splitIdx = idx + 1
+
+            await this.app.client.waitUntil(async () => {
+              const actualText = await this.app.client.$(Selectors.SPLIT_N(splitIdx)).then(_ => _.getText())
+              return actualText.includes(split.text)
+            }, timeout)
+
+            if (split.inverseColors) {
+              await this.app.client.$(Selectors.SPLIT_N(splitIdx, true)).then(_ => _.waitForExist(timeout))
+            }
+
+            if (split.isTerminal) {
+              const activePrompt = this.app.client.$(Selectors.CURRENT_PROMPT_FOR_SPLIT(splitIdx))
+              await activePrompt.waitForExist(timeout)
+
+              await CLI.commandInSplit('kuiecho AAAA', this.app, splitIdx).then(ReplExpect.okWithString('AAAA'))
+
+              await CLI.commandInSplit('kuiecho BBBB', this.app, splitIdx).then(ReplExpect.okWithString('BBBB'))
+
+              await CLI.commandInSplit('kuiecho CCCC', this.app, splitIdx).then(ReplExpect.okWithString('CCCC'))
+            }
+          })
+        )
+      } catch (err) {
+        await Common.oops(this, true)(err)
+      }
+    })
+  })
+})

--- a/plugins/plugin-client-common/tests/data/terminal1.md
+++ b/plugins/plugin-client-common/tests/data/terminal1.md
@@ -1,0 +1,11 @@
+---
+layout:
+    1: terminal
+    2: default
+---
+
+XXXX
+
+---
+
+YYYY

--- a/plugins/plugin-client-common/tests/data/terminal2.md
+++ b/plugins/plugin-client-common/tests/data/terminal2.md
@@ -1,0 +1,11 @@
+---
+layout:
+    2: terminal
+    1: default
+---
+
+XXXX
+
+---
+
+YYYY

--- a/plugins/plugin-client-common/tests/data/terminal3.md
+++ b/plugins/plugin-client-common/tests/data/terminal3.md
@@ -1,0 +1,13 @@
+---
+layout:
+    2: 
+        position: terminal
+        inverseColors: true
+    1: default
+---
+
+XXXX
+
+---
+
+YYYY


### PR DESCRIPTION
Right now, guidebooks can only have markdown content in splits. Some use cases would benefit from having one of their splits be a normal terminal.

This PR adds a `terminal` option to the guidebook topmatter, e.g. (from terminal1.md test input) this guidebook would have the first split offer a normal terminal interaction, and the second split be markdown only, without a normal terminal interaction (which is the default behavior for splits in guidebooks,  hence the `2: default`)

```markdown
---
layout:
    1: terminal
    2: default
---

XXXX

---

YYYY
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
