### PR TITLE
fix: wide content in left or right strip does not horizontally overflow

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/LeftStrip.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/LeftStrip.scss
@@ -18,6 +18,18 @@
 @import '../../Page/mixins';
 @import '../../TopLevelTab/mixins';
 
+@include Scrollback {
+  @include LeftStrip {
+    /**
+         * Normally, this will have a min-width: 0, which allows the
+         * flex box to adjust to reduced width. However, the
+         * RightStrip is narrow, and so we probably would rather have
+         * horizontal overflow than wrapping.
+         */
+    @include WrapNormally;
+  }
+}
+
 @include KuiTabContainer {
   @include SidebarOpen {
     @include TopLevelTab {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/RightStrip.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/RightStrip.scss
@@ -22,6 +22,18 @@
 /** Special background color for RightStrip splits */
 $bgcolor: var(--color-base00);
 
+@include Scrollback {
+  @include RightStrip {
+    /**
+         * Normally, this will have a min-width: 0, which allows the
+         * flex box to adjust to reduced width. However, the
+         * RightStrip is narrow, and so we probably would rather have
+         * horizontal overflow than wrapping.
+         */
+    @include WrapNormally;
+  }
+}
+
 @include KuiTabContainer {
   @include SidebarOpen {
     @include TopLevelTab {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -678,3 +678,18 @@ $sepia-filter: sepia(0.5) opacity(0.9) contrast(0.95) blur(0.25px);
     }
   }
 }
+
+/**
+ * Normally, certain elements will have a min-width: 0, which allows
+ * the flex box to adjust to reduced width. In some cases, e.g. areas
+ * we know will be particularly narrow, we probably would rather have
+ * horizontal overflow than wrapping.
+ *
+ * Future Devs: update the rules here as we define other regions (in
+ * addition to Commentary) that have this property.
+ */
+@mixin WrapNormally {
+  @include Commentary {
+    min-width: unset;
+  }
+}


### PR DESCRIPTION
This is due to a `min-width: 0` rule on Commentary. We put this rule in place to allow the flex box to respond to narrower windows, and re-wrap appropritately.

However, for regions that we know will be relatively narrow, we should use the define scroll overflow behavior. Text wrapping in a narrow region does not seem to be very readable.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
