### PR TITLE
11.4.3

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -506,7 +506,15 @@ export const getCommand = (argv: string[], screen: () => Promise<{ screen: Scree
   argv = dashDash === -1 ? argv.slice(1) : argv.slice(dashDash + 1)
 
   // re: the -psn bit, opening Kui from macOS Finder adds additional argv -psn; see: https://github.com/IBM/kui/issues/382
-  argv = argv.filter(_ => _ !== '--ui' && _ !== '--no-color' && !_.match(/^-psn/))
+  // re: the --allow-file... and --enable-av...; see https://github.com/kubernetes-sigs/kui/issues/8746
+  argv = argv.filter(
+    _ =>
+      _ !== '--ui' &&
+      _ !== '--no-color' &&
+      !_.match(/^-psn/) &&
+      _ !== '--allow-file-access-from-files' &&
+      _ !== '--enable-avfoundation'
+  )
 
   // re: argv.length === 0, this should happen for double-click launches
   const isShell =


### PR DESCRIPTION
[11.4.3 a020d7522] fix(packages/core): strip off chrome args for second electron instance
 Date: Fri Mar 11 15:31:15 2022 -0500
 1 file changed, 9 insertions(+), 1 deletion(-)