### PR TITLE
fix(plugins/plugin-client-common): StatusStripe widgets may have extr…

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/TextWithIconWidget.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/TextWithIconWidget.tsx
@@ -56,29 +56,32 @@ export default class TextWithIconWidget extends React.PureComponent<Props> {
       (this.props.iconIsNarrow ? 'tiny-right-pad' : 'small-right-pad') +
       (this.props.iconOnclick ? ' clickable' : '')
 
-    const iconPart = this.props.iconOnclick ? (
-      <a
-        href="#"
-        className={iconClassName}
-        onMouseDown={evt => evt.preventDefault()}
-        onClick={
-          !this.props.iconOnclick
-            ? undefined
-            : (evt: React.MouseEvent) => {
-                evt.stopPropagation()
-                if (typeof this.props.iconOnclick === 'string') {
-                  pexecInCurrentTab(this.props.iconOnclick)
-                } else {
-                  this.props.iconOnclick()
+    const iconPart =
+      !this.props.children || React.Children.count(this.props.children) === 0 ? (
+        <React.Fragment />
+      ) : this.props.iconOnclick ? (
+        <a
+          href="#"
+          className={iconClassName}
+          onMouseDown={evt => evt.preventDefault()}
+          onClick={
+            !this.props.iconOnclick
+              ? undefined
+              : (evt: React.MouseEvent) => {
+                  evt.stopPropagation()
+                  if (typeof this.props.iconOnclick === 'string') {
+                    pexecInCurrentTab(this.props.iconOnclick)
+                  } else {
+                    this.props.iconOnclick()
+                  }
                 }
-              }
-        }
-      >
-        {this.props.children}
-      </a>
-    ) : (
-      <span className={iconClassName}>{this.props.children}</span>
-    )
+          }
+        >
+          {this.props.children}
+        </a>
+      ) : (
+        <span className={iconClassName}>{this.props.children}</span>
+      )
 
     const textPart = <span className="kui--status-stripe-text">{this.props.text}</span>
 


### PR DESCRIPTION
…a left padding

This can affect widgets with no "icon" part.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
