### PR TITLE
fix(plugins/plugin-client-common): tooltips often have low contrast a…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
@@ -17,12 +17,21 @@
 @import 'mixins';
 @import '../Editor/mixins';
 
-$color: var(--color-base00);
-$bgcolor: var(--color-base06);
+$tooltip-fgcolor: var(--color-base00);
+$tooltip-fgcolor-dark: var(--color-text-01);
+$tooltip-bgcolor: var(--color-blue);
+
+body[kui-theme-style='dark'] {
+  @include Tooltip {
+    filter: grayscale(0.9);
+  }
+}
 
 @include Tooltip {
-  color: $color;
-  background-color: $bgcolor;
+  --tooltip-fgcolor: #{$tooltip-fgcolor};
+  color: var(--tooltip-fgcolor);
+  background-color: $tooltip-bgcolor;
+  filter: grayscale(0.85);
 
   &[data-is-markdown] {
     @include EditorInMarkdown {
@@ -77,7 +86,7 @@ $bgcolor: var(--color-base06);
 
     code {
       opacity: 0.9;
-      color: var(--color-base00);
+      color: var(--tooltip-fgcolor);
       font-family: var(--font-sans-serif);
     }
 
@@ -87,16 +96,15 @@ $bgcolor: var(--color-base06);
   }
 
   & > div {
-    color: $color;
-    background-color: $bgcolor;
-    filter: brightness(2);
+    color: var(--tooltip-fgcolor);
+    background-color: $tooltip-bgcolor;
   }
 
   h1,
   h2,
   h3,
   h4 {
-    color: $color;
+    color: var(--tooltip-fgcolor);
     padding-top: 0;
     font-size: inherit;
   }


### PR DESCRIPTION
…gainst surrounding elements

We use a tooltip background color that is the same as that used by other common elements, such as the sidecar background, code block backgrounds.

With this PR:
<img width="217" alt="Screen Shot 2022-02-26 at 9 24 58 PM" src="https://user-images.githubusercontent.com/4741620/155865741-99293ce0-3fea-41fb-a11a-9570ea09ef71.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
