### PR TITLE
fix: creating split can cause funky layout

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -81,7 +81,7 @@ import '../../../../web/scss/components/Terminal/_index.scss'
 const strings = i18n('plugin-client-common')
 
 /** Hard limit on the number of Terminal splits */
-const MAX_TERMINALS = 6
+const MAX_TERMINALS = 5
 
 /** Remember the welcomed count in localStorage, using this key */
 const NUM_WELCOMED = 'kui-shell.org/ScrollableTerminal/NumWelcomed'

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/BottomStrip.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/BottomStrip.scss
@@ -81,20 +81,6 @@ $min-height: 7rem;
         'T3 T4'
         'B1 B1';
     }
-
-    @include Split(6) {
-      @include Rows(8);
-      @include Columns(6);
-      grid-template-areas:
-        'T1 T1 T2 T2 T3 T3'
-        'T1 T1 T2 T2 T3 T3'
-        'T1 T1 T2 T2 T3 T3'
-        'T4 T4 T4 T5 T5 T5'
-        'T4 T4 T4 T5 T5 T5'
-        'T4 T4 T4 T5 T5 T5'
-        'T4 T4 T4 T5 T5 T5'
-        'B1 B1 B1 B1 B1 B1';
-    }
   }
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/Default.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/Default.scss
@@ -81,30 +81,3 @@
     'T4 T4 T4 T5 T5 T5'
     'T4 T4 T4 T5 T5 T5';
 }
-
-@include Split(6) {
-  @include Rows(3);
-  @include Columns(4);
-  grid-template-areas:
-    'T1 T2 T3 T3'
-    'T4 T4 T6 T6'
-    'T5 T5 T6 T6';
-}
-
-@include Split(7) {
-  @include Rows(3);
-  @include Columns(4);
-  grid-template-areas:
-    'T1 T2 T3 T3'
-    'T4 T5 T7 T7'
-    'T6 T6 T7 T7';
-}
-
-@include Split(8) {
-  @include Rows(3);
-  @include Columns(4);
-  grid-template-areas:
-    'T1 T2 T3 T3'
-    'T4 T5 T8 T8'
-    'T6 T7 T8 T8';
-}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/LeftStrip.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/LeftStrip.scss
@@ -58,6 +58,14 @@
         'L1 L1 T1 T1 T1 T2 T2 T2'
         'L1 L1 T3 T3 T3 T3 T3 T3';
     }
+
+    @include Split(5) {
+      @include Rows(2);
+      @include Columns(8);
+      grid-template-areas:
+        'L1 L1 T1 T1 T1 T2 T2 T2'
+        'L1 L1 T3 T3 T3 T4 T4 T4';
+    }
   }
 
   @include Scrollback {

--- a/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
@@ -396,9 +396,9 @@ describe('click and show in splits', function(this: Common.ISuite) {
   count(5)
   clickAndValidate(5)
 
-  splitTheTerminalViaButton(6)
+  /* splitTheTerminalViaButton(6)
   count(6)
-  clickAndValidate(6)
+  clickAndValidate(6) */
 
   /* splitTheTerminalViaButton(7)
   count(7)


### PR DESCRIPTION
We have some missing rules for 5 or 6 splits. This PR addresses the 5 gap with extra CSS rules, and addresses the 6 gap by reducing the MAX_SPLITS from 6 to 5.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
