### PR TITLE
fix(plugins/plugin-client-common): secondary markdown tabs do not display well

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/tabbed.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/tabbed.tsx
@@ -114,6 +114,10 @@ class LinkableTabs extends React.PureComponent<Props, State> {
     return this.asTabs()
   }
 
+  private get isSecondary() {
+    return this.props.depth > 0
+  }
+
   /** Render as a Tabs UI */
   private asTabs() {
     return (
@@ -124,6 +128,7 @@ class LinkableTabs extends React.PureComponent<Props, State> {
         mountOnEnter
         unmountOnExit
         data-depth={this.props.depth}
+        isSecondary={this.isSecondary}
       >
         {(this.props.children || []).map((_, idx) => (
           <Tab

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -628,6 +628,15 @@ pre {
   }
 }
 
+@include MarkdownSecondaryTabs {
+  padding-top: 0;
+
+  /** This is to snap the alignment back to the top of the enclosing
+  tabs, thus compensating for the top-padding of our Card wrapper (see
+  tabbed.tsx) */
+  margin-top: -1rem;
+}
+
 @include CodeBlock {
   &:hover {
     @include CodeBlockActions {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -566,6 +566,15 @@ $action-hover-delay: 210ms;
     @content;
   }
 }
+
+@mixin MarkdownSecondaryTabs {
+  @include MarkdownTabs {
+    &.pf-m-secondary {
+      @content;
+    }
+  }
+}
+
 @mixin MarkdownTabContent {
   section.kui--markdown-tab:not([hidden]) {
     @content;


### PR DESCRIPTION
we aren't leveraging patternfly's built-in support for secondary tabs. there is a lot of vertical padding between each layer of tabs, due to our Card wrapper around the tab body content.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
