### PR TITLE
fix(plugins/plugin-client-common): support for tips in guidebook wizard steps

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
@@ -83,28 +83,46 @@ function visitDFS(root: Node, type: string, visitors: { pre?: Visitor; post?: Vi
 
 function stringifyTabs(root: Node) {
   const post = (node: Node) => {
-    if (isElementWithProperties(node) && isTabs(node.properties)) {
-      const tabStackDepth = getTabsDepth(node.properties)
-      const indentation = ''.padStart(tabStackDepth, '    ')
+    if (isElementWithProperties(node)) {
+      if (isTabs(node.properties)) {
+        const tabStackDepth = getTabsDepth(node.properties)
+        const indentation = ''.padStart(tabStackDepth, '    ')
 
-      node['value'] = indentAll(
-        node.children.map(tab => {
-          const tabTitle = getTabTitle(tab)
+        node['value'] = indentAll(
+          node.children.map(tab => {
+            const tabTitle = getTabTitle(tab)
 
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          const tabContent = indent(toMarkdownString(tab), '    ')
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            const tabContent = indent(toMarkdownString(tab))
 
-          return `=== "${tabTitle}"
+            return `=== "${tabTitle}"
 
 ${tabContent}
 `
-        }),
-        indentation
-      )
+          }),
+          indentation
+        )
 
-      delete node.tagName
-      delete node.children
-      delete node.properties
+        delete node.tagName
+        delete node.children
+        delete node.properties
+      } else if (node.tagName === 'tip') {
+        const { className, title, open } = node.properties
+
+        const tipContent = node.children
+          .map(toMarkdownString) // eslint-disable-line @typescript-eslint/no-use-before-define
+          .map(_ => indent(_))
+          .join('\n')
+
+        node['value'] = `!!!${open ? '+' : ''} ${className} "${title}"
+
+${tipContent}
+`
+
+        delete node.tagName
+        delete node.children
+        delete node.properties
+      }
     }
   }
 


### PR DESCRIPTION

This PR updates `toMarkdownString()` i.e. the logic to turn the markdown AST back into a string, so that it supports tips.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
