### PR TITLE
fix(plugins/plugin-client-common): avoid super-tall action buttons in…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -694,6 +694,8 @@ pre {
         width: calc(2em * $action-size);
       }
       @include BlockAction {
+        width: auto;
+        padding: 8px;
         font-size: $action-size + em;
         color: var(--color-for-guidebook-block-actions);
       }


### PR DESCRIPTION
… code blocks

Right now, the code block action buttons have a hover effect that makes them appear to be as tall as the code block input area -- which, with wrapping, is unboundedly tall.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
