### PR TITLE
fix(packages/builder): make sure to build win32 electron last

### DIFF
--- a/packages/builder/dist/electron/build.sh
+++ b/packages/builder/dist/electron/build.sh
@@ -266,8 +266,6 @@ function builddeps {
 function build {
     echo "builddeps" && builddeps
 
-    win32 x64
-
     if [ -z "$ARCH" ] || [ "$ARCH" = "all" ]; then
 	echo "Building all arch for mac"
         mac x64
@@ -283,6 +281,10 @@ function build {
     else
 	linux ${ARCH-x64}
     fi
+
+    # must be at the end, for now, due to the way we hack in node-pty
+    # 0.10 (see "Hacking win32 node-pty" above)
+    win32 x64
 }
 
 # line up the work


### PR DESCRIPTION
This is due to the way we hack node-pty 0.10.0 in, just for win32.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
