### PR TITLE
fix(plugins/plugin-client-common): snippet inliner does not properly …

### DIFF
--- a/plugins/plugin-client-common/notebook/src/load.ts
+++ b/plugins/plugin-client-common/notebook/src/load.ts
@@ -37,6 +37,7 @@ export async function loadNotebook(
       if (stats.isDirectory) {
         throw new Error('Invalid filepath')
       } else {
+        debug('successfully loaded guidebook data', filepath)
         return stats.data as string
       }
     }

--- a/plugins/plugin-client-common/src/controller/snippets.ts
+++ b/plugins/plugin-client-common/src/controller/snippets.ts
@@ -102,7 +102,7 @@ export default function inlineSnippets(snippetBasePath?: string) {
           // Call ourselves recursively, in case a fetched snippet
           // fetches other files. We also may need to reroute relative
           // <img> and <a> links according to the given `basePath`.
-          const recurse = (basePath: string, data: string) => {
+          const recurse = (basePath: string, snippetFileName: string, data: string) => {
             // Note: intentionally using `snippetBasePath` for the
             // first argument, as this represents the "root" base
             // path, either from the URL of the original filepath (we
@@ -120,7 +120,7 @@ export default function inlineSnippets(snippetBasePath?: string) {
           const snippetDatas = isUrl(snippetFileName)
             ? [
                 await loadNotebook(snippetFileName, args)
-                  .then(data => recurse(snippetBasePath || dirname(snippetFileName), toString(data)))
+                  .then(data => recurse(snippetBasePath || dirname(snippetFileName), snippetFileName, toString(data)))
                   .catch(err => {
                     debug('Warning: could not fetch inlined content 1', snippetBasePath, snippetFileName, err)
                     return err
@@ -137,7 +137,7 @@ export default function inlineSnippets(snippetBasePath?: string) {
                   .filter(_ => _ && _.filepath !== srcFilePath) // avoid cycles
                   .map(({ myBasePath, filepath }) =>
                     loadNotebook(filepath, args)
-                      .then(data => recurse(myBasePath, toString(data)))
+                      .then(data => recurse(myBasePath, filepath, toString(data)))
                       .catch(err => {
                         debug('Warning: could not fetch inlined content 2', myBasePath, snippetFileName, err)
                         return err

--- a/plugins/plugin-client-common/src/test/core/snippets-in-markdown.ts
+++ b/plugins/plugin-client-common/src/test/core/snippets-in-markdown.ts
@@ -63,7 +63,13 @@ ${cContent}
 ccc`,
   tips: [{ title: 'TipTitle', content: 'TipContent' }]
 }
-;[IN1, IN1viaUrl, IN2, IN3].forEach(markdown => {
+
+const IN4: Input = {
+  input: join(ROOT, 'data', 'snippet4.md'),
+  content: IN3.content,
+  tips: IN3.tips
+}
+;[IN1, IN1viaUrl, IN2, IN3, IN4].forEach(markdown => {
   describe(`markdown snippets hash include ${markdown.input} ${process.env.MOCHA_RUN_TARGET ||
     ''}`, function(this: Common.ISuite) {
     before(Common.before(this))

--- a/plugins/plugin-client-common/tests/data/snippet4.md
+++ b/plugins/plugin-client-common/tests/data/snippet4.md
@@ -1,0 +1,3 @@
+<!-- This tests recursive inlining with varying relative paths. 4a includes 4b in a subdirectory, then 4b includes other snippets in ../ -->
+
+--8<-- "snippet4a.md"

--- a/plugins/plugin-client-common/tests/data/snippet4a.md
+++ b/plugins/plugin-client-common/tests/data/snippet4a.md
@@ -1,0 +1,3 @@
+aaa
+
+--8<-- "snippet4b.md"

--- a/plugins/plugin-client-common/tests/data/snippetc.md
+++ b/plugins/plugin-client-common/tests/data/snippetc.md
@@ -1,2 +1,2 @@
 ???+ tip "TipTitle"
-   TipContent
+    TipContent

--- a/plugins/plugin-client-common/tests/data/snippets/snippet4b.md
+++ b/plugins/plugin-client-common/tests/data/snippets/snippet4b.md
@@ -1,0 +1,7 @@
+--8<-- "../snippeta.md"
+
+bbb
+
+--8<-- "../snippetc.md"
+
+ccc


### PR DESCRIPTION
…handle certain recursion

If file1 references file2 via relative path, and file2 references file3 via relative path... This is just a bug in one path that calls `recurse()`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
