### PR TITLE
fix(plugins/plugin-client-common): split header tooltips have odd spa…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
@@ -48,7 +48,7 @@ export default class SplitHeader extends React.PureComponent<Props> {
   private closeButton() {
     return (
       this.props.onRemove && (
-        <Tooltip markdown={strings('Close this split pane')}>
+        <Tooltip content={strings('Close this split pane')} position="bottom-end">
           <a
             href="#"
             className="kui--split-close-button kui--tab-navigatable kui--split-header-button"
@@ -92,7 +92,7 @@ export default class SplitHeader extends React.PureComponent<Props> {
   private splitPositionToggleButton() {
     return (
       this.props.willToggleSplitPosition && (
-        <Tooltip markdown={strings('Toggle position')}>
+        <Tooltip content={strings('Toggle position')} position="bottom-end">
           <a
             href="#"
             className="kui--tab-navigatable"
@@ -111,7 +111,7 @@ export default class SplitHeader extends React.PureComponent<Props> {
 
   private invertButton() {
     return (
-      <Tooltip markdown={strings('Invert colors')}>
+      <Tooltip content={strings('Invert colors')} position="bottom-end">
         <a href="#" className="kui--tab-navigatable" onMouseDown={this.stopFocusStealing} onClick={this.props.onInvert}>
           <Icons className="kui--split-invert-button kui--split-header-button" icon="Contrast" />
         </a>
@@ -121,7 +121,7 @@ export default class SplitHeader extends React.PureComponent<Props> {
 
   private clearButton() {
     return (
-      <Tooltip markdown={strings('Clear this split pane')}>
+      <Tooltip content={strings('Clear this split pane')} position="bottom-end">
         <a href="#" className="kui--tab-navigatable" onMouseDown={this.stopFocusStealing} onClick={this.props.onClear}>
           <Icons className="kui--split-clear-button kui--split-header-button" icon="Clear" />
         </a>


### PR DESCRIPTION
…cing

Screenshot of current behavior (before the fix):

<img width="178" alt="Screen Shot 2022-02-26 at 9 22 23 PM" src="https://user-images.githubusercontent.com/4741620/155865713-abfbdbc3-7b21-4d74-b499-5b5f0eb38955.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
