### PR TITLE
fix(plugins/plugin-client-common): improved display of subtree status in guidebook tree view

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/ImportsTree.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/ImportsTree.tsx
@@ -27,6 +27,7 @@ export default abstract class Tree {
    * child, and no other children, then we can fold the Imports and
    * treat them as prefix steps in the Wizard
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private static xformFoldImportsIntoWizards(children: TreeViewProps['data'], depth = 0): TreeViewProps['data'] {
     const { subtasks, titledSteps, rest } = children.reduce(
       (P, child) => {
@@ -49,14 +50,15 @@ export default abstract class Tree {
 
     if (subtasks.length > 0 && titledSteps.length === 1 && rest.length === 0) {
       const wizard = titledSteps[0]
-      const prereqs = {
+      /* const prereqs = {
         name: 'Prerequisites',
         hasBadge: true,
         children: subtasks,
         defaultExpanded: depth < 2
       }
       wizard.children.splice(0, 0, prereqs)
-      return [wizard]
+      return [wizard] */
+      return [...subtasks, wizard]
     } else {
       return children
     }

--- a/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
@@ -27,6 +27,7 @@ import {
   ChartBarIcon as ChartBar,
   CopyIcon as Copy,
   PlusIcon as Add,
+  BookIcon as Guidebook,
   TerminalIcon as Terminal,
   OutlinedWindowMaximizeIcon /* TerminalIcon */ as TerminalOnly,
   ColumnsIcon as TerminalPlusSidecar,
@@ -123,6 +124,8 @@ export default function PatternFly4Icons(props: Props) {
       return <Grid {...props} />
     case 'Github':
       return <Github {...props} />
+    case 'Guidebook':
+      return <Guidebook {...props} />
     case 'Hamburger':
       return <Hamburger {...props} />
     case 'Help':

--- a/plugins/plugin-client-common/src/components/spi/Icons/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/index.tsx
@@ -36,6 +36,7 @@ export type SupportedIcon =
   | 'Forward'
   | 'Grid'
   | 'Github'
+  | 'Guidebook'
   | 'Hamburger'
   | 'Help'
   | 'Info'

--- a/plugins/plugin-client-common/web/scss/components/Wizard/Imports.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Imports.scss
@@ -65,6 +65,20 @@
     }
   }
 
+  svg {
+    @include Success {
+      color: $complete-color;
+    }
+  }
+
+  /** We hijack "isRead" badges to mean that the subtree is complete. And for these, we use a badge, so we can "mute" these badges. */
+  .pf-c-badge.pf-m-unread {
+    padding: 0;
+    min-width: unset;
+    font-size: 1rem;
+    background-color: transparent;
+  }
+
   strong {
     font-weight: 500;
     color: var(--color-text-02);


### PR DESCRIPTION

<img width="1473" alt="Screen Shot 2022-03-17 at 1 17 05 PM" src="https://user-images.githubusercontent.com/4741620/158858033-5699f1d6-96aa-476a-a76e-d18f63f57ae3.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
