### PR TITLE
fix(plugins/plugin-client-common): table status column can yield odd …

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -185,6 +185,8 @@ export default function renderCell(table: KuiTable, kuiRow: KuiRow, justUpdated:
             modifier={
               /OBJECT/i.test(key) || /MESSAGE/i.test(key)
                 ? 'wrap'
+                : /STATUS/i.test(key)
+                ? 'nowrap'
                 : !/NAME|NAMESPACE/i.test(key)
                 ? 'fitContent'
                 : undefined


### PR DESCRIPTION
…vertical alignment

We are using the patternfly "fitContent" policy, which does not cooperate with the `display: flex` we have for the inner content of Status cells. Instead, we need to use the patternfly "nowrap" policy for this column.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
