### PR TITLE
fix(packages/core): strip off chrome args for second electron instance (v2)

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -513,7 +513,8 @@ export const getCommand = (argv: string[], screen: () => Promise<{ screen: Scree
       _ !== '--no-color' &&
       !_.match(/^-psn/) &&
       _ !== '--allow-file-access-from-files' &&
-      _ !== '--enable-avfoundation'
+      _ !== '--enable-avfoundation' &&
+      _ !== '--enable-crashpad' // this one seems to be linux-specific?
   )
 
   // re: argv.length === 0, this should happen for double-click launches


### PR DESCRIPTION
Fixes #8746

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
