### PR TITLE
fix(plugins/plugin-client-common): increase default expansion depth for Imports component

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
@@ -203,7 +203,7 @@ class ImportsImpl extends React.PureComponent<Props, State> {
       {
         id: key,
         name: title || basename(filepath),
-        defaultExpanded: depth < 1,
+        defaultExpanded: depth < 3 && !isDone(rollupStatus),
         children: children.length === 0 ? undefined : children,
         icon: <Icons icon="Guidebook" />,
         action: hasAction && (


### PR DESCRIPTION

For SubTask subtrees, we should expand a bit further, unless that SubTask is already complete.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
