### PR TITLE
fix(packages/core): strip off chrome args for second electron instance

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -506,7 +506,15 @@ export const getCommand = (argv: string[], screen: () => Promise<{ screen: Scree
   argv = dashDash === -1 ? argv.slice(1) : argv.slice(dashDash + 1)
 
   // re: the -psn bit, opening Kui from macOS Finder adds additional argv -psn; see: https://github.com/IBM/kui/issues/382
-  argv = argv.filter(_ => _ !== '--ui' && _ !== '--no-color' && !_.match(/^-psn/))
+  // re: the --allow-file... and --enable-av...; see https://github.com/kubernetes-sigs/kui/issues/8746
+  argv = argv.filter(
+    _ =>
+      _ !== '--ui' &&
+      _ !== '--no-color' &&
+      !_.match(/^-psn/) &&
+      _ !== '--allow-file-access-from-files' &&
+      _ !== '--enable-avfoundation'
+  )
 
   // re: argv.length === 0, this should happen for double-click launches
   const isShell =


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
