### PR TITLE
fix(plugins/plugin-client-common): tweak code block option color

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.scss
+++ b/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.scss
@@ -56,15 +56,22 @@ body[kui-theme-style] .monaco-editor .strong {
   color: var(--color-base0D);
 }
 
-body[kui-theme-style] .monaco-editor .mtk22,
-body[kui-theme-style] .monaco-editor .mtk4 {
+body[kui-theme-style] .monaco-editor .mtk22 {
   /* map keys */
   /* notes:
        mtk22 is the CSS class for YAML keys
-       mtk4 is the CSS class for JSON keys
    */
   transition: color 300ms ease-in-out;
-  color: var(--color-map-key);
+  color: var(--color-base0C);
+}
+
+body[kui-theme-style] .monaco-editor .mtk4 {
+  /* map keys */
+  /* notes:
+       mtk4 is the CSS class for JSON keys and --options in bash
+   */
+  transition: color 300ms ease-in-out;
+  color: var(--color-base0E);
 }
 
 body[kui-theme-style] .monaco-editor .mtk1 {


### PR DESCRIPTION
We were using the cyan (color-base0C), which is used in lots of places. This PR adjusts to use base0E (magenta) for --options in code blocks, for a bit more variety.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
