### PR TITLE
fix(plugins/plugin-client-common): guidebooks cannot have wizards in second+ splits

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
@@ -46,18 +46,23 @@ export default function div(mdprops: MarkdownProps, uuid: string) {
     const hasActiveInput = position === 'terminal' || undefined
     const inverseColors = props['data-kui-inverse-colors'] === 'true' || undefined
 
-    if (isWizard(props)) {
-      return <Wizard uuid={uuid} {...props} />
-    } else if (isTabs(props)) {
+    if (isTabs(props)) {
       return tabbed(props)
     } else if (isImports(props)) {
       // Don't render the content of imported documents. We will process these separately.
       return <React.Fragment />
-    } else if (!position || (isNormalSplit(position) && count === 0 && !maximized && !placeholder)) {
+    } else if (
+      !position ||
+      ((isNormalSplit(position) || position === 'wizard') && count === 0 && !maximized && !placeholder)
+    ) {
       // don't create a split if a position wasn't indicated, or if
       // this is the first default-positioned section; if it is
       // maximized, we'll have to go through the injector path
-      const node = <div data-is-maximized={maximized || undefined}>{props.children}</div>
+      const node = isWizard(props) ? (
+        <Wizard uuid={uuid} {...props} />
+      ) : (
+        <div data-is-maximized={maximized || undefined}>{props.children}</div>
+      )
       if (!mdprops.tab || (hasActiveInput !== true && hasActiveInput !== false)) {
         return node
       } else {
@@ -77,13 +82,17 @@ export default function div(mdprops: MarkdownProps, uuid: string) {
               <ReactCommentary>
                 <TextContent>
                   <div className="padding-content marked-content page-content" data-is-nested>
-                    {props.children || (placeholder ? <span className="italic sub-text">{placeholder}</span> : '')}
+                    {isWizard(props) ? (
+                      <Wizard uuid={uuid} {...props} />
+                    ) : (
+                      props.children || (placeholder ? <span className="italic sub-text">{placeholder}</span> : '')
+                    )}
                   </div>
                 </TextContent>
               </ReactCommentary>
             )
 
-            const positionForView = position === 'terminal' ? 'default' : position
+            const positionForView = position === 'terminal' || position === 'wizard' ? 'default' : position
 
             setTimeout(() =>
               injector.inject(

--- a/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
@@ -163,7 +163,7 @@ function extractSplitsAndSections(tree /*: Root */, frontmatter: KuiFrontmatter)
     const maximized = isValidPositionObj(positionAsGiven) && positionAsGiven.maximized === true
     const inverseColors = isValidPositionObj(positionAsGiven) && positionAsGiven.inverseColors === true
 
-    const positionForCount = isNormalSplit(position) ? 'default' : position
+    const positionForCount = isNormalSplit(position) || position === 'wizard' ? 'default' : position
     const count = frontmatter.layoutCount[positionForCount] || 0
     frontmatter.layoutCount[positionForCount] = count + 1
 


### PR DESCRIPTION


This PR fixes a few issues in the guidebook layout logic that were limiting wizards to appearing in the first de
fault split.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
