### PR TITLE
feat(plugins/plugin-client-common): add two tree reductions to guideb…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
@@ -221,7 +221,7 @@ class ImportsImpl extends React.PureComponent<Props, State> {
       hasBadge
     )
 
-    return { data: [data] }
+    return { data: [Tree.xformFoldNestedSubTask(data)] }
   }
 
   private treeModelForTitledStep(
@@ -278,24 +278,20 @@ class ImportsImpl extends React.PureComponent<Props, State> {
     // only show the "n of m" text for the root
     const hasBadge = isDone(rollupStatus) || depth === 0
 
-    const data =
-      // eslint-disable-next-line no-constant-condition
-      false && children.length === 1 && children[0].name === 'Choice'
-        ? children[0].children
-        : // : [Object.assign(children[0], { name: name || children[0].name })]
-          [
-            this.withIcons(
-              rollupStatus,
-              graph,
-              {
-                name: name || 'Sequence',
-                defaultExpanded: depth < 1,
-                children: children.length === 0 ? undefined : children
-              },
-              hasBadge
-            )
-          ]
-    return { data }
+    const data = [
+      this.withIcons(
+        rollupStatus,
+        graph,
+        {
+          name: name || 'Sequence',
+          defaultExpanded: depth < 1,
+          children: children.length === 0 ? undefined : children
+        },
+        hasBadge
+      )
+    ]
+
+    return { data: Tree.xformFoldSingletonSubTask(data) }
   }
 
   private treeModelForParallel(

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts
@@ -48,6 +48,10 @@ export type ChoicesMap = Record<CodeBlockChoice['group'], CodeBlockChoice['membe
 export interface Ordered {
   order: number
   postorder: number
+  controlDependenceRegion?: {
+    depth: number
+    group: CodeBlockChoice['group']
+  }
 }
 
 export type Unordered = Partial<Ordered>
@@ -431,9 +435,11 @@ export function compile(blocks: CodeBlockProps[], ordering: 'sequence' | 'parall
           } else if (isCodeBlockWizardStep(parent)) {
             // new graph node for wizard
             set(idx, { parent, graph: newWizard(block, parent, isDeepest) })
-          } else {
+          } else if (isCodeBlockImport(parent)) {
             // new graph node for import
             set(idx, { parent, graph: newSubTask(block, parent, isDeepest) })
+          } else {
+            console.error('Missing handler in graph compilation', parent)
           }
         }
       })


### PR DESCRIPTION
…ook dependence tree

```typescript
  /**
   * Transform A -> SubTask -> 1,2,3,4
   *      ===> A -> 1,2,3,4
   *
   * This logic currently assumes that A has a good name.
   */
  public static xformFoldSingletonSubTask(data: TreeViewProps['data'])
```

```typescript
  /**
   * Transform A -> SubTask1 -> SubTask2 -> 1,2,3,4
   *      ===> A -> SubTask1|SubTask2 -> 1,2,3,4
   *
   * where we choose whichever of SubTask1 or SubTask2 has a title,
   * giving preference to SubTask1.
   */
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
