### PR TITLE
fix(plugins/plugin-client-common): remove wizard right-margin

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -30,7 +30,6 @@
 @import 'Keys';
 
 $marginTop: 0.5em;
-$box-shadow-margin: 4px; /* room for box shadow */
 
 @mixin TextContent {
   .pf-c-content {
@@ -400,21 +399,14 @@ body[kui-theme-style='light'] {
 }
 
 @include Commentary {
-  @include WizardHeader {
-    margin-right: $box-shadow-margin; /* room for box shadow */
-  }
   @include Accordion {
     font-size: $terminal-font-size;
   }
   @include ExpandableSection {
     font-size: $terminal-font-size;
-    margin-right: $box-shadow-margin; /* room for box shadow */
     @include ExpandableSectionContentElement {
       @include ParagraphBoundaryMargins;
     }
-  }
-  @include CodeBlock {
-    margin-right: $box-shadow-margin; /* room for box shadow */
   }
 
   @include ExpandableSectionContent {


### PR DESCRIPTION
We put this in place when the wizard header had a box shadow. It no longer does.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
