### PR TITLE
feat(plugins/plugin-client-common): increase font size of markdown ic…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -730,3 +730,12 @@ pre {
     color: var(--color-error);
   }
 }
+
+@include h1 {
+  @include MarkdownIcon {
+    font-size: 12rem;
+    display: flex;
+    justify-content: center;
+    line-height: 10rem;
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -633,6 +633,12 @@ $action-hover-delay: 210ms;
   }
 }
 
+@mixin MarkdownIcon {
+  .kui--markdown-icon {
+    @content;
+  }
+}
+
 @mixin Markdown {
   .page-content {
     @content;


### PR DESCRIPTION
…ons inside of h1

To get the icon in this figure:
```markdown
# :material-kubernetes:
```

<img width="298" alt="markdown-header-icon" src="https://user-images.githubusercontent.com/4741620/155770920-60b6c89b-7633-41cd-baa5-8bd309434276.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
