### PR TITLE
fix(plugins/plugin-kubectl): Fixing guidebook layouts and validation code

### DIFF
--- a/plugins/plugin-kubectl/notebooks/install-knative-quickstart.md
+++ b/plugins/plugin-kubectl/notebooks/install-knative-quickstart.md
@@ -2,6 +2,7 @@
 title: Install Knative - Quickstart
 layout:
     1: left
+    2: right
     default: wizard
 wizard:
     steps:
@@ -9,9 +10,9 @@ wizard:
         - name: Install the Knative quickstart plugin
           description: The plugin sets up Knative against kind by creating a kind cluster populated with Knative
         - Run the Knative quickstart plugin
-        - Clean Up
+        # - Clean Up
 codeblocks:
-    # validation for step 2: install the knative quickstart plugin
+    # Validation for step 2: install the knative quickstart plugin
     - match: ^brew install knative-sandbox/kn-plugins/quickstart$
       validate: kn quickstart --help
     - match: ^brew upgrade knative-sandbox/kn-plugins/quickstart$
@@ -19,25 +20,25 @@ codeblocks:
     - match: ^kn quickstart --help$
       validate: $body
     - match: ^git clone https://github.com/knative-sandbox/kn-plugin-quickstart.git
-      validate: $? -e 0 && exit 0 || exit 1
+      validate: $? -e 0 && exit 0 \|\| exit 1
     - match: ^hack/build.sh$
-      validate: $? -e 0 && exit 0 || exit 1
+      validate: $? -e 0 && exit 0 \|\| exit 1
     - match: ^mv kn-quickstart /usr/local/bin$
       validate: kn quickstart --help
-    # validation for step 3: Run the knative quickstart plugin
+    # Validation for step 3: Run the knative quickstart plugin
     - match: ^kn quickstart kind$
-      validate: (kubectl cluster-info --context kind-knative) && exit 0 || exit 1
+      validate: \(kubectl cluster-info --context kind-knative\) && exit 0 \|\| exit 1
     - match: ^kn quickstart minikube$
       validate: minikube profile list
     - match: ^minikube tunnel --profile knative$
-      validate: $? -e 0 && exit 0 || exit 1
+      validate: $? -e 0 && exit 0 \|\| exit 1
     # Validation for Step 4: Clean Up
-    - match: ^kubectl delete --filename service.yaml$
-    - match : ^kn service delete helloworld-go$
-    - match: ^kind delete clusters knative$
-      validate: (kubectl cluster-info --context kind-knative) && exit 1 \|\| exit 0
-    - match: ^minikube delete -p knative$
-      validate: (kubectl cluster-info --context kind-knative) && exit 1 \|\| exit 0
+    # - match: ^kubectl delete --filename service.yaml$
+    # - match : ^kn service delete helloworld-go$
+    # - match: ^kind delete clusters knative$
+    #   validate: \(kubectl cluster-info --context kind-knative\) && exit 1 \|\| exit 0
+    # - match: ^minikube delete -p knative$
+    #   validate: \(kubectl cluster-info --context kind-knative\) && exit 1 \|\| exit 0
 ---
 
 --8<-- "https://raw.githubusercontent.com/mra-ruiz/docs/guidebooks/docs/guidebooks/install-knative-quickstart.md"

--- a/plugins/plugin-kubectl/notebooks/knative-serving-hello-world.md
+++ b/plugins/plugin-kubectl/notebooks/knative-serving-hello-world.md
@@ -2,12 +2,13 @@
 title: Knative Serving - Hello World
 layout:
     1: left
+    2: right
     default: wizard
 wizard:
     steps:
         - name: Install Required Tools
           description: Install Knative Serving and the kn CLI
-        - match: Hello World - Go
+        - match: Building
           name: Building your application
           description: In this example, you will build a "Hello world" application
         - name: Deploying
@@ -19,20 +20,20 @@ wizard:
 codeblocks:
     # Validation for Step 2: Building your application
     - match: ^git clone https://github.com/knative/docs.git knative-docs
-      validation: $? -e 0 && exit 0 \|\| exit 1
+      validate: $? -e 0 && exit 0 \|\| exit 1
     - match: ^go mod init github.com/knative/docs/code-samples/
-      validation: ls go.mod
+      validate: ls go.mod
     # Validation for Step 3: Deploying your service
     - match: ^# Build the container on your local machine
-      validation: $? -e 0 && exit 0 \|\| exit 1
+      validate: $? -e 0 && exit 0 \|\| exit 1
     - match: ^kubectl apply --filename service.yaml$
-      validation: kn service describe service
+      validate: kn service describe service
     - match: ^kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,URL:.status.url$
-      validation: $body
+      validate: $body
     - match: ^ NAME
       optional: true
     - match: ^kn service create helloworld-go --image=docker.io/{username}/helloworld-go --env TARGET="Go Sample v1"$
-      validation: kn service describe helloworld-go
+      validate: kn service describe helloworld-go
     - match: ^Creating service 'helloworld-go' in namespace 'default'
       optional: true
     # Validation for Step 4: Pinging your Knative Service
@@ -42,9 +43,9 @@ codeblocks:
     - match: ^kubectl delete --filename service.yaml$
     - match : ^kn service delete helloworld-go$
     - match: ^kind delete clusters knative$
-      validate: (kubectl cluster-info --context kind-knative) && exit 1 \|\| exit 0
+      validate: \(kubectl cluster-info --context kind-knative\) && exit 1 \|\| exit 0
     - match: ^minikube delete -p knative$
-      validate: (kubectl cluster-info --context kind-knative) && exit 1 \|\| exit 0
+      validate: \(kubectl cluster-info --context kind-knative\) && exit 1 \|\| exit 0
 ---
 
 --8<-- "https://raw.githubusercontent.com/mra-ruiz/docs/guidebooks/docs/guidebooks/knative-serving-hello-world.md"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
With the introduction of `:imports`, install-knative-quickstart.md needed an updated layout. The Clean Up section has been commented out for now because this guidebook is being used as an import in other files and the Clean Up content is not necessary when file is imported. Also, some validation scripts were not running due to a typo in the validation flag. This has also been fixed.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
