### PR TITLE
fix(plugins/plugin-client-common): Tooltip component can present empt…

### DIFF
--- a/plugins/plugin-client-common/src/components/spi/Tooltip/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Tooltip/impl/PatternFly.tsx
@@ -25,6 +25,12 @@ import '../../../../../web/scss/components/Tooltip/PatternFly.scss'
 
 export default function PatternFlyTooltip(props: Props): React.ReactElement {
   const isMarkdown = isMarkdownProps(props)
+  const isReference = isReferenceProps(props)
+
+  if (!isReference && ((isMarkdown && !props.markdown) || (!isMarkdown && !props.content))) {
+    // no content to display!
+    return <React.Fragment>{props.children}</React.Fragment>
+  }
 
   return (
     <Tooltip
@@ -35,11 +41,11 @@ export default function PatternFlyTooltip(props: Props): React.ReactElement {
       position={props.position || 'auto'}
       entryDelay={props.entryDelay || 200}
       data-is-markdown={isMarkdown || undefined}
-      reference={isReferenceProps(props) && props.reference}
+      reference={isReference && props.reference}
       content={
-        isReferenceProps(props) ? (
+        isReference ? (
           props.children
-        ) : isMarkdownProps(props) ? (
+        ) : isMarkdown ? (
           <React.Suspense fallback={<div />}>
             <Markdown nested executableCodeBlocks={false} source={props.markdown} />
           </React.Suspense>
@@ -48,7 +54,7 @@ export default function PatternFlyTooltip(props: Props): React.ReactElement {
         )
       }
     >
-      {!isReferenceProps(props) && <React.Fragment>{props.children}</React.Fragment>}
+      {!isReference && <React.Fragment>{props.children}</React.Fragment>}
     </Tooltip>
   )
 }


### PR DESCRIPTION
…y tooltip

We should guard against empty content. The MadeWithKui widget is an example.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
