### PR TITLE
fix(plugins/plugin-client-common): Imports checkmarks are too tall

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Wizard/Imports.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Imports.scss
@@ -75,7 +75,6 @@
   .pf-c-badge.pf-m-unread {
     padding: 0;
     min-width: unset;
-    font-size: 1rem;
     background-color: transparent;
   }
 


### PR DESCRIPTION
We have a `font-size: 1rem` css rule that causes non-aligned row content in the tree view.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
