### PR TITLE
fix(plugins/plugin-client-common): dependence tree can place nodes in prior sibling

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/ImportsTree.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/ImportsTree.tsx
@@ -153,6 +153,7 @@ export default abstract class Tree {
 
       const childOrigin = child['data-origin']
       if (childOrigin && isSubTask(childOrigin)) {
+        // then we have a potentially shared node
         const { key } = childOrigin
         const already = subTaskMemo[key]
         if (already) {
@@ -169,9 +170,13 @@ export default abstract class Tree {
   }
 
   private static toGraph(data: TreeViewProps['data']) {
-    const graph: number[][] = []
-    const backmap: TreeViewProps['data'][0][] = []
-    const blank: boolean[] = []
+    const maxPostorder = data
+      .map(_ => _['data-origin'].postorder)
+      .reduce((max, postorder) => Math.max(max, postorder), 0)
+
+    const graph: number[][] = Array(maxPostorder)
+    const backmap: TreeViewProps['data'][0][] = Array(maxPostorder)
+    const blank: boolean[] = Array(maxPostorder)
     const subTaskMemo: Record<SubTask['key'], number> = {}
 
     data.forEach(_ => Tree.toGraphForNode(_, graph, backmap, subTaskMemo))
@@ -211,6 +216,12 @@ export default abstract class Tree {
             parent.children.push(child)
           }
         }
+      }
+    })
+
+    backmap.forEach(_ => {
+      if (_.children.length === 0) {
+        delete _.children
       }
     })
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts
@@ -383,7 +383,7 @@ export function compile(blocks: CodeBlockProps[], ordering: 'sequence' | 'parall
                   }
                 } else {
                   // here we are at [1b]
-                  curNesting.parent = parent
+                  currentNesting = [...currentNesting.slice(0, idx), { parent, graph: curNesting.graph }]
                   curNesting.graph.choices.push(newChoice(block, parent, isDeepest))
                 }
               } else {
@@ -403,7 +403,7 @@ export function compile(blocks: CodeBlockProps[], ordering: 'sequence' | 'parall
                   addToCurrentWizardStep(curNesting.graph, block, parent, isDeepest)
                 } else {
                   // here we are at [4b]
-                  curNesting.parent = parent
+                  currentNesting = [...currentNesting.slice(0, idx), { parent, graph: curNesting.graph }]
                   addWizardStep(curNesting.graph, block, parent, isDeepest)
                 }
               } else {

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/2.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/2.ts
@@ -19,7 +19,10 @@ import { importa, importe, importd } from './1'
 
 const thisContent: Tree = {
   name: 'AAA',
-  children: [{ name: 'Option 1: Tab1', children: [importd] }]
+  children: [
+    { name: 'Option 1: Tab1', children: [importd] },
+    { name: 'Option 2: Tab2', children: [{ name: 'echo XXX' }] }
+  ]
 }
 
 const IN2: Input = {

--- a/plugins/plugin-client-common/tests/data/guidebook-tree-model3.md
+++ b/plugins/plugin-client-common/tests/data/guidebook-tree-model3.md
@@ -1,0 +1,8 @@
+---
+imports:
+    - snippets-in-tab5.md
+---
+
+<!-- You should see a tree view. This is the Imports.tsx component -->
+
+::imports

--- a/plugins/plugin-client-common/tests/data/snippets-in-tab4b.md
+++ b/plugins/plugin-client-common/tests/data/snippets-in-tab4b.md
@@ -1,1 +1,5 @@
 BBBoo
+
+```bash
+echo XXX
+```

--- a/plugins/plugin-client-common/tests/data/snippets-in-tab5.md
+++ b/plugins/plugin-client-common/tests/data/snippets-in-tab5.md
@@ -1,0 +1,24 @@
+---
+layout:
+    1: right
+imports:
+    - importa.md
+    - importe.md
+---
+
+::imports
+
+---
+
+# AAA
+
+=== "Tab1"
+    --8<-- "snippets-in-tab3a.md"
+
+=== "Tab2"
+    --8<-- "snippets-in-tab4b.md"
+
+=== "Tab3"
+    --8<-- "snippets-in-tab5c.md"
+
+DDD

--- a/plugins/plugin-client-common/tests/data/snippets-in-tab5c.md
+++ b/plugins/plugin-client-common/tests/data/snippets-in-tab5c.md
@@ -1,0 +1,6 @@
+---
+imports:
+    - importd.md
+---
+
+CCCoo


### PR DESCRIPTION

We aren't clearing out prior subtrees on two paths in compile()

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
