### PR TITLE
feat(plugins/plugin-client-common): infer Wizard from guidebook DAG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,6 +1187,11 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
+    },
     "node_modules/@types/fs-extra": {
       "version": "9.0.12",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.12.tgz",
@@ -7421,6 +7426,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-embedded": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-2.0.0.tgz",
+      "integrity": "sha512-vEr54rDu2CheBM4nLkWbW8Rycf8HhkA/KsrDnlyKnvBTyhyO+vAG6twHnfUbiRGo56YeUBNCI4HFfHg3Wu+tig==",
+      "dependencies": {
+        "hast-util-is-element": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-from-parse5": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.0.tgz",
@@ -7461,6 +7478,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.2.tgz",
+      "integrity": "sha512-thjnlGAnwP8ef/GSO1Q8BfVk2gundnc2peGQqEg2kUt/IqesiGg/5mSwN2fE7nLzy61pg88NG6xV+UrGOrx9EA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.0.tgz",
@@ -7495,6 +7525,40 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-mdast": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-8.3.1.tgz",
+      "integrity": "sha512-nxLcom1oW5y/1CyaV24K16LOfYbAIS74BDbCPW6WduzAYTAVDp3g/DM1CY6Ngo+Dx5itLzvmCm7SnUHBZd3NVQ==",
+      "dependencies": {
+        "@types/extend": "^3.0.0",
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "extend": "^3.0.0",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-to-text": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "rehype-minify-whitespace": "^5.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-mdast/node_modules/mdast-util-to-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+      "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.0.0.tgz",
@@ -7518,6 +7582,20 @@
       "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
       "dependencies": {
         "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.1.tgz",
+      "integrity": "sha512-7S3mOBxACy8syL45hCn3J7rHqYaXkxRfsX6LXEU5Shz4nt4GxdjtMUtG+T6G/ZLUHd7kslFAf14kAN71bz30xA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "unist-util-find-after": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9759,6 +9837,19 @@
       "integrity": "sha512-jXbFD0C+MfRkwsaze+btzG9CmVrxnc5kpcJLtx3SvSlPWnNdGMlDRHKDB9/TIPEq9nRHnkixppT8yvaUJ5agJg==",
       "dependencies": {
         "mdast-util-to-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.0.tgz",
+      "integrity": "sha512-S+QYsDRLkGi8U7o5JF1agKa/sdP+CNGXXLqC17pdTVL8FHHgQEiwFGa9yE5aYtUxNiFGYoaDy9V1kC85Sz86Gg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13246,6 +13337,23 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-5.0.0.tgz",
+      "integrity": "sha512-cUkQldYx8jpWM6FZmCkOF/+mev09+5NAtBzUFZgnfXsIoglxo3h6t3S3JbNouiaqIDE6vbpI+GQpOg0xD3Z7kg==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-embedded": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-raw": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-6.1.1.tgz",
@@ -15425,6 +15533,15 @@
         "hasharray": "^1.1.1"
       }
     },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.0.0.tgz",
+      "integrity": "sha512-lyJ/STqmYO8k9aWZbodPTrVkRh/50yFwNZ/HxKp/30eM9zf898MgQCG/NxfMnx7fZSKbaEcuZ1V+QgWrXFH6rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trough": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
@@ -15704,6 +15821,19 @@
       "integrity": "sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==",
       "dependencies": {
         "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.0.tgz",
+      "integrity": "sha512-gfpsxKQde7atVF30n5Gff2fQhAc4/HTOV4CvkXpTg9wRfQhZWdXitpyXHWB6YcYgnsxLx+4gGHeVjCTAAp9sjw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -17712,6 +17842,7 @@
         "@patternfly/react-styles": "4.48.19",
         "@patternfly/react-table": "4.67.19",
         "anser": "2.1.1",
+        "hast-util-to-mdast": "8.3.1",
         "html-entities": "2.3.2",
         "monaco-editor": "0.33.0",
         "monaco-editor-webpack-plugin": "7.0.1",
@@ -18457,6 +18588,7 @@
         "@patternfly/react-styles": "4.48.19",
         "@patternfly/react-table": "4.67.19",
         "anser": "2.1.1",
+        "hast-util-to-mdast": "8.3.1",
         "html-entities": "2.3.2",
         "monaco-editor": "0.33.0",
         "monaco-editor-webpack-plugin": "7.0.1",
@@ -18993,6 +19125,11 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
     },
     "@types/fs-extra": {
       "version": "9.0.12",
@@ -23857,6 +23994,14 @@
         "web-namespaces": "^2.0.0"
       }
     },
+    "hast-util-embedded": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-2.0.0.tgz",
+      "integrity": "sha512-vEr54rDu2CheBM4nLkWbW8Rycf8HhkA/KsrDnlyKnvBTyhyO+vAG6twHnfUbiRGo56YeUBNCI4HFfHg3Wu+tig==",
+      "requires": {
+        "hast-util-is-element": "^2.0.0"
+      }
+    },
     "hast-util-from-parse5": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.0.tgz",
@@ -23885,6 +24030,15 @@
         "@types/hast": "^2.0.0"
       }
     },
+    "hast-util-is-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.2.tgz",
+      "integrity": "sha512-thjnlGAnwP8ef/GSO1Q8BfVk2gundnc2peGQqEg2kUt/IqesiGg/5mSwN2fE7nLzy61pg88NG6xV+UrGOrx9EA==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      }
+    },
     "hast-util-parse-selector": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.0.tgz",
@@ -23911,6 +24065,34 @@
         "zwitch": "^2.0.0"
       }
     },
+    "hast-util-to-mdast": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-8.3.1.tgz",
+      "integrity": "sha512-nxLcom1oW5y/1CyaV24K16LOfYbAIS74BDbCPW6WduzAYTAVDp3g/DM1CY6Ngo+Dx5itLzvmCm7SnUHBZd3NVQ==",
+      "requires": {
+        "@types/extend": "^3.0.0",
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "extend": "^3.0.0",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-to-text": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "rehype-minify-whitespace": "^5.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "dependencies": {
+        "mdast-util-to-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+          "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
+        }
+      }
+    },
     "hast-util-to-parse5": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.0.0.tgz",
@@ -23930,6 +24112,16 @@
       "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
       "requires": {
         "@types/hast": "^2.0.0"
+      }
+    },
+    "hast-util-to-text": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.1.tgz",
+      "integrity": "sha512-7S3mOBxACy8syL45hCn3J7rHqYaXkxRfsX6LXEU5Shz4nt4GxdjtMUtG+T6G/ZLUHd7kslFAf14kAN71bz30xA==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "unist-util-find-after": "^4.0.0"
       }
     },
     "hast-util-whitespace": {
@@ -25561,6 +25753,15 @@
       "integrity": "sha512-jXbFD0C+MfRkwsaze+btzG9CmVrxnc5kpcJLtx3SvSlPWnNdGMlDRHKDB9/TIPEq9nRHnkixppT8yvaUJ5agJg==",
       "requires": {
         "mdast-util-to-string": "^1.0.0"
+      }
+    },
+    "mdast-util-phrasing": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.0.tgz",
+      "integrity": "sha512-S+QYsDRLkGi8U7o5JF1agKa/sdP+CNGXXLqC17pdTVL8FHHgQEiwFGa9yE5aYtUxNiFGYoaDy9V1kC85Sz86Gg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
       }
     },
     "mdast-util-to-hast": {
@@ -27997,6 +28198,19 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "rehype-minify-whitespace": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-5.0.0.tgz",
+      "integrity": "sha512-cUkQldYx8jpWM6FZmCkOF/+mev09+5NAtBzUFZgnfXsIoglxo3h6t3S3JbNouiaqIDE6vbpI+GQpOg0xD3Z7kg==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-embedded": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-is": "^5.0.0"
+      }
+    },
     "rehype-raw": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-6.1.1.tgz",
@@ -29687,6 +29901,11 @@
         "hasharray": "^1.1.1"
       }
     },
+    "trim-trailing-lines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.0.0.tgz",
+      "integrity": "sha512-lyJ/STqmYO8k9aWZbodPTrVkRh/50yFwNZ/HxKp/30eM9zf898MgQCG/NxfMnx7fZSKbaEcuZ1V+QgWrXFH6rg=="
+    },
     "trough": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
@@ -29894,6 +30113,15 @@
       "integrity": "sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==",
       "requires": {
         "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-find-after": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.0.tgz",
+      "integrity": "sha512-gfpsxKQde7atVF30n5Gff2fQhAc4/HTOV4CvkXpTg9wRfQhZWdXitpyXHWB6YcYgnsxLx+4gGHeVjCTAAp9sjw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
       }
     },
     "unist-util-generated": {

--- a/packages/test/src/api/Wizard.ts
+++ b/packages/test/src/api/Wizard.ts
@@ -16,8 +16,8 @@
 
 export default class Wizard {
   public readonly wizard = '.kui--wizard'
-  private readonly title = '.kui--wizard-header-title'
-  private readonly _description = '.kui--wizard-header-description'
+  private readonly title = '.pf-c-wizard__title'
+  private readonly _description = '.pf-c-wizard__description'
   private readonly _navItem = '.pf-c-wizard__nav-item'
   private readonly _navItemTitle = '.pf-c-wizard__nav-link'
   public readonly isCurrentStep = 'pf-m-current'

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -28,6 +28,7 @@
     "@patternfly/react-styles": "4.48.19",
     "@patternfly/react-table": "4.67.19",
     "anser": "2.1.1",
+    "hast-util-to-mdast": "8.3.1",
     "html-entities": "2.3.2",
     "monaco-editor": "0.33.0",
     "monaco-editor-webpack-plugin": "7.0.1",

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Guide.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+
+import order from './code/graph/order'
+import compile from './code/graph/compile'
+import { findChoiceFrontier, findCodeBlockFrontier, findPrereqsAndMainTasks } from './code/graph/choice-frontier'
+import {
+  Graph,
+  ChoicesMap,
+  CodeBlockProps,
+  OrderedGraph,
+  extractTitle,
+  extractDescription,
+  hasSource,
+  // isSequence,
+  // isParallel,
+  sameGraph
+} from './code/graph'
+
+import Markdown from '..'
+import Card from '../../../spi/Card'
+// import CodeBlock from '../../../Views/Terminal/Block/Inputv2'
+
+const Wizard = React.lazy(() => import('@patternfly/react-core').then(_ => ({ default: _.Wizard })))
+
+import '../../../../../web/scss/components/Wizard/PatternFly.scss'
+
+interface Props {
+  /** markdown document id */
+  uuid: string
+
+  /** Raw list of code blocks */
+  blocks: CodeBlockProps[]
+}
+
+interface State {
+  /** Graph of code blocks to be executed */
+  graph: OrderedGraph
+
+  /** Map from tab group to currently selected tab member */
+  choices: ChoicesMap
+
+  /** Choice Frontier */
+  frontier: ReturnType<typeof findChoiceFrontier>
+}
+
+class Guide extends React.PureComponent<Props, State> {
+  public constructor(props: Props) {
+    super(props)
+    this.state = Guide.getDerivedStateFromProps(props)
+  }
+
+  /**
+   * TODO move to a more common location?
+   *
+   * It may be the case that our state.graph has no choices (or no
+   * remaining choices, subject to the `ChoicesMap`, i.e. the
+   * choices already made). In this situation, we still need to
+   * present the remaining, non-choicey work. We do so by presenting
+   * the Prerequisites and Main Tasks. If we still get nothing, then
+   * we present the raw code blocks (just below).
+   *
+   */
+  private static computeChoiceFrontier(graph: Graph, choices: State['choices']) {
+    const frontier1 = findChoiceFrontier(graph, choices)
+
+    const frontier2 =
+      frontier1.length > 0
+        ? frontier1
+        : [
+            {
+              prereqs: findPrereqsAndMainTasks(graph),
+              choice: undefined
+            }
+          ]
+
+    const frontier =
+      frontier2.length > 0
+        ? frontier2
+        : [
+            {
+              prereqs: findCodeBlockFrontier(graph, choices),
+              choice: undefined
+            }
+          ]
+
+    return frontier
+  }
+
+  public static getDerivedStateFromProps(props: Props, state?: State) {
+    const newGraph = compile(props.blocks, 'sequence')
+    const noChangeToGraph = state && sameGraph(state.graph, newGraph)
+
+    const choices = !state ? {} : state.choices
+    const graph = noChangeToGraph ? state.graph : order(newGraph)
+    const frontier = Guide.computeChoiceFrontier(graph, choices)
+
+    return { choices, graph, frontier }
+  }
+
+  private allDoneWithChoices() {
+    return 'all done with choices'
+  }
+
+  private graph(graph: Graph) {
+    if (hasSource(graph)) {
+      return (
+        <Card className="kui--markdown-tab-card">
+          <Markdown nested source={graph.source} />
+        </Card>
+      )
+    } /* else if (isSequence(graph)) {
+      return <React.Fragment>{graph.sequence.map(_ => this.graph(_))}</React.Fragment>
+    } else if (isParallel(graph)) {
+      return <React.Fragment>{graph.parallel.map(_ => this.graph(_))}</React.Fragment>
+    } else {
+      return (
+        <pre key={graph.id}>
+          <CodeBlock
+            className="kui--code-block-in-markdown"
+            value={graph.body}
+            language={graph.language}
+            optional={graph.optional}
+            validate={graph.validate}
+            id={graph.id}
+            tab={undefined}
+            arg1={undefined}
+            onResponse={this.onResponse}
+          />
+        </pre>
+      )
+    } */
+  }
+
+  /* private readonly onResponse = () => {
+    // noop
+  } */
+
+  private wizardStepDescription(description: string) {
+    return (
+      <div className="kui--wizard-nav-item-description">
+        {/* this.wizardCodeBlockSteps(stepIdx) */}
+        <div className="paragraph">{description}</div>
+      </div>
+    )
+  }
+
+  private presentChoices() {
+    const steps = this.state.frontier
+      .flatMap(({ prereqs, choice }) =>
+        [
+          ...prereqs.map(_ => ({
+            name: extractTitle(_),
+            component: this.graph(_),
+            stepNavItemProps: {
+              children: this.wizardStepDescription(extractDescription(_))
+            }
+          })),
+          choice ? { name: choice.title, component: this.graph(choice) } : undefined
+        ].filter(Boolean)
+      )
+      .map(_ => Object.assign(_, { hideCancelButton: true }))
+
+    return steps.length === 0 ? (
+      'Nothing to do!'
+    ) : (
+      <div className="kui--wizard">
+        <div className="kui--wizard-main-content">
+          <Wizard
+            hideClose
+            steps={steps}
+            title={extractTitle(this.state.graph)}
+            description={extractDescription(this.state.graph)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  public render() {
+    if (!this.state) {
+      return <React.Fragment />
+    } else if (this.state.frontier.length === 0) {
+      return this.allDoneWithChoices()
+    } else {
+      return this.presentChoices()
+    }
+  }
+}
+
+export default function guidebookGuideWrapper(uuid: string) {
+  return function guidebookGuide(props: { 'data-kui-code-blocks': string }) {
+    const blocks = props['data-kui-code-blocks']
+      ? JSON.parse(props['data-kui-code-blocks']).map(_ => JSON.parse(Buffer.from(_, 'base64').toString()))
+      : undefined
+
+    return !blocks ? <span className="all-pad">Nothing to do!</span> : <Guide uuid={uuid} blocks={blocks} />
+  }
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/CodeBlockProps.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/CodeBlockProps.ts
@@ -38,18 +38,24 @@ export interface Description {
   description: string
 }
 
+export type Source = {
+  source: string
+}
+
 /**
  * Is this a member of a group of choices? e.g. am I `A` in a choice
  * to do either `A+B` or `C+D`?
  */
 export type Choice = GroupMember &
+  Source &
   Title &
   Kind<'Choice'> & {
-    /** Title for the choice group */
-    groupTitle: string
+    /** Title and Source for the choice group */
+    groupDetail: Partial<Title> & Source
   }
 
 export type Import = Title &
+  Source &
   Kind<'Import'> & {
     key: string
     filepath: string
@@ -60,10 +66,10 @@ type Kind<T extends string> = {
 }
 
 export type Wizard = {
-  wizard: Title & Partial<Description>
+  wizard: Title & Partial<Description> & Source
 }
 
-export type WizardStep = Wizard & GroupMember & Title & Partial<Description> & Kind<'WizardStep'>
+export type WizardStep = Wizard & GroupMember & Title & Partial<Description> & Kind<'WizardStep'> & Source
 
 type CodeBlockNestingParent = Choice | Import | WizardStep
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/index.tsx
@@ -34,7 +34,6 @@ import { MiniProgressStepper, StepperProps } from '../../../MiniProgressStepper'
 import { ProgressStepState, statusFromStatusVector } from '../../../ProgressStepper'
 import { subscribeToLinkUpdates, unsubscribeToLinkUpdates } from '../../../LinkStatus'
 
-import '../../../../../../web/scss/components/Wizard/_index.scss'
 import '../../../../../../web/scss/components/Wizard/PatternFly.scss'
 
 import { WizardStep } from '@patternfly/react-core'
@@ -224,14 +223,14 @@ export default class Wizard extends React.PureComponent<Props, State> {
   private title() {
     const label = this.props['data-kui-title'].trim()
     return (
-      <div className="kui--wizard-header-title" aria-label={label}>
+      <div className="kui--wizard-header-title pf-c-wizard__title" aria-label={label}>
         {label}
       </div>
     )
   }
 
   private description() {
-    return <div className="kui--wizard-header-description">{this.props.children[0]}</div>
+    return <div className="pf-c-wizard__description">{this.props.children[0]}</div>
   }
 
   private header() {
@@ -269,7 +268,11 @@ export default class Wizard extends React.PureComponent<Props, State> {
   }
 
   public render() {
-    return this.wizard()
+    if (this.props['data-kui-is-from-import'] === 'true') {
+      return <React.Fragment />
+    } else {
+      return this.wizard()
+    }
   }
 }
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/dump.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/dump.ts
@@ -15,7 +15,12 @@
  */
 
 /** Re-serialize the given attributes and code block body */
-export default function dump(attributes: Record<string, any>, body: string) {
+export default function dump(attrs: Record<string, any>, body: string) {
+  // the nesting attribute is expensive to serialize, and we don't
+  // need to reserialize it
+  const attributes = Object.assign({}, attrs)
+  delete attributes.nesting
+
   return `
 ---
 ${require('js-yaml').dump(attributes)}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/choice-frontier.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/choice-frontier.ts
@@ -14,25 +14,188 @@
  * limitations under the License.
  */
 
-import { Choice, Graph, isSubTask, isChoice, isSequence, isParallel, isTitledSteps } from '.'
+import { v4 } from 'uuid'
+
+import {
+  ChoicesMap,
+  Choice,
+  CodeBlockProps,
+  Graph,
+  hasKey,
+  hasTitle,
+  isSubTask,
+  isChoice,
+  isSequence,
+  isParallel,
+  isTitledSteps,
+  subtask
+} from '.'
+
+function key(graph: Graph) {
+  if (hasKey(graph)) {
+    return graph.key
+  } else if (hasTitle(graph)) {
+    return graph.title
+  } else if (isChoice(graph)) {
+    return graph.group
+  } else {
+    return graph.id
+  }
+}
+
+/**
+ * Find the first set of `CodeBlock` nodes, when scanning the given
+ * `graph`. Do not scan under Choice nodes for nested subtasks, unless
+ *  the user has already indicated a selection for that choice.
+ */
+
+export function findCodeBlockFrontier(graph: Graph, choices: ChoicesMap = {}): CodeBlockProps[] {
+  if (isSubTask(graph)) {
+    return findCodeBlockFrontier(graph.graph)
+  } else if (isChoice(graph)) {
+    if (graph.group in choices) {
+      const whatTheUserChose = choices[graph.group]
+      return findCodeBlockFrontier(graph.choices[whatTheUserChose].graph, choices)
+    } else {
+      return []
+    }
+  } else if (isSequence(graph)) {
+    return graph.sequence.flatMap(_ => findCodeBlockFrontier(_, choices))
+  } else if (isParallel(graph)) {
+    return graph.parallel.flatMap(_ => findCodeBlockFrontier(_, choices))
+  } else if (isTitledSteps(graph)) {
+    return graph.steps.flatMap(_ => findCodeBlockFrontier(_.graph, choices))
+  } else {
+    return [graph]
+  }
+}
+
+/**
+ * Enumerate the Prerequisites and Main Tasks in the given `graph.
+ */
+export function findPrereqsAndMainTasks(graph: Graph): Graph[] {
+  if (isSubTask(graph) && isSequence(graph.graph) && graph.graph.sequence.length === 2) {
+    const child1 = graph.graph.sequence[0]
+    const child2 = graph.graph.sequence[1]
+
+    if (isSubTask(child1) && child1.title === 'Prerequisites' && isSubTask(child2) && child2.title === 'Main Tasks') {
+      // this needs a bit more refinement. we need to find a general
+      // way to deal with an arbitrary mixture of titled and untitled
+      // tasks
+      if (child2.graph.sequence.every(_ => hasTitle(_))) {
+        return child1.graph.sequence.concat(child2.graph.sequence)
+      } else {
+        return child1.graph.sequence.concat(child2)
+      }
+    }
+  } else if (isTitledSteps(graph)) {
+    return graph.steps.map(_ => subtask(v4(), _.title, _.description, '', _.graph, _.source))
+  }
+
+  return []
+}
 
 /**
  * Find the first set of `Choice` nodes, when scanning the given
- * `graph`. Do not scan under Choice nodes for nested choices.
+ * `graph`. Do not scan under Choice nodes for nested
+ * choices... unless the user has already made a choice (according to
+ * the given `ChoicesMap`) for that choice; in which case, we tunnel
+ * through under that branch, looking for the next choice...
  *
  */
-export default function findChoiceFrontier(graph: Graph): Choice[] {
+export function findChoiceFrontier(
+  graph: Graph,
+  choices: ChoicesMap = {},
+  prereqs: Graph[] = [],
+  marks: Record<string, boolean> = {}
+): { prereqs?: Graph[]; choice: Choice }[] {
   if (isChoice(graph)) {
-    return [graph]
+    marks[key(graph)] = true
+
+    if (!(graph.group in choices)) {
+      // user has not yet made a choice. stop here and consume all
+      // prereqs
+      const frontier = [{ prereqs: prereqs.slice(), choice: graph }]
+      prereqs.forEach(_ => (marks[key(_)] = true))
+      prereqs.splice(0, prereqs.length) // consume...
+      return frontier
+    } else {
+      // otherwise, we continue to tunnel down that chosen branch
+      const whatTheUserChose = choices[graph.group]
+      return findChoiceFrontier(graph.choices[whatTheUserChose].graph, choices, prereqs, marks)
+    }
   } else if (isSubTask(graph)) {
-    return findChoiceFrontier(graph.graph)
+    const frontier = findChoiceFrontier(graph.graph, choices, prereqs, marks)
+    if (isSequence(graph.graph) && graph.graph.sequence.every(child => marks[key(child)])) {
+      marks[graph.key] = true
+    }
+    return frontier
   } else if (isSequence(graph)) {
-    return graph.sequence.flatMap(findChoiceFrontier)
+    const frontier = graph.sequence.flatMap(_ => {
+      const frontier = findChoiceFrontier(_, choices, prereqs, marks)
+
+      if (!marks[key(_)]) {
+        prereqs.push(_)
+      }
+
+      return frontier
+    })
+    graph.sequence.forEach(a => {
+      const idx = prereqs.findIndex(b => a === b)
+      if (idx >= 0) {
+        prereqs.splice(idx, 1)
+      }
+    })
+    if (graph.sequence.every(child => marks[key(child)])) {
+      marks[key(graph)] = true
+    }
+    return frontier
   } else if (isParallel(graph)) {
-    return graph.parallel.flatMap(findChoiceFrontier)
+    const frontier = graph.parallel.flatMap(_ => {
+      const frontier = findChoiceFrontier(_, choices, prereqs, marks)
+
+      if (!marks[key(_)]) {
+        prereqs.push(_)
+      }
+
+      return frontier
+    })
+    graph.parallel.forEach(a => {
+      const idx = prereqs.findIndex(b => a === b)
+      if (idx >= 0) {
+        prereqs.splice(idx, 1)
+      }
+    })
+    if (graph.parallel.every(child => marks[key(child)])) {
+      marks[key(graph)] = true
+    }
+    return frontier
   } else if (isTitledSteps(graph)) {
-    return graph.steps.flatMap(_ => findChoiceFrontier(_.graph))
+    const frontier = graph.steps.flatMap(_ => {
+      const frontier = findChoiceFrontier(_.graph, choices, prereqs, marks)
+
+      if (!marks[key(_.graph)]) {
+        prereqs.push(_.graph)
+      }
+
+      return frontier
+    })
+    graph.steps.forEach(({ graph: a }) => {
+      const idx = prereqs.findIndex(b => a === b)
+      if (idx >= 0) {
+        prereqs.splice(idx, 1)
+      }
+    })
+    if (graph.steps.every(step => marks[key(step.graph)])) {
+      marks[key(graph)] = true
+    }
+    return frontier
   } else {
+    // leaf-most code blocks. no choices here.
     return []
   }
+}
+
+export default function findChoicesOnFrontier(graph: Graph, choices: ChoicesMap = {}): Choice[] {
+  return findChoiceFrontier(graph, choices).map(_ => _.choice)
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/compile.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/compile.ts
@@ -64,8 +64,9 @@ export default function compile(blocks: CodeBlockProps[], ordering: 'sequence' |
   })
 
   const newChoices = (block: CodeBlockProps, parent: CodeBlockChoice, isDeepest: boolean): Choice => ({
-    title: parent.groupTitle,
     group: parent.group,
+    title: parent.groupDetail.title,
+    source: parent.groupDetail.source,
     choices: [newChoice(block, parent, isDeepest)]
   })
 
@@ -77,6 +78,7 @@ export default function compile(blocks: CodeBlockProps[], ordering: 'sequence' |
     return {
       title: parent.title,
       description: parent.description,
+      source: parent.source,
       graph: isDeepest ? seq(block) : emptySequence()
     }
   }
@@ -105,6 +107,7 @@ export default function compile(blocks: CodeBlockProps[], ordering: 'sequence' |
 
   const newWizard = (block: CodeBlockProps, parent: CodeBlockWizardStep, isDeepest: boolean): TitledSteps => {
     const wiz = {
+      source: parent.source,
       title: parent.wizard.title,
       description: parent.wizard.description,
       steps: []
@@ -115,6 +118,7 @@ export default function compile(blocks: CodeBlockProps[], ordering: 'sequence' |
   const newSubTask = (block: CodeBlockProps, parent: CodeBlockImport, isDeepest: boolean): SubTask => ({
     key: parent.key,
     title: parent.title,
+    source: parent.source,
     filepath: parent.filepath,
     graph: isDeepest ? seq(block) : emptySequence()
   })

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/deadCodeElimination.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/deadCodeElimination.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Graph, emptySequence, isSequence, isParallel, isSubTask, isTitledSteps, isChoice } from '.'
+
+/** Remove any subgraphs that contain no code blocks */
+function dce<G extends Graph>(graph: G): G {
+  if (isSequence(graph)) {
+    const sequence = graph.sequence.map(dce).filter(Boolean)
+    if (sequence.length > 0) {
+      return Object.assign({}, graph, { sequence })
+    }
+  } else if (isParallel(graph)) {
+    const parallel = graph.parallel.map(dce).filter(Boolean)
+    if (parallel.length > 0) {
+      return Object.assign({}, graph, { parallel })
+    }
+  } else if (isSubTask(graph)) {
+    const subgraph = dce(graph.graph)
+    if (subgraph) {
+      return Object.assign({}, graph, { graph: subgraph })
+    }
+  } else if (isTitledSteps(graph)) {
+    const steps = graph.steps
+      .map(_ => {
+        const subgraph = dce(_.graph)
+        if (subgraph) {
+          return Object.assign({}, _, { graph: subgraph })
+        }
+      })
+      .filter(Boolean)
+    if (steps.length > 0) {
+      return Object.assign({}, graph, { steps })
+    }
+  } else if (isChoice(graph)) {
+    const choices = graph.choices
+      .map(_ => {
+        const subgraph = dce(_.graph)
+        if (subgraph) {
+          return Object.assign({}, _, { graph: subgraph })
+        }
+      })
+      .filter(Boolean)
+    if (choices.length > 0) {
+      return Object.assign({}, graph, { choices })
+    }
+  } else {
+    return graph
+  }
+}
+
+/** Remove any subgraphs that contain no code blocks */
+export default function deadCodeElimination(graph: Graph): Graph {
+  return dce(graph) || emptySequence()
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/order.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/order.ts
@@ -45,7 +45,7 @@ function orderSequence(graph: Sequence = emptySequence(), ordinal = 0): Sequence
     { postorder: ordinal, sequence: [] }
   )
 
-  return { order: ordinal, postorder, sequence }
+  return { key: graph.key, order: ordinal, postorder, sequence }
 }
 
 function orderParallel(graph: Parallel, ordinal: number): Parallel<Ordered> {
@@ -59,7 +59,7 @@ function orderParallel(graph: Parallel, ordinal: number): Parallel<Ordered> {
     { postorder: ordinal, parallel: [] }
   )
 
-  return { order: ordinal, postorder, parallel }
+  return { key: graph.key, order: ordinal, postorder, parallel }
 }
 
 function orderTitledSteps(graph: TitledSteps<Unordered>, ordinal = 0): TitledSteps<Ordered> {
@@ -104,7 +104,7 @@ function orderCodeBlock(graph: CodeBlockProps, ordinal: number): CodeBlockProps 
 }
 
 // T extends Sequence ? Sequence<Ordered> : T extends Parallel ? Parallel<Ordered> : T extends Choice ? Choice<Ordered> : (CodeBlockProps & Ordered)
-export default function order<T extends Graph<Unordered>>(graph: T, ordinal = 0): Graph<Ordered> {
+export default function order(graph: Graph, ordinal = 0): Graph<Ordered> {
   if (isSequence(graph)) {
     return orderSequence(graph, ordinal)
   } else if (isParallel(graph)) {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/propagateTitles.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/propagateTitles.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Graph, isSubTask, isChoice, isSequence, isParallel, isTitledSteps } from '.'
+
+/**
+ * Attempt to propagate "meaning" to less areas without prior meaning,
+ * but whose meaning can be properly associated with other
+ * meanings. For example, we may not have a `title` attribute for a
+ * `Choice`, but a `SubTask` immediate parent may have a title.
+ *
+ */
+export default function propagateTitles(graph: Graph, title?: string) {
+  if (isSequence(graph)) {
+    graph.sequence.forEach(_ => propagateTitles(_, title))
+  } else if (isParallel(graph)) {
+    graph.parallel.forEach(_ => propagateTitles(_, title))
+  } else if (isSubTask(graph)) {
+    if (graph.graph) {
+      propagateTitles(graph.graph, graph.title)
+    }
+  } else if (isTitledSteps(graph)) {
+    graph.steps.forEach(_ => {
+      if (_.graph) {
+        propagateTitles(_.graph, _.title)
+      }
+    })
+  } else if (isChoice(graph)) {
+    if (!graph.title && title) {
+      graph.title = title
+    }
+
+    graph.choices.forEach(_ => propagateTitles(_.graph, _.title))
+  }
+
+  return graph
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
@@ -26,6 +26,7 @@ import tabbed from './tabbed'
 import _heading from './heading'
 import blockquote from './blockquote'
 import { list, li } from './list'
+import guidebookguide from './Guide'
 import guidebookimports from './Imports'
 import { details, tip } from './details'
 import { table, thead, tbody, tr, th, td } from './table'
@@ -87,7 +88,8 @@ function components(args: Args) {
       tip,
       tag,
       guidebookimports,
-      tabbed: tabbed(args.uuid)
+      tabbed: tabbed(args.uuid),
+      guidebookguide: guidebookguide(args.uuid)
     },
     typedComponents(args)
   )

--- a/plugins/plugin-client-common/src/components/Content/Markdown/indent.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/indent.ts
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
-import { Graph } from '.'
+function indentArray(strings: string[], indentation: string) {
+  return (indentation.length === 0 ? strings : strings.map(_ => `${indentation}${_}`)).join('\n')
+}
 
-import hoistSubTasks from './hoistSubTasks'
-import propagateTitles from './propagateTitles'
-import deadCodeElimination from './deadCodeElimination'
+export default function indent(str: string, indentation = '    ') {
+  return indentArray(str.split(/\n/), indentation)
+}
 
-export default function optimize(graph: Graph) {
-  return propagateTitles(deadCodeElimination(hoistSubTasks(graph)))
+export function indentAll(strings: string[], indentation: string) {
+  if (indentation.length === 0) {
+    return strings.join('\n')
+  } else {
+    return strings.map(_ => indent(_, indentation)).join('\n')
+  }
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -43,7 +43,7 @@ import inlineSnippets from '../../../controller/snippets'
 import emojis from 'remark-emoji'
 import frontmatter from 'remark-frontmatter'
 
-import { filepathForResponses } from '../../../controller/commentary'
+import { filepathForResponses } from '../../../controller/fetch'
 
 import tip from './rehype-tip'
 import tabbed, { hackIndentation } from './rehype-tabbed'
@@ -197,7 +197,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
    * react.
    */
   private prepareSource() {
-    const sourcePriorToInlining = Markdown.source(this.props)
+    const sourcePriorToInlining = Markdown.source(this.props).trim()
 
     if (this.props.tab && this.props.tab.REPL) {
       setTimeout(async () => {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/isElement.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/isElement.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { Graph } from '.'
+import { Node, Parent } from 'unist'
+import { Element, ElementContent } from 'hast'
 
-import hoistSubTasks from './hoistSubTasks'
-import propagateTitles from './propagateTitles'
-import deadCodeElimination from './deadCodeElimination'
+export function isElement(_: Node | Parent | ElementContent): _ is Element {
+  const elt = _ as Element
+  return elt && typeof elt.tagName === 'string'
+}
 
-export default function optimize(graph: Graph) {
-  return propagateTitles(deadCodeElimination(hoistSubTasks(graph)))
+export default function isElementWithProperties(_: Element | ElementContent | Parent | Node): _ is Element {
+  return isElement(_) && _.properties !== undefined
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/remark-import.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/remark-import.ts
@@ -99,6 +99,12 @@ export function remarkImports() {
         data.hProperties = {
           'data-kui-code-blocks': [] // rehype-imports will populate this
         }
+      } else if (node.name === 'guide') {
+        const data = node.data || (node.data = {})
+        data.hName = 'guidebookguide'
+        data.hProperties = {
+          'data-kui-code-blocks': [] // rehype-imports will populate this
+        }
       }
     })
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/remark-mark.ts
@@ -20,9 +20,14 @@
  * highlighter background.
  */
 export default function plugin(markdownText: string) {
-  const RE_MARK_BASE = '==([^=]+)==([^=])'
+  const RE_MARK_BASE0 = '==([^=]+)=='
+  const RE_MARK_BASE = `${RE_MARK_BASE0}([^=])`
   const RE_MARK = new RegExp(`([^=])${RE_MARK_BASE}`, 'g')
-  const RE_MARK_AT_TOP = new RegExp(`^${RE_MARK_BASE}`, 'g')
+  const RE_MARK_AT_TOP = new RegExp(`^${RE_MARK_BASE}`)
+  const RE_MARK_AT_BOTTOM = new RegExp(`${RE_MARK_BASE0}$`)
 
-  return markdownText.replace(RE_MARK_AT_TOP, '<mark>$1</mark>$2').replace(RE_MARK, '$1<mark>$2</mark>$3')
+  return markdownText
+    .replace(RE_MARK_AT_TOP, '<mark>$1</mark>$2')
+    .replace(RE_MARK, '$1<mark>$2</mark>$3')
+    .replace(RE_MARK_AT_BOTTOM, '<mark>$1</mark>')
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Raw } from 'hast-util-raw'
+import { Element, Parent } from 'hast'
+import { visit } from 'unist-util-visit'
+import { toMdast } from 'hast-util-to-mdast'
+import { Node } from 'hast-util-to-mdast/lib'
+import { toMarkdown } from 'mdast-util-to-markdown'
+
+import { isImports } from './remark-import'
+import indent, { indentAll } from './indent'
+import isElementWithProperties from './isElement'
+import { isTabs, getTabTitle, getTabsDepth } from './components/tabbed'
+
+export { Node }
+
+/**
+ * remark-import smashes in a container directive import. This does
+ * not need to survive the backport to a markdown string.
+ */
+function pruneImports(root: Node) {
+  visit(root, 'element', (node: Element, childIdx: number, parent: Parent) => {
+    if (isImports(node.properties)) {
+      if (parent && Array.isArray(parent.children)) {
+        parent.children.splice(childIdx, 1)
+      }
+    }
+  })
+
+  return root
+}
+
+/**
+ * Something, I think either toMdast to toMarkdown seems to turn
+ * comments into \<!-- and that leading backslash escape messes up re-parsing.
+ */
+const RE_COMMENT = /<!--.*-->/g
+function pruneComments(root: Node) {
+  visit(root, 'raw', (node: Raw) => {
+    node.value = node.value.replace(RE_COMMENT, '')
+  })
+
+  return root
+}
+
+type Visitor = (node: Node, childIdx: number, parent: Parent) => void
+
+function visitDFS(root: Node, type: string, visitors: { pre?: Visitor; post?: Visitor }) {
+  const walk = (node: Node, childIdx: number, parent: Parent) => {
+    if (node.type === type) {
+      if (visitors.pre) {
+        visitors.pre(node, childIdx, parent)
+      }
+    }
+
+    if (isElementWithProperties(node) && Array.isArray(node.children)) {
+      node.children.forEach((child, childIdx) => walk(child, childIdx, node))
+    }
+
+    if (node.type === type) {
+      if (visitors.post) {
+        visitors.post(node, childIdx, parent)
+      }
+    }
+  }
+
+  walk(root, -1, null)
+}
+
+function stringifyTabs(root: Node) {
+  const post = (node: Node) => {
+    if (isElementWithProperties(node) && isTabs(node.properties)) {
+      const tabStackDepth = getTabsDepth(node.properties)
+      const indentation = ''.padStart(tabStackDepth, '    ')
+
+      node['value'] = indentAll(
+        node.children.map(tab => {
+          const tabTitle = getTabTitle(tab)
+
+          // eslint-disable-next-line @typescript-eslint/no-use-before-define
+          const tabContent = indent(toMarkdownString(tab), '    ')
+
+          return `=== "${tabTitle}"
+
+${tabContent}
+`
+        }),
+        indentation
+      )
+
+      delete node.tagName
+      delete node.children
+      delete node.properties
+    }
+  }
+
+  visitDFS(root, 'element', { post })
+
+  return root
+}
+
+/** This is the small bit of munging we need to do */
+function munge(root: Node) {
+  return stringifyTabs(pruneComments(pruneImports(root)))
+}
+
+/**
+ * Turn a hast tree back into a markdown string. We need to do a small
+ * bit of munging on the data structures to facilitate the operation.
+ */
+export default function toMarkdownString(root: Node) {
+  if (typeof root['value'] === 'string' && !Array.isArray(root['children'])) {
+    return root['value']
+  }
+
+  return toMarkdown(toMdast(munge(JSON.parse(JSON.stringify(root)) as Node)))
+    .replace(/(\\)+([=`-][=`-][=`-])/g, '$2')
+    .replace(/(\\)+([*<>`])/g, '$2')
+    .replace(/&#x20;/g, ' ')
+}

--- a/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/impl/PatternFly.tsx
@@ -28,6 +28,7 @@ import {
   CopyIcon as Copy,
   PlusIcon as Add,
   BookIcon as Guidebook,
+  BookOpenIcon as GuidebookOpen,
   TerminalIcon as Terminal,
   OutlinedWindowMaximizeIcon /* TerminalIcon */ as TerminalOnly,
   ColumnsIcon as TerminalPlusSidecar,
@@ -126,6 +127,8 @@ export default function PatternFly4Icons(props: Props) {
       return <Github {...props} />
     case 'Guidebook':
       return <Guidebook {...props} />
+    case 'GuidebookOpen':
+      return <GuidebookOpen {...props} />
     case 'Hamburger':
       return <Hamburger {...props} />
     case 'Help':

--- a/plugins/plugin-client-common/src/components/spi/Icons/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/index.tsx
@@ -37,6 +37,7 @@ export type SupportedIcon =
   | 'Grid'
   | 'Github'
   | 'Guidebook'
+  | 'GuidebookOpen'
   | 'Hamburger'
   | 'Help'
   | 'Info'

--- a/plugins/plugin-client-common/src/controller/card.ts
+++ b/plugins/plugin-client-common/src/controller/card.ts
@@ -17,7 +17,7 @@
 import { Arguments, Registrar, ParsedOptions, UsageModel, ReactResponse } from '@kui-shell/core'
 
 import card from '../components/spi/Card'
-import { fetchMarkdownFile } from './commentary'
+import fetchMarkdownFile from './fetch'
 
 /**
  * card command parsedOptions type

--- a/plugins/plugin-client-common/src/controller/fetch.ts
+++ b/plugins/plugin-client-common/src/controller/fetch.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename, dirname as pathDirname, join as pathJoin } from 'path'
+
+import { Arguments, CommentaryResponse } from '@kui-shell/core'
+import { loadNotebook } from '@kui-shell/plugin-client-common/notebook'
+
+function isUrl(a: string) {
+  return /^https?:/.test(a)
+}
+
+function dirname(a: string) {
+  if (isUrl(a)) {
+    const url = new URL(a)
+    url.pathname = pathDirname(url.pathname)
+    return url.toString()
+  } else {
+    return pathDirname(a)
+  }
+}
+
+export function join(a: string, b: string) {
+  if (isUrl(a)) {
+    const url = new URL(a)
+    url.pathname = pathJoin(url.pathname, b)
+    return url.toString()
+  } else {
+    return pathJoin(a, b)
+  }
+}
+
+export function filepathForResponses(filepath: string) {
+  return join(dirname(filepath), basename(filepath).replace(/\..*$/, '') + '.json')
+}
+
+export default async function fetchMarkdownFile(filepath: string, args: Pick<Arguments, 'REPL'>) {
+  const { pathname } = /^https?:/.test(filepath) ? new URL(filepath) : { pathname: filepath }
+
+  if (!/\.md$/.test(pathname)) {
+    throw new Error('File extension not support')
+  } else {
+    const [data, codeBlockResponses] = await Promise.all([
+      loadNotebook(filepath, args),
+      loadNotebook(filepathForResponses(filepath), args, true)
+    ])
+
+    return {
+      data: typeof data === 'string' ? data : JSON.stringify(data),
+      codeBlockResponses: (typeof codeBlockResponses === 'string'
+        ? JSON.parse(codeBlockResponses)
+        : codeBlockResponses) as CommentaryResponse['props']['codeBlockResponses']
+    }
+  }
+}

--- a/plugins/plugin-client-common/src/controller/guide.ts
+++ b/plugins/plugin-client-common/src/controller/guide.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Debug from 'debug'
+import { Arguments, CommentaryResponse, ParsedOptions, Registrar, Util, encodeComponent } from '@kui-shell/core'
+
+import fetchMarkdownFile from './fetch'
+import { setTabReadonly } from './commentary' // TODO move to core?
+
+const debug = Debug('plugin-client-common/controller/guide')
+
+interface HereOptions extends ParsedOptions {
+  /** Show the content in the current tab? */
+  here: boolean
+}
+
+function response(
+  filepath: string,
+  { data, codeBlockResponses }: Awaited<ReturnType<typeof fetchMarkdownFile>>
+): CommentaryResponse {
+  return {
+    apiVersion: 'kui-shell/v1',
+    kind: 'CommentaryResponse',
+    props: {
+      filepath,
+      children: data,
+      codeBlockResponses
+    }
+  }
+}
+
+async function show(args: Arguments<HereOptions>) {
+  const filepath = args.argvNoOptions[1]
+
+  if (!args.parsedOptions.here) {
+    await args.REPL.qexec(`tab new --cmdline "show --here ${encodeComponent(filepath)}"`)
+    return true
+  }
+
+  setTabReadonly(args)
+  return response(filepath, await fetchMarkdownFile(filepath, args))
+}
+
+async function guide(args: Arguments<HereOptions>) {
+  const filepath = args.argvNoOptions[1]
+
+  if (!args.parsedOptions.here) {
+    await args.REPL.qexec(`tab new --cmdline "guide --here ${encodeComponent(filepath)}"`)
+    return true
+  }
+
+  const { codeBlockResponses } = await fetchMarkdownFile(filepath, args)
+
+  const data = `---
+layout:
+    1: left
+    2: default
+imports:
+    - ${Util.expandHomeDir(filepath)}
+---
+
+::imports
+
+---
+
+::guide
+`
+
+  debug('guide generated markdown', data)
+
+  setTabReadonly(args)
+  return response(filepath, {
+    data,
+    codeBlockResponses
+  })
+}
+
+/**
+ * This plugin introduces the commentary command
+ *
+ */
+export default function registerGuideController(commandTree: Registrar) {
+  const flags = {
+    boolean: ['here']
+  }
+
+  commandTree.listen('/show', show, { outputOnly: true, flags })
+  commandTree.listen('/guide', guide, { outputOnly: true, flags })
+}

--- a/plugins/plugin-client-common/src/plugin.ts
+++ b/plugins/plugin-client-common/src/plugin.ts
@@ -18,16 +18,17 @@ import { Capabilities, Registrar } from '@kui-shell/core'
 
 export default async (registrar: Registrar) => {
   if (!Capabilities.isHeadless()) {
-    await import(/* webpackMode: "lazy" */ './controller/confirm').then(_ => _.default(registrar))
-    await import(/* webpackMode: "lazy" */ './controller/split').then(_ => {
+    await import('./controller/confirm').then(_ => _.default(registrar))
+    await import('./controller/split').then(_ => {
       registrar.listen('/split', _.default, { flags: { boolean: ['inverse'], alias: { split: ['s'] } } })
       registrar.listen('/split-debug', _.debug)
       registrar.listen('/split-count', ({ tab }) => tab.splitCount())
       registrar.listen('/is-split', ({ tab }) => tab.hasSideBySideTerminals())
     })
-    await import(/* webpackMode: "lazy" */ './controller/alert').then(_ => _.default(registrar))
-    await import(/* webpackMode: "lazy" */ './controller/card').then(_ => _.default(registrar))
-    await import(/* webpackMode: "lazy" */ './controller/commentary').then(_ => _.default(registrar))
-    await import(/* webpackMode: "lazy" */ './controller/user-settings').then(_ => _.default(registrar))
+    await import('./controller/alert').then(_ => _.default(registrar))
+    await import('./controller/card').then(_ => _.default(registrar))
+    await import('./controller/commentary').then(_ => _.default(registrar))
+    await import('./controller/guide').then(_ => _.default(registrar))
+    await import('./controller/user-settings').then(_ => _.default(registrar))
   }
 }

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/Input.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/Input.ts
@@ -21,5 +21,5 @@ export interface Tree {
 
 export default interface Input {
   input: string
-  tree: Tree[]
+  tree: (command: string) => Tree[]
 }

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/index.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/index.ts
@@ -22,88 +22,91 @@ import inputs from './inputs'
 import { Tree } from './Input'
 
 inputs.forEach(markdown => {
-  describe(`markdown code block dependence tree ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
-    ''}`, function(this: Common.ISuite) {
-    before(Common.before(this))
-    after(Common.after(this))
+  ;['commentary -f', 'guide'].forEach(command => {
+    describe(`markdown code block dependence tree using command="${command}" ${basename(markdown.input)} ${process.env
+      .MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+      before(Common.before(this))
+      after(Common.after(this))
 
-    const timeout = { timeout: CLI.waitTimeout }
+      const timeout = { timeout: CLI.waitTimeout }
 
-    const checkNode = async (tree: Tree, containerSelector: string) => {
-      console.error('5', tree.name)
-      const nodeSelector = `${containerSelector} .pf-c-tree-view__node`
-      console.error('6', tree.name, nodeSelector)
-      const nodeElement = await this.app.client.$(nodeSelector)
-      console.error('7', tree.name)
-      await nodeElement.waitForExist(timeout)
-      console.error('8', tree.name)
+      const checkNode = async (tree: Tree, containerSelector: string) => {
+        console.error('5', tree.name)
+        const nodeSelector = `${containerSelector} .pf-c-tree-view__node`
+        console.error('6', tree.name, nodeSelector)
+        const nodeElement = await this.app.client.$(nodeSelector)
+        console.error('7', tree.name)
+        await nodeElement.waitForExist(timeout)
+        console.error('8', tree.name)
 
-      const nameSelector = '.pf-c-tree-view__node-text'
-      console.error('9', tree.name)
-      const nameElement = await nodeElement.$(nameSelector)
-      console.error('10', tree.name)
-      await nameElement.waitForExist(timeout)
-      console.error('11', tree.name)
+        const nameSelector = '.pf-c-tree-view__node-text'
+        console.error('9', tree.name)
+        const nameElement = await nodeElement.$(nameSelector)
+        console.error('10', tree.name)
+        await nameElement.waitForExist(timeout)
+        console.error('11', tree.name)
 
-      await this.app.client.waitUntil(async () => {
-        const actualText = await nameElement.getText()
-        if (actualText !== tree.name) {
-          console.error('12a', tree.name, actualText)
-          console.error('12b', containerSelector)
+        await this.app.client.waitUntil(async () => {
+          const actualText = await nameElement.getText()
+          if (actualText !== tree.name) {
+            console.error('12a', tree.name, actualText)
+            console.error('12b', containerSelector)
+          }
+          return actualText === tree.name
+        }, timeout)
+        console.error('13', tree.name)
+      }
+
+      const scanNode = async (tree: Tree, containerSelector: string) => {
+        await checkNode(tree, containerSelector)
+
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        await scanNodes(tree.children, containerSelector)
+      }
+
+      const scanNodes = async (children: Tree[], containerSelector: string) => {
+        if (children) {
+          await Promise.all(
+            children.map(async (subtree, idx) => {
+              const listItemSelector = `${containerSelector} > ul > li:nth-child(${idx + 1})`
+              const listItemElement = await this.app.client.$(listItemSelector)
+              await listItemElement.waitForExist(timeout)
+
+              const isExpanded = await listItemElement.getAttribute('aria-expanded')
+              if (!isExpanded) {
+                await listItemElement.scrollIntoView()
+                await listItemElement.click()
+              }
+
+              await scanNode(subtree, listItemSelector)
+
+              if (!isExpanded) {
+                await listItemElement.scrollIntoView()
+                await listItemElement.click()
+              }
+            })
+          )
         }
-        return actualText === tree.name
-      }, timeout)
-      console.error('13', tree.name)
-    }
-
-    const scanNode = async (tree: Tree, containerSelector: string) => {
-      await checkNode(tree, containerSelector)
-
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      await scanNodes(tree.children, containerSelector)
-    }
-
-    const scanNodes = async (children: Tree[], containerSelector: string) => {
-      if (children) {
-        await Promise.all(
-          children.map(async (subtree, idx) => {
-            const listItemSelector = `${containerSelector} > ul > li:nth-child(${idx + 1})`
-            const listItemElement = await this.app.client.$(listItemSelector)
-            await listItemElement.waitForExist(timeout)
-
-            const isExpanded = await listItemElement.getAttribute('aria-expanded')
-            if (!isExpanded) {
-              await listItemElement.scrollIntoView()
-              await listItemElement.click()
-            }
-
-            await scanNode(subtree, listItemSelector)
-
-            if (!isExpanded) {
-              await listItemElement.scrollIntoView()
-              await listItemElement.click()
-            }
-          })
-        )
       }
-    }
 
-    it(`should load the markdown and show dependence tree with root=${markdown.tree[0].name}`, async () => {
-      try {
-        await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
+      const tree = markdown.tree(command)
+      it(`should load the markdown and show dependence tree with root=${tree[0].name}`, async () => {
+        try {
+          await CLI.command(`${command} ${encodeComponent(markdown.input)}`, this.app)
 
-        console.error('1')
-        const treeSelector = '.kui--dependence-tree'
-        console.error('2')
-        const treeElement = await this.app.client.$(treeSelector)
-        console.error('3')
-        await treeElement.waitForExist(timeout)
-        console.error('4')
+          console.error('1')
+          const treeSelector = '.kui--dependence-tree'
+          console.error('2')
+          const treeElement = await this.app.client.$(treeSelector)
+          console.error('3')
+          await treeElement.waitForExist(timeout)
+          console.error('4')
 
-        await scanNodes(markdown.tree, treeSelector)
-      } catch (err) {
-        await Common.oops(this, true)(err)
-      }
+          await scanNodes(tree, treeSelector)
+        } catch (err) {
+          await Common.oops(this, true)(err)
+        }
+      })
     })
   })
 })

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/1.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/1.ts
@@ -32,17 +32,22 @@ const importd: Tree = {
   ]
 }
 
-const snippetsInTab3 = {
-  name: 'snippets-in-tab3.md',
+const prerequisites = {
+  name: 'Prerequisites',
+  children: [importa, importe, importd]
+}
+
+const mainTasks = {
+  name: 'Main Tasks',
   children: [option2Tab2]
 }
 
 const IN1: Input = {
   input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model1.md'),
-  tree: [
+  tree: () => [
     {
-      name: 'Tasks',
-      children: [snippetsInTab3, importa, importe, importd]
+      name: 'snippets-in-tab3.md',
+      children: [prerequisites, mainTasks]
     }
   ]
 }

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/2.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/2.ts
@@ -25,12 +25,22 @@ const snippetsInTab4: Tree = {
   ]
 }
 
+const prerequisites = {
+  name: 'Prerequisites',
+  children: [importa, importe]
+}
+
+const mainTasks = {
+  name: 'Main Tasks',
+  children: snippetsInTab4.children
+}
+
 const IN2: Input = {
   input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model2.md'),
-  tree: [
+  tree: () => [
     {
-      name: 'Tasks',
-      children: [snippetsInTab4, importa, importe]
+      name: snippetsInTab4.name,
+      children: [prerequisites, mainTasks]
     }
   ]
 }

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/3.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/3.ts
@@ -26,12 +26,22 @@ const snippetsInTab5: Tree = {
   ]
 }
 
+const prerequisites = {
+  name: 'Prerequisites',
+  children: [importa, importe]
+}
+
+const mainTasks = {
+  name: 'Main Tasks',
+  children: snippetsInTab5.children
+}
+
 const IN3: Input = {
   input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model3.md'),
-  tree: [
+  tree: () => [
     {
-      name: 'Tasks',
-      children: [snippetsInTab5, importa, importe]
+      name: snippetsInTab5.name,
+      children: [prerequisites, mainTasks]
     }
   ]
 }

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/4.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/4.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { join } from 'path'
+
 import Input, { Tree } from '../Input'
 import { importa, importe, importd } from './1'
 
@@ -22,12 +24,14 @@ const snippetsInTab5: Tree = {
   children: [{ name: 'Option 2: Tab2', children: [{ name: 'echo XXX' }] }]
 }
 
+const filename = 'guidebook-tree-model4.md'
+
 const IN4: Input = {
-  input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model4.md'),
-  tree: [
+  input: require.resolve(join('@kui-shell/plugin-client-common/tests/data', filename)),
+  tree: (command: string) => [
     {
-      name: 'Tasks',
-      children: [importd, snippetsInTab5, importa, importe]
+      name: command === 'guide' ? filename : 'Tasks',
+      children: [importd, importa, importe, snippetsInTab5]
     }
   ]
 }

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/5.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/5.ts
@@ -19,12 +19,7 @@ import { importd } from './1'
 
 const IN5: Input = {
   input: require.resolve('@kui-shell/plugin-client-common/tests/data/guidebook-tree-model5.md'),
-  tree: [
-    {
-      name: 'Tasks',
-      children: [importd]
-    }
-  ]
+  tree: () => [importd]
 }
 
 export default IN5

--- a/plugins/plugin-client-common/src/test/core/markdown/wizards.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/wizards.ts
@@ -20,7 +20,24 @@ import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
 
 const ROOT = join(dirname(require.resolve('@kui-shell/plugin-client-common/notebooks/wizard.md')), '..')
 
-const steps = [
+interface Step {
+  name: string
+  description: string
+  body: string
+  codeBlocks: { index: number; output: string }[]
+}
+
+interface Input {
+  input: string
+  title: string
+  description: string
+  expectedSplitCount: number
+  expectedCodeBlockTasks: number
+  steps: Step[]
+  notIn?: (command: string) => boolean
+}
+
+const steps: Step[] = [
   {
     name: 'Step1Title',
     description: 'Step1Description',
@@ -38,7 +55,7 @@ const steps = [
   }
 ]
 
-const IN1 = {
+const IN1: Input = {
   input: join(ROOT, 'notebooks/wizard.md'),
   title: 'WizardTitle',
   description: 'WizardDescription',
@@ -48,7 +65,7 @@ const IN1 = {
 }
 
 // make sure we can display wizards in tabs with splits
-const IN2 = {
+const IN2: Input = {
   input: join(ROOT, 'tests/data/wizard-with-splits.md'),
   title: 'WizardTitleWithSplits',
   description: 'WizardDescriptionWithSplits',
@@ -58,7 +75,7 @@ const IN2 = {
 }
 
 // make sure we can display wizards in tabs with splits
-const IN3 = {
+const IN3: Input = {
   input: join(ROOT, 'tests/data/wizard-steps-in-topmatter.md'),
   title: 'Getting Started with Knative',
   description: 'WizardDescriptionInTopmatter',
@@ -67,11 +84,15 @@ const IN3 = {
   steps: [
     { name: 'TestRewritingOfStepName', body: 'This topic describes', description: '', codeBlocks: [] },
     { name: 'Before you begin', body: 'Before you can get started', description: 'TestDescription2', codeBlocks: [] }
-  ]
+  ],
+
+  // the guide does not yet show non-code block steps
+  // i don't think we'll ever want this?
+  notIn: (command: string) => command === 'guide'
 }
 
 // sequential execution of code blocks
-const IN4 = {
+const IN4: Input = {
   input: join(ROOT, 'tests/data/wizard-steps-in-topmatter2.md'),
   title: 'WizardTitle',
   description: 'WizardDescription',
@@ -85,7 +106,7 @@ const IN4 = {
 }
 
 // nested choice
-const IN5 = {
+const IN5: Input = {
   input: join(ROOT, 'tests/data/nested-choice1.md'),
   title: 'WizardTitle',
   description: 'WizardDescription',
@@ -95,7 +116,7 @@ const IN5 = {
 }
 
 // nested choice
-const IN6 = {
+const IN6: Input = {
   input: join(ROOT, 'tests/data/nested-choice2.md'),
   title: 'WizardTitle',
   description: 'WizardDescription',
@@ -114,62 +135,87 @@ const IN6 = {
   ]
 }
 ;[IN1, IN2, IN3, IN4, IN5, IN6].forEach(markdown => {
-  describe(`wizards in markdown ${basename(markdown.input)} ${process.env.MOCHA_RUN_TARGET ||
-    ''}`, function(this: Common.ISuite) {
-    before(Common.before(this))
-    after(Common.after(this))
+  ;['guide', 'commentary -f'].forEach(command => {
+    if (markdown.notIn && markdown.notIn(command)) {
+      return
+    }
 
-    it('should load markdown and show a wizard UI', async () => {
-      try {
-        await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
-        await this.app.client.$(Selectors.Wizard.wizard).then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
-      } catch (err) {
-        await Common.oops(this, true)(err)
+    describe(`wizards in markdown command="${command}" input="${basename(markdown.input)}" ${process.env
+      .MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+      before(Common.before(this))
+      after(Common.after(this))
+
+      it('should load markdown and show a wizard UI', async () => {
+        try {
+          await CLI.command(`${command} ${encodeComponent(markdown.input)}`, this.app)
+          await this.app.client.$(Selectors.Wizard.wizard).then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+        } catch (err) {
+          await Common.oops(this, true)(err)
+        }
+      })
+
+      it(`should show wizard title ${markdown.title}`, () =>
+        this.app.client
+          .$(Selectors.Wizard.withTitle(markdown.title))
+          .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+          .catch(Common.oops(this, true)))
+
+      it(`should show wizard description ${markdown.description}`, async () => {
+        try {
+          const elt = await this.app.client.$(Selectors.Wizard.description)
+          await elt.waitForExist({ timeout: CLI.waitTimeout })
+          await this.app.client.waitUntil(
+            async () => {
+              const actualText = await elt.getText()
+              return actualText.includes(markdown.description)
+            },
+            { timeout: CLI.waitTimeout }
+          )
+        } catch (err) {
+          await Common.oops(this, true)(err)
+        }
+      })
+
+      if (command !== 'guide') {
+        it(`should show "n of ${markdown.expectedCodeBlockTasks}" in progress bar`, () =>
+          this.app.client.waitUntil(async () => {
+            const actualMeasureText = await this.app.client.$(Selectors.Wizard.progressMeasure).then(_ => _.getText())
+            const match = actualMeasureText.match(/of (\d+)/)
+
+            return match && parseInt(match[1], 10) === markdown.expectedCodeBlockTasks
+          }))
+
+        it(`should have ${markdown.expectedSplitCount} splits`, () =>
+          ReplExpect.splitCount(markdown.expectedSplitCount))
       }
-    })
 
-    it(`should show wizard title ${markdown.title}`, () =>
-      this.app.client
-        .$(Selectors.Wizard.withTitle(markdown.title))
-        .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
-        .catch(Common.oops(this, true)))
+      markdown.steps.forEach((step, idx) => {
+        if (idx === 0) {
+          it(`should show wizard body ${step.body}`, async () => {
+            try {
+              const elt = await this.app.client.$(Selectors.Wizard.body)
+              await elt.waitForExist({ timeout: CLI.waitTimeout })
+              await this.app.client.waitUntil(
+                async () => {
+                  const actualText = await elt.getText()
+                  return actualText.includes(step.body)
+                },
+                { timeout: CLI.waitTimeout }
+              )
+            } catch (err) {
+              await Common.oops(this, true)(err)
+            }
+          })
+        }
 
-    it(`should show wizard description ${markdown.description}`, async () => {
-      try {
-        const elt = await this.app.client.$(Selectors.Wizard.description)
-        await elt.waitForExist({ timeout: CLI.waitTimeout })
-        await this.app.client.waitUntil(
-          async () => {
-            const actualText = await elt.getText()
-            return actualText.includes(markdown.description)
-          },
-          { timeout: CLI.waitTimeout }
-        )
-      } catch (err) {
-        await Common.oops(this, true)(err)
-      }
-    })
-
-    it(`should show "n of ${markdown.expectedCodeBlockTasks}" in progress bar`, () =>
-      this.app.client.waitUntil(async () => {
-        const actualMeasureText = await this.app.client.$(Selectors.Wizard.progressMeasure).then(_ => _.getText())
-        const match = actualMeasureText.match(/of (\d+)/)
-
-        return match && parseInt(match[1], 10) === markdown.expectedCodeBlockTasks
-      }))
-
-    it(`should have ${markdown.expectedSplitCount} splits`, () => ReplExpect.splitCount(markdown.expectedSplitCount))
-
-    markdown.steps.forEach((step, idx) => {
-      if (idx === 0) {
-        it(`should show wizard body ${step.body}`, async () => {
+        it(`should show nav item ${idx} title ${step.name}`, async () => {
           try {
-            const elt = await this.app.client.$(Selectors.Wizard.body)
+            const elt = await this.app.client.$(Selectors.Wizard.navItemTitle(idx))
             await elt.waitForExist({ timeout: CLI.waitTimeout })
             await this.app.client.waitUntil(
               async () => {
                 const actualText = await elt.getText()
-                return actualText.includes(step.body)
+                return actualText === step.name
               },
               { timeout: CLI.waitTimeout }
             )
@@ -177,117 +223,105 @@ const IN6 = {
             await Common.oops(this, true)(err)
           }
         })
-      }
 
-      it(`should show nav item ${idx} title ${step.name}`, async () => {
-        try {
-          const elt = await this.app.client.$(Selectors.Wizard.navItemTitle(idx))
-          await elt.waitForExist({ timeout: CLI.waitTimeout })
-          await this.app.client.waitUntil(
-            async () => {
-              const actualText = await elt.getText()
-              return actualText === step.name
-            },
-            { timeout: CLI.waitTimeout }
-          )
-        } catch (err) {
-          await Common.oops(this, true)(err)
-        }
-      })
-
-      it(`should show nav item ${idx} description ${step.description}`, async () => {
-        try {
-          const elt = await this.app.client.$(Selectors.Wizard.navItemDescription(idx))
-          await elt.waitForExist({ timeout: CLI.waitTimeout })
-          await this.app.client.waitUntil(
-            async () => {
-              const actualText = await elt.getText()
-              return actualText === step.description
-            },
-            { timeout: CLI.waitTimeout }
-          )
-        } catch (err) {
-          await Common.oops(this, true)(err)
-        }
-      })
-
-      step.codeBlocks.forEach((codeBlock, codeBlockIdx) => {
-        it(`should show nav item ${idx} progress step ${codeBlockIdx}`, async () => {
-          try {
-            const elt = await this.app.client.$(Selectors.Wizard.navItemProgressStep(idx, codeBlockIdx))
-            await elt.waitForExist({ timeout: CLI.waitTimeout })
-          } catch (err) {
-            await Common.oops(this, true)(err)
-          }
-        })
-      })
-    })
-  })
-
-  describe(`sequential execution of code blocks in wizards in markdown ${basename(markdown.input)} ${process.env
-    .MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
-    before(Common.before(this))
-    after(Common.after(this))
-
-    it('should load markdown and show a wizard UI', async () => {
-      try {
-        await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
-        await this.app.client.$(Selectors.Wizard.wizard).then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
-      } catch (err) {
-        await Common.oops(this, true)(err)
-      }
-    })
-
-    const stepsWithCodeBlocks = markdown.steps
-      .map((step, idx) => ({ step, idx }))
-      .filter(_ => Array.isArray(_.step.codeBlocks) && _.step.codeBlocks.length > 0)
-
-    if (stepsWithCodeBlocks.length > 1) {
-      it('should show a play button for the first code blocks in the first step (with code blocks)', async () => {
-        try {
-          const firstBlockInFirstStep = stepsWithCodeBlocks[0].step.codeBlocks[0]
-          const codeBlock = await this.app.client.$(Selectors.Markdown.codeBlock(firstBlockInFirstStep.index))
-          await codeBlock.waitForExist({ timeout: CLI.waitTimeout })
-          await codeBlock.$(Selectors.Markdown.runButton).then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
-        } catch (err) {
-          await Common.oops(this, true)(err)
-        }
-      })
-
-      stepsWithCodeBlocks.slice(1).forEach(({ step, idx }) => {
-        it(`should switch to step ${idx}`, async () => {
-          try {
-            const button = await this.app.client.$(Selectors.Wizard.navItemSwitchToButton(idx))
-
-            await this.app.client.waitUntil(async () => {
-              return !(await button.getAttribute('class')).includes(Selectors.Wizard.isCurrentStep)
-            })
-
-            await button.waitForExist({ timeout: CLI.waitTimeout })
-            await button.click()
-
-            await this.app.client.waitUntil(async () => {
-              return (await button.getAttribute('class')).includes(Selectors.Wizard.isCurrentStep)
-            })
-          } catch (err) {
-            await Common.oops(this, true)(err)
-          }
-        })
-
-        step.codeBlocks.forEach(block => {
-          it(`should *not* show a play button for code block ${block.index} in step ${idx}`, async () => {
+        if (step.description) {
+          it(`should show nav item ${idx} description ${step.description}`, async () => {
             try {
-              const codeBlock = await this.app.client.$(Selectors.Markdown.codeBlock(block.index))
-              await codeBlock.waitForExist({ timeout: CLI.waitTimeout })
-              await codeBlock
-                .$(Selectors.Markdown.runButton)
-                .then(_ => _.waitForDisplayed({ reverse: true, timeout: CLI.waitTimeout }))
+              const elt = await this.app.client.$(Selectors.Wizard.navItemDescription(idx))
+              await elt.waitForExist({ timeout: CLI.waitTimeout })
+              await this.app.client.waitUntil(
+                async () => {
+                  const actualText = await elt.getText()
+                  return actualText === step.description
+                },
+                { timeout: CLI.waitTimeout }
+              )
             } catch (err) {
               await Common.oops(this, true)(err)
             }
           })
-        })
+        }
+
+        if (command !== 'guide') {
+          step.codeBlocks.forEach((codeBlock, codeBlockIdx) => {
+            it(`should show nav item ${idx} progress step ${codeBlockIdx}`, async () => {
+              try {
+                const elt = await this.app.client.$(Selectors.Wizard.navItemProgressStep(idx, codeBlockIdx))
+                await elt.waitForExist({ timeout: CLI.waitTimeout })
+              } catch (err) {
+                await Common.oops(this, true)(err)
+              }
+            })
+          })
+        }
       })
-    }
+    })
+
+    describe(`sequential execution of code blocks in wizards in markdown ${basename(markdown.input)} ${process.env
+      .MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+      before(Common.before(this))
+      after(Common.after(this))
+
+      it('should load markdown and show a wizard UI', async () => {
+        try {
+          await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
+          await this.app.client.$(Selectors.Wizard.wizard).then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+        } catch (err) {
+          await Common.oops(this, true)(err)
+        }
+      })
+
+      const stepsWithCodeBlocks = markdown.steps
+        .map((step, idx) => ({ step, idx }))
+        .filter(_ => Array.isArray(_.step.codeBlocks) && _.step.codeBlocks.length > 0)
+
+      if (stepsWithCodeBlocks.length > 1) {
+        it('should show a play button for the first code blocks in the first step (with code blocks)', async () => {
+          try {
+            const firstBlockInFirstStep = stepsWithCodeBlocks[0].step.codeBlocks[0]
+            const codeBlock = await this.app.client.$(Selectors.Markdown.codeBlock(firstBlockInFirstStep.index))
+            await codeBlock.waitForExist({ timeout: CLI.waitTimeout })
+            await codeBlock.$(Selectors.Markdown.runButton).then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+          } catch (err) {
+            await Common.oops(this, true)(err)
+          }
+        })
+
+        stepsWithCodeBlocks.slice(1).forEach(({ step, idx }) => {
+          it(`should switch to step ${idx}`, async () => {
+            try {
+              const button = await this.app.client.$(Selectors.Wizard.navItemSwitchToButton(idx))
+
+              await this.app.client.waitUntil(async () => {
+                return !(await button.getAttribute('class')).includes(Selectors.Wizard.isCurrentStep)
+              })
+
+              await button.waitForExist({ timeout: CLI.waitTimeout })
+              await button.click()
+
+              await this.app.client.waitUntil(async () => {
+                return (await button.getAttribute('class')).includes(Selectors.Wizard.isCurrentStep)
+              })
+            } catch (err) {
+              await Common.oops(this, true)(err)
+            }
+          })
+
+          step.codeBlocks.forEach(block => {
+            it(`should *not* show a play button for code block ${block.index} in step ${idx}`, async () => {
+              try {
+                const codeBlock = await this.app.client.$(Selectors.Markdown.codeBlock(block.index))
+                await codeBlock.waitForExist({ timeout: CLI.waitTimeout })
+                await codeBlock
+                  .$(Selectors.Markdown.runButton)
+                  .then(_ => _.waitForDisplayed({ reverse: true, timeout: CLI.waitTimeout }))
+              } catch (err) {
+                await Common.oops(this, true)(err)
+              }
+            })
+          })
+        })
+      }
+    })
   })
 })

--- a/plugins/plugin-client-common/web/scss/components/Wizard/Imports.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Imports.scss
@@ -27,27 +27,50 @@
   }
 }
 
-@include Scrollback {
-  @include RightStrip {
-    @include DependenceTree {
-      $code-font-size: 0.6875rem;
-      $font-size: 0.75rem;
-      $spacer-md: 0.875rem;
-      $guide-top: 0.6875rem;
-      $guide-width: 0.5625rem;
+@mixin DependenceTreeSubTaskIcon {
+  .kui--dependence-tree-subtask--icon {
+    @content;
+  }
+}
 
+@mixin SmallerFonts {
+  @include DependenceTree {
+    $code-font-size: 0.6875rem;
+    $font-size: 0.75rem;
+    $spacer-md: 0.875rem;
+    $guide-top: 0.6875rem;
+    $guide-width: 0.5625rem;
+
+    font-size: $font-size;
+
+    ul {
+      /** Overrides some other LeftStrip rules */
       font-size: $font-size;
-      --pf-global--FontSize--md: #{0.5 * $font-size};
-      --pf-global--spacer--sm: #{0.333 * $font-size};
-      --pf-global--spacer--md: #{$spacer-md};
-      --pf-c-tree-view--m-guides__node--before--Top: #{$guide-top};
-      --pf-c-tree-view--m-guides__node--before--Width: #{$guide-width};
+    }
 
-      code {
-        font-size: $code-font-size;
-      }
+    --pf-global--FontSize--md: #{0.5 * $font-size};
+    --pf-global--spacer--sm: #{0.333 * $font-size};
+    --pf-global--spacer--md: #{$spacer-md};
+    --pf-c-tree-view--m-guides__node--before--Top: #{$guide-top};
+    --pf-c-tree-view--m-guides__node--before--Width: #{$guide-width};
+
+    code {
+      font-size: $code-font-size;
     }
   }
+}
+
+@include Scrollback {
+  @include LeftStrip {
+    @include SmallerFonts;
+  }
+  @include RightStrip {
+    @include SmallerFonts;
+  }
+}
+
+@include DependenceTreeSubTaskIcon {
+  color: var(--color-brand-01);
 }
 
 @include DependenceTree {

--- a/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
@@ -15,6 +15,7 @@
  */
 
 @import 'mixins';
+@import 'index';
 @import '../ExpandableSection/mixins';
 
 @include Wizard {

--- a/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
@@ -21,7 +21,7 @@
 }
 
 @mixin WizardTitle {
-  .kui--wizard-header-title {
+  .pf-c-wizard__title {
     @content;
   }
 }
@@ -45,7 +45,7 @@
 }
 
 @mixin WizardDescription {
-  .kui--wizard-header-description {
+  .pf-c-wizard__description {
     @content;
   }
 }


### PR DESCRIPTION
This PR adds 
- a `::guide` markdown directive that infers a wizard ui from the guidebook DAG model.
- a `guide` command that does some syntactic sugaring over that directive, allowing users to point to the underlying markdown file, without having to worry about the markdown directive.

It includes plenty of fixes for the "choice frontier" logic.

<img width="1303" alt="inferred wizard v4" src="https://user-images.githubusercontent.com/4741620/160250638-6a388042-26dd-4b3d-8f25-1120cf0cf698.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
