### PR TITLE
11.4.4

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -513,7 +513,8 @@ export const getCommand = (argv: string[], screen: () => Promise<{ screen: Scree
       _ !== '--no-color' &&
       !_.match(/^-psn/) &&
       _ !== '--allow-file-access-from-files' &&
-      _ !== '--enable-avfoundation'
+      _ !== '--enable-avfoundation' &&
+      _ !== '--enable-crashpad' // this one seems to be linux-specific?
   )
 
   // re: argv.length === 0, this should happen for double-click launches


### PR DESCRIPTION
[11.4.4 b15c75a48] fix(packages/core): strip off chrome args for second electron instance (v2)
 Date: Fri Mar 11 17:04:47 2022 -0500
 1 file changed, 2 insertions(+), 1 deletion(-)