### PR TITLE
fix(plugins/plugin-client-common): improved hoisting of subtasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5330,14 +5330,6 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
-    "node_modules/dominators": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/dominators/-/dominators-1.1.2.tgz",
-      "integrity": "sha512-WC0Sv+xQYMp18SRlpSd7VJ5kTXM6CdXe2LGTW0uI+1eTVpTqtImLEleQy/CpZ8Yf52Ft3hYwu2ErNfZxHJJ27Q==",
-      "dependencies": {
-        "traversals": "^1.0.15"
-      }
-    },
     "node_modules/domino": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
@@ -15546,11 +15538,6 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
     },
-    "node_modules/traversals": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/traversals/-/traversals-1.0.15.tgz",
-      "integrity": "sha512-bYKOp6AEc8uaYJnYuHm2sYh7g9v3Mv2UyP7tXNSIJPJGtH1M4gjNl6FBqLV+UOl2MrZaGK42sdTcL9fG+0E0YQ=="
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -17838,7 +17825,6 @@
         "@patternfly/react-styles": "4.48.5",
         "@patternfly/react-table": "4.67.5",
         "anser": "2.1.1",
-        "dominators": "^1.1.2",
         "html-entities": "2.3.2",
         "monaco-editor": "0.32.1",
         "monaco-editor-webpack-plugin": "7.0.1",
@@ -18567,7 +18553,6 @@
         "@patternfly/react-styles": "4.48.5",
         "@patternfly/react-table": "4.67.5",
         "anser": "2.1.1",
-        "dominators": "^1.1.2",
         "html-entities": "2.3.2",
         "monaco-editor": "0.32.1",
         "monaco-editor-webpack-plugin": "7.0.1",
@@ -22371,14 +22356,6 @@
       "dev": true,
       "requires": {
         "domelementtype": "^2.2.0"
-      }
-    },
-    "dominators": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/dominators/-/dominators-1.1.2.tgz",
-      "integrity": "sha512-WC0Sv+xQYMp18SRlpSd7VJ5kTXM6CdXe2LGTW0uI+1eTVpTqtImLEleQy/CpZ8Yf52Ft3hYwu2ErNfZxHJJ27Q==",
-      "requires": {
-        "traversals": "^1.0.15"
       }
     },
     "domino": {
@@ -29934,11 +29911,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
-    },
-    "traversals": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/traversals/-/traversals-1.0.15.tgz",
-      "integrity": "sha512-bYKOp6AEc8uaYJnYuHm2sYh7g9v3Mv2UyP7tXNSIJPJGtH1M4gjNl6FBqLV+UOl2MrZaGK42sdTcL9fG+0E0YQ=="
     },
     "tree-kill": {
       "version": "1.2.2",

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -28,7 +28,6 @@
     "@patternfly/react-styles": "4.48.5",
     "@patternfly/react-table": "4.67.5",
     "anser": "2.1.1",
-    "dominators": "^1.1.2",
     "html-entities": "2.3.2",
     "monaco-editor": "0.32.1",
     "monaco-editor-webpack-plugin": "7.0.1",

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
@@ -124,9 +124,7 @@ class ImportsImpl extends React.PureComponent<Props, State> {
     status = this.state.codeBlockStatus,
     doValidate = true
   ): Pick<State, 'data'> {
-    return {
-      data: Tree.domTree(this.treeModelForLeaf(imports, status, doValidate, undefined, undefined, 'Tasks').data)
-    }
+    return this.treeModelForLeaf(imports, status, doValidate, undefined, undefined, 'Tasks')
   }
 
   private withIcons(
@@ -198,7 +196,7 @@ class ImportsImpl extends React.PureComponent<Props, State> {
     )
 
     const hasAction = !!filepath
-    const hasBadge = hasAction
+    const hasBadge = hasAction && rollupStatus.nDone > 0
 
     const data = this.withIcons(
       rollupStatus,

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph.ts
@@ -37,6 +37,8 @@ import CodeBlockProps, {
 } from '../Wizard/CodeBlockProps'
 import { ProgressStepState } from '../../../ProgressStepper'
 
+import hoistSubTasks from './graph/hoistSubTasks'
+
 type Status = ProgressStepState['status']
 
 export { CodeBlockProps }
@@ -89,7 +91,7 @@ type ChoicePart<T extends Unordered | Ordered = Unordered> = {
   graph: Sequence<T>
 }
 
-type Choice<T extends Unordered | Ordered = Unordered> = T &
+export type Choice<T extends Unordered | Ordered = Unordered> = T &
   Title & {
     group: ChoiceGroup
     choices: ChoicePart<T>[]
@@ -146,6 +148,15 @@ export type SubTask<T extends Unordered | Ordered = Unordered> = T & {
 }
 
 export type OrderedSubTask = SubTask<Ordered>
+
+export function subtask(key: string, title: string, filepath: string, graph: Sequence<Unordered>): SubTask<Unordered> {
+  return {
+    key,
+    title,
+    filepath,
+    graph
+  }
+}
 
 function sameSubTask(A: SubTask, B: SubTask) {
   return (
@@ -226,7 +237,7 @@ export function parallel(parallel: Graph[]): Parallel {
   }
 }
 
-function emptySequence(): Sequence {
+export function emptySequence(): Sequence {
   return sequence([])
 }
 
@@ -256,9 +267,11 @@ function isWizardStepNesting(nesting: Nesting): nesting is WizardStepNesting {
 }
 
 function optimize(graph: Graph) {
-  return graph
+  return hoistSubTasks(graph)
+  // return graph
 }
 
+/** Take a list of code blocks and arrange them into a control flow dag */
 export function compile(blocks: CodeBlockProps[], ordering: 'sequence' | 'parallel' = 'parallel'): Graph {
   if (!blocks) {
     return undefined

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/hoistSubTasks.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/hoistSubTasks.ts
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Choice,
+  Graph,
+  SubTask,
+  emptySequence,
+  isSubTask,
+  isChoice,
+  isSequence,
+  isParallel,
+  isTitledSteps,
+  parallel,
+  sequence,
+  subtask
+} from '../graph'
+
+type LookupTable = Record<SubTask['key'], SubTask>
+
+function toLookupTable(list: SubTask[]): LookupTable {
+  return list.reduce((M, subtask) => {
+    M[subtask.key] = subtask
+    return M
+  }, {})
+}
+
+function removeDuplicates(list: SubTask[]): SubTask[] {
+  const uniqueKeys = Array.from(new Set(list.map(_ => _.key)))
+  const lookupTable = toLookupTable(list)
+  return uniqueKeys.map(key => lookupTable[key])
+}
+
+function extractDominatedSubTasksUpToChoice(graph: Graph): SubTask[] {
+  if (isSubTask(graph)) {
+    return [graph, ...extractDominatedSubTasksUpToChoice(graph.graph)]
+  } else if (isChoice(graph)) {
+    return []
+  } else if (isSequence(graph)) {
+    return removeDuplicates(graph.sequence.flatMap(extractDominatedSubTasksUpToChoice))
+  } else if (isParallel(graph)) {
+    return removeDuplicates(graph.parallel.flatMap(extractDominatedSubTasksUpToChoice))
+  } else if (isTitledSteps(graph)) {
+    return removeDuplicates(graph.steps.flatMap(_ => extractDominatedSubTasksUpToChoice(_.graph)))
+  } else {
+    return []
+  }
+}
+
+function extractSubTasksCommonToAllChoices(choice: Choice): SubTask[] {
+  const subTasksPerChoice = choice.choices.map(_ => extractDominatedSubTasksUpToChoice(_.graph))
+
+  if (subTasksPerChoice.find(_ => _.length === 0)) {
+    // there exists at least one empty set, across choices
+    return []
+  } else if (subTasksPerChoice.length === 1) {
+    return subTasksPerChoice[0]
+  } else {
+    // otherwise, every choice has at least one SubTask
+    return subTasksPerChoice
+      .slice(1)
+      .reduce(
+        (sofar, subtasks) => sofar.filter(subtask => subtasks.find(_ => _.key === subtask.key)),
+        subTasksPerChoice[0]
+      )
+  }
+}
+
+function pruneSubTasks(
+  graph: SubTask,
+  inheritedSubTasks: SubTask[],
+  includingMe = true
+): { changed: boolean; graph: SubTask } {
+  if (includingMe && inheritedSubTasks.find(_ => _.key === graph.key)) {
+    // then we can zero out this particular instance of the subtask,
+    // since it is inherited from above
+    return { changed: true, graph: undefined }
+  } else if (!graph.graph) {
+    return { changed: false, graph }
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    const { changed, graph: subgraph } = pruneShadowedSubTasks(graph.graph, inheritedSubTasks)
+    if (!subgraph) {
+      return { changed: !!graph, graph: undefined }
+    } else {
+      return { changed, graph: Object.assign({}, graph, { graph: subgraph }) }
+    }
+  }
+}
+
+function pruneShadowedSubTasks(graph: Graph, inheritedSubTasks: SubTask[]): { changed: boolean; graph: Graph | void } {
+  if (isSubTask(graph)) {
+    return pruneSubTasks(graph, inheritedSubTasks)
+  } else if (isSequence(graph)) {
+    const elements = graph.sequence.map(_ => pruneShadowedSubTasks(_, inheritedSubTasks))
+    const changed = !!elements.find(_ => _.changed)
+    const residual = elements.map(_ => _.graph).filter(Boolean)
+
+    return {
+      changed,
+      graph: !changed
+        ? graph
+        : residual.length === 0
+        ? undefined
+        : Object.assign({}, graph, {
+            sequence: residual
+          })
+    }
+  } else if (isParallel(graph)) {
+    const elements = graph.parallel.map(_ => pruneShadowedSubTasks(_, inheritedSubTasks))
+    const changed = !!elements.find(_ => _.changed)
+    const residual = elements.map(_ => _.graph).filter(Boolean)
+
+    return {
+      changed,
+      graph: !changed
+        ? graph
+        : residual.length === 0
+        ? undefined
+        : Object.assign({}, graph, {
+            parallel: residual
+          })
+    }
+  } else if (isChoice(graph)) {
+    const prunedSubGraphs = graph.choices.map(_ => pruneShadowedSubTasks(_.graph, inheritedSubTasks))
+    const changed = !!prunedSubGraphs.find(_ => _.changed)
+    const prunedGraph = !changed
+      ? graph
+      : Object.assign({}, graph, {
+          choices: graph.choices
+            .map((_, idx) => {
+              const prunedSubGraph = prunedSubGraphs[idx].graph
+              if (prunedSubGraph) {
+                return Object.assign({}, _, {
+                  graph: prunedSubGraph
+                })
+              }
+            })
+            .filter(Boolean)
+        })
+
+    return {
+      changed,
+      graph: prunedGraph.choices.length === 0 ? undefined : prunedGraph
+    }
+  } else if (isTitledSteps(graph)) {
+    const prunedSubGraphs = graph.steps.map(_ => pruneShadowedSubTasks(_.graph, inheritedSubTasks))
+    const changed = !!prunedSubGraphs.find(_ => _.changed)
+    return {
+      changed,
+      graph: !changed
+        ? graph
+        : Object.assign({}, graph, {
+            steps: graph.steps
+              .map((_, idx) => {
+                const prunedSubGraph = prunedSubGraphs[idx].graph
+                if (prunedSubGraph) {
+                  return Object.assign({}, _, {
+                    graph: prunedSubGraph
+                  })
+                }
+              })
+              .filter(Boolean)
+          })
+    }
+  } else {
+    return { changed: false, graph }
+  }
+}
+
+function findChoiceFrontier(graph: Graph): Choice[] {
+  if (isChoice(graph)) {
+    return [graph]
+  } else if (isSubTask(graph)) {
+    return findChoiceFrontier(graph.graph)
+  } else if (isSequence(graph)) {
+    return graph.sequence.flatMap(findChoiceFrontier)
+  } else if (isParallel(graph)) {
+    return graph.parallel.flatMap(findChoiceFrontier)
+  } else if (isTitledSteps(graph)) {
+    return graph.steps.flatMap(_ => findChoiceFrontier(_.graph))
+  } else {
+    return []
+  }
+}
+
+function findAndHoistChoiceFrontier(
+  graph: void | Graph,
+  inheritedSubTasks: SubTask[]
+): { changed: boolean; graph: Graph | void } {
+  if (!graph) {
+    return { changed: false, graph }
+  } else if (isChoice(graph)) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    const recurse = graph.choices.map(_ => hoist(_.graph, inheritedSubTasks))
+    const changed = !!recurse.find(_ => _.changed)
+    return {
+      changed,
+      graph: !changed
+        ? graph
+        : Object.assign({}, graph, {
+            choices: graph.choices.map((_, idx) =>
+              Object.assign({}, _, {
+                graph: recurse[idx].graph
+              })
+            )
+          })
+    }
+  } else if (isSubTask(graph)) {
+    const recurse = findAndHoistChoiceFrontier(graph.graph, inheritedSubTasks)
+    return { changed: recurse.changed, graph: Object.assign({}, graph, { graph: recurse.graph }) }
+  } else if (isSequence(graph)) {
+    const recurse = graph.sequence.map(_ => findAndHoistChoiceFrontier(_, inheritedSubTasks))
+    const changed = !!recurse.find(_ => _.changed)
+    return { changed, graph: !changed ? graph : Object.assign({}, graph, { sequence: recurse.map(_ => _.graph) }) }
+  } else if (isParallel(graph)) {
+    const recurse = graph.parallel.map(_ => findAndHoistChoiceFrontier(_, inheritedSubTasks))
+    const changed = !!recurse.find(_ => _.changed)
+    return { changed, graph: !changed ? graph : Object.assign({}, graph, { parallel: recurse.map(_ => _.graph) }) }
+  } else if (isTitledSteps(graph)) {
+    const recurse = graph.steps.map(_ => findAndHoistChoiceFrontier(_.graph, inheritedSubTasks))
+    const changed = !!recurse.find(_ => _.changed)
+    return {
+      changed,
+      graph: !changed
+        ? graph
+        : Object.assign({}, graph, {
+            steps: graph.steps.map((_, idx) =>
+              Object.assign({}, _, {
+                graph: recurse[idx].graph
+              })
+            )
+          })
+    }
+  } else {
+    return { changed: false, graph }
+  }
+}
+
+function extractTopLevelSubTasks(graph: Graph): { toplevelSubTasks: SubTask[]; residual: Graph } {
+  if (isSequence(graph)) {
+    const toplevelSubTasks = graph.sequence.filter(isSubTask)
+    const residual = sequence(graph.sequence.filter(_ => !isSubTask(_)))
+    return { toplevelSubTasks, residual }
+  } else if (isParallel(graph)) {
+    const toplevelSubTasks = graph.parallel.filter(isSubTask)
+    const residual = parallel(graph.parallel.filter(_ => !isSubTask(_)))
+    return { toplevelSubTasks, residual }
+  } else if (isSubTask(graph)) {
+    return { toplevelSubTasks: [graph], residual: emptySequence() }
+  } else {
+    return { toplevelSubTasks: [], residual: graph }
+  }
+}
+
+function union(...As: SubTask[][]): SubTask[] {
+  return As.reduce((set, subtasks) => set.concat(subtasks.filter(b => !set.find(a => a.key === b.key))), [])
+}
+
+/** Smash in any subTasks we hoisted */
+function recombine(graph: Graph | void, subTasks1: SubTask[]) {
+  const subTasks = subTasks1.map(_ => pruneSubTasks(_, subTasks1, false).graph).filter(Boolean)
+
+  if (subTasks.length === 0) {
+    return graph
+  } else if (!graph) {
+    return sequence(subTasks)
+  } else {
+    const { toplevelSubTasks, residual } = extractTopLevelSubTasks(graph)
+    const allSubTasks = union(toplevelSubTasks, subTasks)
+    return sequence([subtask('Prerequisites', 'Prerequisites', '', sequence(allSubTasks)), residual])
+  }
+}
+
+/* function names(A: SubTask[]): string[] {
+  return A.map(_ => _.key)
+} */
+
+/** Hoist shared SubTasks as high as possible in the graph */
+function hoist(inputGraph: Graph, inheritedSubTasks: SubTask[]): { changed: boolean; graph: Graph | void } {
+  const myDominatedSubTasks = extractDominatedSubTasksUpToChoice(inputGraph)
+
+  const choiceFrontier = findChoiceFrontier(inputGraph)
+  const frontierAllChoicesSubTasks = choiceFrontier.flatMap(extractSubTasksCommonToAllChoices)
+
+  const subTasks = union(myDominatedSubTasks, frontierAllChoicesSubTasks, inheritedSubTasks)
+  // console.error('!!!!!!SUB1', names(myDominatedSubTasks))
+  // console.error('!!!!!!SUB2', names(frontierAllChoicesSubTasks))
+  // console.error('!!!!!!SUB3', names(inheritedSubTasks))
+
+  if (subTasks.length === 0) {
+    return { changed: false, graph: inputGraph }
+  }
+
+  const { changed: changed1, graph: prunedGraph } = pruneShadowedSubTasks(inputGraph, subTasks)
+
+  // recurse, for each control subregion
+  const { changed: changed2, graph: prunedGraph2 } = findAndHoistChoiceFrontier(prunedGraph, subTasks)
+
+  // any changes from me or a control subregion?
+  const changed = changed1 || changed2
+
+  // smash in any subTasks we hoisted
+  const graph = recombine(prunedGraph2, subTasks)
+
+  return {
+    changed,
+    graph
+  }
+}
+
+/** Hoist shared SubTasks as high as possible in the graph */
+export default function hoistSubTasks(inputGraph: Graph): Graph {
+  const { graph } = hoist(inputGraph, [])
+  /* if (changed) {
+    if (graph) {
+      return hoistSubTasks(graph)
+    } else {
+      return emptySequence()
+    }
+  } else */
+  return graph || emptySequence()
+}

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/1.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/1.ts
@@ -20,6 +20,8 @@ const importa: Tree = { name: 'importa.md', children: [{ name: 'echo AAA' }] }
 
 const importc: Tree = { name: 'importc.md', children: [{ name: 'echo CCC' }] }
 
+const option2Tab2: Tree = { name: 'Option 2: Tab2', children: [importc] }
+
 const importe: Tree = { name: 'EEE', children: [{ name: 'Option 1: TabE1', children: [{ name: 'echo EEE' }] }] }
 
 const importd: Tree = {
@@ -30,20 +32,17 @@ const importd: Tree = {
   ]
 }
 
-// the dominator tree will elimimate this node from the view
-// const importf: Tree = { name: 'importf.md', children: [importd] }
-
-const thisContent: Tree = {
-  name: 'AAA',
-  children: [{ name: 'Option 1: Tab1' }, { name: 'Option 2: Tab2', children: [importc] }]
+const snippetsInTab3 = {
+  name: 'snippets-in-tab3.md',
+  children: [option2Tab2]
 }
 
 const IN1: Input = {
   input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model1.md'),
   tree: [
     {
-      name: 'snippets-in-tab3.md',
-      children: [importa, importe, importd, thisContent]
+      name: 'Tasks',
+      children: [snippetsInTab3, importa, importe, importd]
     }
   ]
 }

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/2.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/2.ts
@@ -17,8 +17,8 @@
 import Input, { Tree } from '../Input'
 import { importa, importe, importd } from './1'
 
-const thisContent: Tree = {
-  name: 'AAA',
+const snippetsInTab4: Tree = {
+  name: 'snippets-in-tab4.md',
   children: [
     { name: 'Option 1: Tab1', children: [importd] },
     { name: 'Option 2: Tab2', children: [{ name: 'echo XXX' }] }
@@ -29,8 +29,8 @@ const IN2: Input = {
   input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model2.md'),
   tree: [
     {
-      name: 'snippets-in-tab4.md',
-      children: [importa, importe, thisContent]
+      name: 'Tasks',
+      children: [snippetsInTab4, importa, importe]
     }
   ]
 }

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/3.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/3.ts
@@ -14,10 +14,26 @@
  * limitations under the License.
  */
 
-import IN1 from './1'
-import IN2 from './2'
-import IN3 from './3'
-import IN4 from './4'
-import IN5 from './5'
+import Input, { Tree } from '../Input'
+import { importa, importe, importd } from './1'
 
-export default [IN1, IN2, IN3, IN4, IN5]
+const snippetsInTab5: Tree = {
+  name: 'snippets-in-tab5.md',
+  children: [
+    { name: 'Option 1: Tab1', children: [importd] },
+    { name: 'Option 2: Tab2', children: [{ name: 'echo XXX' }] },
+    { name: 'Option 3: Tab3', children: [importd] }
+  ]
+}
+
+const IN3: Input = {
+  input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model3.md'),
+  tree: [
+    {
+      name: 'Tasks',
+      children: [snippetsInTab5, importa, importe]
+    }
+  ]
+}
+
+export default IN3

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/4.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/4.ts
@@ -14,10 +14,22 @@
  * limitations under the License.
  */
 
-import IN1 from './1'
-import IN2 from './2'
-import IN3 from './3'
-import IN4 from './4'
-import IN5 from './5'
+import Input, { Tree } from '../Input'
+import { importa, importe, importd } from './1'
 
-export default [IN1, IN2, IN3, IN4, IN5]
+const snippetsInTab5: Tree = {
+  name: 'snippets-in-tab5.md',
+  children: [{ name: 'Option 2: Tab2', children: [{ name: 'echo XXX' }] }]
+}
+
+const IN4: Input = {
+  input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model4.md'),
+  tree: [
+    {
+      name: 'Tasks',
+      children: [importd, snippetsInTab5, importa, importe]
+    }
+  ]
+}
+
+export default IN4

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/5.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/5.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-import IN1 from './1'
-import IN2 from './2'
-import IN3 from './3'
-import IN4 from './4'
-import IN5 from './5'
+import Input from '../Input'
+import { importd } from './1'
 
-export default [IN1, IN2, IN3, IN4, IN5]
+const IN5: Input = {
+  input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model5.md'),
+  tree: [
+    {
+      name: 'Tasks',
+      children: [importd]
+    }
+  ]
+}
+
+export default IN5

--- a/plugins/plugin-client-common/tests/data/guidebook-tree-model4.md
+++ b/plugins/plugin-client-common/tests/data/guidebook-tree-model4.md
@@ -1,0 +1,9 @@
+---
+imports:
+    - importd.md
+    - snippets-in-tab5.md
+---
+
+<!-- You should see a tree view. This is the Imports.tsx component -->
+
+::imports

--- a/plugins/plugin-client-common/tests/data/guidebook-tree-model5.md
+++ b/plugins/plugin-client-common/tests/data/guidebook-tree-model5.md
@@ -1,0 +1,6 @@
+---
+imports:
+    - snippets-in-tab6.md
+---
+
+::imports

--- a/plugins/plugin-client-common/tests/data/snippets-in-tab6.md
+++ b/plugins/plugin-client-common/tests/data/snippets-in-tab6.md
@@ -1,0 +1,11 @@
+# Chooser
+
+=== "Tab1"
+    :import{importd.md}
+
+=== "Tab2"
+    :import{importd.md}
+
+=== "Tab3"
+    :import{importd.md}
+


### PR DESCRIPTION
This PR switches us off a dominator tree, and instead uses an algorithm closer to an iterative control dependence region optimizer.

We should no longer hoist imports that appear on only a subset of choice branches, e.g.

```
root
    choice1: import foo
    choice2: import bar
    choice3: import foo
```

Prior to this PR, we were using a dominator tree, which blindly hoisted both up, since the root dominates those two imports.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
