### PR TITLE
feat(plugins/plugin-client-common): automate selection of platform choices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@types/tmp": "0.2.3",
         "@types/turndown": "5.0.1",
         "@types/uuid": "8.3.4",
+        "@types/which": "2.0.1",
         "@types/yargs-parser": "20.2.1",
         "@typescript-eslint/eslint-plugin": "2.25.0",
         "@typescript-eslint/parser": "2.25.0",
@@ -1514,9 +1515,9 @@
       "dev": true
     },
     "node_modules/@types/which": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
-      "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -5336,6 +5337,12 @@
         "@types/which": "^1.3.2",
         "which": "^2.0.2"
       }
+    },
+    "node_modules/edge-paths/node_modules/@types/which": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
+      "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+      "dev": true
     },
     "node_modules/edge-paths/node_modules/which": {
       "version": "2.0.2",
@@ -17860,7 +17867,22 @@
         "tmp": "0.2.1",
         "turndown": "7.1.1",
         "turndown-plugin-gfm": "1.0.2",
-        "url": "0.11.0"
+        "url": "0.11.0",
+        "which": "2.0.2"
+      }
+    },
+    "plugins/plugin-client-common/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "plugins/plugin-client-default": {
@@ -18606,7 +18628,18 @@
         "tmp": "0.2.1",
         "turndown": "7.1.1",
         "turndown-plugin-gfm": "1.0.2",
-        "url": "0.11.0"
+        "url": "0.11.0",
+        "which": "2.0.2"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "@kui-shell/plugin-core-support": {
@@ -19453,9 +19486,9 @@
       "dev": true
     },
     "@types/which": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
-      "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
     },
     "@types/ws": {
@@ -22391,6 +22424,12 @@
         "which": "^2.0.2"
       },
       "dependencies": {
+        "@types/which": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
+          "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+          "dev": true
+        },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@types/tmp": "0.2.3",
     "@types/turndown": "5.0.1",
     "@types/uuid": "8.3.4",
+    "@types/which": "2.0.1",
     "@types/yargs-parser": "20.2.1",
     "@typescript-eslint/eslint-plugin": "2.25.0",
     "@typescript-eslint/parser": "2.25.0",

--- a/packages/builder/dist/electron/builders/electron.js
+++ b/packages/builder/dist/electron/builders/electron.js
@@ -266,7 +266,9 @@ const platform = process.argv[2]
 const arch = process.argv[3]
 const launcher = process.argv[4]
 
-const download = undefined // platform !== 'darwin' ? undefined : require('../electron-get-options')
+const download = undefined
+// const download = platform !== 'darwin' ? undefined : require('../electron-get-options')
+// ^^^^ in case you need to hack electron download options in the future
 
 //
 // invoke electron-packager, catching any errors it might throw

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -46,7 +46,8 @@
     "tmp": "0.2.1",
     "turndown": "7.1.1",
     "turndown-plugin-gfm": "1.0.2",
-    "url": "0.11.0"
+    "url": "0.11.0",
+    "which": "2.0.2"
   },
   "kui": {
     "webpack": {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
@@ -42,6 +42,7 @@ import order from './code/graph/order'
 import compile from './code/graph/compile'
 import progress from './code/graph/progress'
 
+import { Choices } from '..'
 import Tree from './ImportsTree'
 import Icons from '../../../spi/Icons'
 import Spinner from '../../../Views/Terminal/Block/Spinner'
@@ -54,7 +55,7 @@ const debug = Debug('plugins/plugin-client-common/components/Content/Markdown/Im
 
 type Status = ProgressStepState['status']
 
-interface Props {
+type Props = Choices & {
   imports: CodeBlockProps[]
 }
 
@@ -83,7 +84,7 @@ class ImportsImpl extends React.PureComponent<Props, State> {
   }
 
   public static getDerivedStateFromProps(props: Props, state?: State) {
-    const newGraph = compile(props.imports, 'sequence')
+    const newGraph = compile(props.imports, props.choices, 'sequence')
     const noChange = state && sameGraph(state.imports, newGraph)
 
     const imports = noChange ? state.imports : order(newGraph)
@@ -500,10 +501,16 @@ class LabelWithStatus extends React.PureComponent<LabelWithStatusProps> {
   }
 }
 
-export default function guidebookImports(props: Props) {
-  const imports = props['data-kui-code-blocks']
-    ? JSON.parse(props['data-kui-code-blocks']).map(_ => JSON.parse(Buffer.from(_, 'base64').toString()))
-    : undefined
+export default function guidebookImportsWrapper(choices: Choices['choices']) {
+  return function guidebookImports(props: Props) {
+    const imports = props['data-kui-code-blocks']
+      ? JSON.parse(props['data-kui-code-blocks']).map(_ => JSON.parse(Buffer.from(_, 'base64').toString()))
+      : undefined
 
-  return !imports ? <span className="all-pad">No imports were found</span> : <ImportsImpl imports={imports} />
+    return !imports ? (
+      <span className="all-pad">No imports were found</span>
+    ) : (
+      <ImportsImpl imports={imports} choices={choices} />
+    )
+  }
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/Progress.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/Progress.tsx
@@ -18,8 +18,6 @@ import React from 'react'
 import { i18n } from '@kui-shell/core'
 import { ProgressVariant } from '@patternfly/react-core'
 
-import { State as WizardState } from '.'
-
 import {
   ReadinessHandler,
   emitCodeBlockReadiness,
@@ -30,6 +28,8 @@ import {
 import blocks from '../code/graph/linearize'
 import progress from '../code/graph/progress'
 import { OrderedGraph } from '../code/graph'
+
+import { Choices } from '../..'
 import { ProgressStepState } from '../../../ProgressStepper'
 
 const PatternFlyProgress = React.lazy(() => import('@patternfly/react-core').then(_ => ({ default: _.Progress })))
@@ -38,7 +38,7 @@ const strings = i18n('plugin-client-common', 'code')
 
 type Status = ProgressStepState['status']
 
-type Props = Pick<WizardState, 'choices'> & {
+type Props = Choices & {
   /** Title to display alongside the progress bar */
   title: string
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/collapseMadeChoices.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/collapseMadeChoices.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Graph, isChoice, isSequence, isParallel, isSubTask, isTitledSteps, emptySequence } from '.'
+
+import { ChoiceState } from '../../..'
+
+function collapse(graph: Graph, choices: ChoiceState): Graph {
+  if (isChoice(graph)) {
+    const madeChoiceTitle = choices.get(graph.group)
+    if (madeChoiceTitle) {
+      const chosenSubtree = graph.choices.find(
+        _ => _.title.localeCompare(madeChoiceTitle, undefined, { sensitivity: 'accent' }) === 0
+      )
+      if (chosenSubtree) {
+        // yes! we can collapse to the chosen subgraph
+        const chosenSubgraph =
+          isSequence(chosenSubtree.graph) && chosenSubtree.graph.sequence.length === 1
+            ? chosenSubtree.graph.sequence[0]
+            : chosenSubtree.graph
+
+        return collapse(chosenSubgraph, choices)
+      }
+    }
+
+    // otherwise, scan the subgraphs across the choices
+    const subchoices = graph.choices
+      .map(_ => {
+        const subgraph = collapse(_.graph, choices)
+        if (subgraph) {
+          return Object.assign({}, _, { graph: subgraph })
+        }
+      })
+      .filter(Boolean)
+    if (subchoices.length > 0) {
+      return Object.assign({}, graph, { choices: subchoices })
+    }
+  } else if (isSequence(graph)) {
+    const subgraphs = graph.sequence.map(_ => collapse(_, choices)).filter(Boolean)
+
+    if (subgraphs.length > 0) {
+      const sequence = subgraphs.every(isSequence) ? subgraphs.flatMap(_ => _.sequence) : subgraphs
+
+      return Object.assign({}, graph, { sequence })
+    }
+  } else if (isParallel(graph)) {
+    const parallel = graph.parallel.map(_ => collapse(_, choices)).filter(Boolean)
+
+    if (parallel.length > 0) {
+      return Object.assign({}, graph, { parallel })
+    }
+  } else if (isSubTask(graph)) {
+    const subgraph = collapse(graph.graph, choices)
+    if (subgraph) {
+      return Object.assign({}, graph, { graph: subgraph })
+    }
+  } else if (isTitledSteps(graph)) {
+    const steps = graph.steps
+      .map(_ => {
+        const subgraph = collapse(_.graph, choices)
+        if (subgraph) {
+          return Object.assign({}, _, { graph: subgraph })
+        }
+      })
+      .filter(Boolean)
+
+    if (steps.length > 0) {
+      return Object.assign({}, graph, { steps })
+    }
+  } else {
+    return graph
+  }
+}
+
+export default function collapseMadeChoices(graph: Graph, choices: ChoiceState): Graph {
+  return collapse(graph, choices) || emptySequence()
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/compile.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/compile.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ChoiceState } from '../../..'
 import { CodeBlockProps, Choice, Graph, SubTask, emptySequence, TitledSteps, parallel, seq, sequence } from '.'
 
 import {
@@ -49,7 +50,11 @@ function isWizardStepNesting(nesting: Nesting): nesting is WizardStepNesting {
 }
 
 /** Take a list of code blocks and arrange them into a control flow dag */
-export default function compile(blocks: CodeBlockProps[], ordering: 'sequence' | 'parallel' = 'parallel'): Graph {
+export default function compile(
+  blocks: CodeBlockProps[],
+  choices: ChoiceState,
+  ordering: 'sequence' | 'parallel' = 'parallel'
+): Graph {
   if (!blocks) {
     return undefined
   }
@@ -249,6 +254,7 @@ export default function compile(blocks: CodeBlockProps[], ordering: 'sequence' |
       ? parts[0]
       : ordering === 'parallel'
       ? parallel(parts)
-      : sequence(parts)
+      : sequence(parts),
+    choices
   )
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/linearize.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/linearize.ts
@@ -27,7 +27,6 @@
 
 import {
   CodeBlockProps,
-  ChoicesMap,
   Ordered,
   Unordered,
   Graph,
@@ -39,10 +38,12 @@ import {
   isChoice
 } from '.'
 
+import { ChoiceState } from '../../..'
+
 /** @return A linearized set of code blocks in the given `graph` */
 export default function blocks<T extends Unordered | Ordered = Unordered>(
   graph: Graph<T>,
-  choices: 'all' | 'default-path' | ChoicesMap = 'default-path'
+  choices: 'all' | 'default-path' | ChoiceState = 'default-path'
 ): (CodeBlockProps & T)[] {
   const subblocks = (subgraph: Graph<T>) => blocks(subgraph, choices)
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/optimize.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/optimize.ts
@@ -16,10 +16,12 @@
 
 import { Graph } from '.'
 
+import { ChoiceState } from '../../..'
 import hoistSubTasks from './hoistSubTasks'
 import propagateTitles from './propagateTitles'
+import collapseMadeChoices from './collapseMadeChoices'
 import deadCodeElimination from './deadCodeElimination'
 
-export default function optimize(graph: Graph) {
-  return propagateTitles(deadCodeElimination(hoistSubTasks(graph)))
+export default function optimize(graph: Graph, choices: ChoiceState) {
+  return propagateTitles(deadCodeElimination(hoistSubTasks(collapseMadeChoices(graph, choices), choices)))
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/progress.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/progress.ts
@@ -16,18 +16,9 @@
 
 import { ProgressStepState } from '../../../../ProgressStepper'
 
-import {
-  CodeBlockProps,
-  Graph,
-  ChoicesMap,
-  Ordered,
-  isSubTask,
-  choose,
-  isChoice,
-  isSequence,
-  isParallel,
-  isTitledSteps
-} from '.'
+import { CodeBlockProps, Graph, Ordered, isSubTask, choose, isChoice, isSequence, isParallel, isTitledSteps } from '.'
+
+import { ChoiceState } from '../../..'
 
 type Status = ProgressStepState['status']
 type Progress = { nDone: number; nError: number; nTotal: number; nextOrdinals: number[] }
@@ -36,7 +27,7 @@ type Progress = { nDone: number; nError: number; nTotal: number; nextOrdinals: n
 export default function progress(
   graph: Graph<Ordered>,
   statusMap?: Record<string, Status> /* map key is code block id */,
-  choices?: ChoicesMap,
+  choices?: ChoiceState,
   filterOut?: (props: CodeBlockProps) => boolean
 ): Progress {
   const zero = { nDone: 0, nError: 0, nTotal: 0, nextOrdinals: [] }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/propagateTitles.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/propagateTitles.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { basename } from 'path'
 import { Graph, isSubTask, isChoice, isSequence, isParallel, isTitledSteps } from '.'
 
 /**
@@ -30,7 +31,7 @@ export default function propagateTitles(graph: Graph, title?: string) {
     graph.parallel.forEach(_ => propagateTitles(_, title))
   } else if (isSubTask(graph)) {
     if (graph.graph) {
-      propagateTitles(graph.graph, graph.title)
+      propagateTitles(graph.graph, graph.title || basename(graph.filepath))
     }
   } else if (isTitledSteps(graph)) {
     graph.steps.forEach(_ => {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
@@ -20,8 +20,8 @@ import { TextContent } from '@patternfly/react-core'
 import SplitInjector from '../../../Views/Terminal/SplitInjector'
 import SplitPosition from '../../../Views/Terminal/SplitPosition'
 
-import { Props as MarkdownProps } from '..'
 import _tabbed, { TabProps, isTabs } from './tabbed'
+import { Props as MarkdownProps, ChoiceState } from '..'
 import { isImports, ImportProps } from '../remark-import'
 import { PositionProps, isNormalSplit } from '../KuiFrontmatter'
 
@@ -30,8 +30,8 @@ const Wizard = React.lazy(() => import('./Wizard'))
 
 const ReactCommentary = React.lazy(() => import('../../Commentary').then(_ => ({ default: _.ReactCommentary })))
 
-export default function div(mdprops: MarkdownProps, uuid: string) {
-  const tabbed = _tabbed(uuid)
+export default function div(mdprops: MarkdownProps, uuid: string, choices: ChoiceState) {
+  const tabbed = _tabbed(uuid, choices)
 
   return (
     props: React.HTMLAttributes<HTMLDivElement> & Partial<PositionProps> & Partial<ImportProps> & Partial<TabProps>
@@ -59,7 +59,7 @@ export default function div(mdprops: MarkdownProps, uuid: string) {
       // this is the first default-positioned section; if it is
       // maximized, we'll have to go through the injector path
       const node = isWizard(props) ? (
-        <Wizard uuid={uuid} {...props} />
+        <Wizard uuid={uuid} {...props} choices={choices} />
       ) : (
         <div data-is-maximized={maximized || undefined}>{props.children}</div>
       )
@@ -83,7 +83,7 @@ export default function div(mdprops: MarkdownProps, uuid: string) {
                 <TextContent>
                   <div className="padding-content marked-content page-content" data-is-nested>
                     {isWizard(props) ? (
-                      <Wizard uuid={uuid} {...props} />
+                      <Wizard uuid={uuid} {...props} choices={choices} />
                     ) : (
                       props.children || (placeholder ? <span className="italic sub-text">{placeholder}</span> : '')
                     )}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
@@ -32,12 +32,13 @@ import { details, tip } from './details'
 import { table, thead, tbody, tr, th, td } from './table'
 import _code, { CodeBlockResponse } from './code'
 
-import { Props } from '../../Markdown'
+import { Props, ChoiceState } from '../../Markdown'
 
 type Args = {
   mdprops: Props
   repl: REPL
   uuid: string
+  choices: ChoiceState
   codeBlockResponses: (codeBlockIdx: number) => CodeBlockResponse & { replayed: boolean }
   spliceInCodeExecution: (
     status: CodeBlockResponse['status'],
@@ -50,7 +51,7 @@ function typedComponents(args: Args): Components {
   const { mdprops, repl, uuid, codeBlockResponses, spliceInCodeExecution } = args
 
   const a = _a(mdprops, uuid, repl)
-  const div = _div(mdprops, uuid)
+  const div = _div(mdprops, uuid, args.choices)
   const img = _img(mdprops)
   const code = _code(mdprops, uuid, codeBlockResponses, spliceInCodeExecution)
   const heading = _heading(uuid)
@@ -87,9 +88,9 @@ function components(args: Args) {
     {
       tip,
       tag,
-      guidebookimports,
-      tabbed: tabbed(args.uuid),
-      guidebookguide: guidebookguide(args.uuid)
+      guidebookimports: guidebookimports(args.choices),
+      tabbed: tabbed(args.uuid, args.choices),
+      guidebookguide: guidebookguide(args.uuid, args.choices)
     },
     typedComponents(args)
   )

--- a/plugins/plugin-client-common/src/components/Content/Markdown/isElement.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/isElement.ts
@@ -17,6 +17,10 @@
 import { Node, Parent } from 'unist'
 import { Element, ElementContent } from 'hast'
 
+export function isParent(node: Node): node is Parent {
+  return Array.isArray((node as Parent).children)
+}
+
 export function isElement(_: Node | Parent | ElementContent): _ is Element {
   const elt = _ as Element
   return elt && typeof elt.tagName === 'string'

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/homebrew.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/homebrew.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Debug from 'debug'
+import { Element } from 'hast'
+import { sync as which } from 'which'
+
+import { ChoiceState } from '../..'
+import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from '..'
+
+const debug = Debug('rehype-tabbed/gruops/homebrew')
+
+class Homebrew {
+  /** internal, the value should be namespaced and unique, but the particulars don't matter */
+  private readonly choiceGroup = 'org.kubernetes-sigs.kui/choice/has-homebrew?'
+
+  /** this helps with processing and optimizing based on the existence of homebrew on the user's system */
+  private readonly canonicalName = 'Homebrew'
+
+  /** tabs whose title matches this pattern will be treated as being a Homebrew choice */
+  private readonly RE_HOMEBREW = /homebrew/i
+
+  /**
+   * This code assumes the given `node` satisfies `import('..').isTabGroup`.
+   *
+   * @return whether or not this tab group represents a MacOS installation choice that includes Homebrew
+   */
+  private isMatchingTabGroup(node: Element) {
+    return node.children
+      .filter(isTabWithProperties)
+      .map(getTabTitle)
+      .find(title => this.RE_HOMEBREW.test(title))
+  }
+
+  private rewriteTabsToUseCanonicalNames(node: Element) {
+    node.children.forEach(tab => {
+      if (isTabWithProperties(tab)) {
+        const title = getTabTitle(tab)
+        if (this.RE_HOMEBREW.test(title) && title !== this.canonicalName) {
+          setTabTitle(tab, this.canonicalName)
+        }
+      }
+    })
+  }
+
+  /** Check to see if we have homebrew installed */
+  public populateChoice(choices: ChoiceState) {
+    // which('brew').then(() => choices.set(this.choiceGroup, this.canonicalName))
+    // .catch(err => debug('Homebrew probably not found', err))
+    try {
+      if (which('brew')) {
+        choices.set(this.choiceGroup, this.canonicalName)
+      }
+    } catch (err) {
+      debug('Homebrew probably not found', err)
+    }
+  }
+
+  /** Check if the given `node` is a tab group that we can inform */
+  public checkAndSet(node: Element) {
+    if (this.isMatchingTabGroup(node)) {
+      setTabGroup(node, this.choiceGroup)
+      this.rewriteTabsToUseCanonicalNames(node)
+      return true
+    }
+  }
+}
+
+export default new Homebrew()

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/index.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Node } from 'hast'
+import { visit } from 'unist-util-visit'
+import { Capabilities } from '@kui-shell/core'
+
+import { isTabGroup } from '..'
+import { ChoiceState } from '../..'
+
+import platform from './platform'
+import homebrew from './homebrew'
+
+const providers = [platform, homebrew]
+
+/**
+ * Scan tab groups to see if we can squash down the choice given our a
+ * priori knowledge, e.g. about what platform we are on.
+ *
+ */
+export default function identifyRecognizableTabGroups(tree: Node, choices: ChoiceState) {
+  if (!Capabilities.inElectron()) {
+    // I don't think this is a meaningful thing to do whilst running
+    // in browser? TODO: maybe we should allow the providers a say?
+    return
+  }
+
+  providers.forEach(_ => _.populateChoice(choices))
+
+  visit(tree, 'element', node => {
+    if (isTabGroup(node)) {
+      for (let idx = 0; idx < providers.length; idx++) {
+        if (providers[idx].checkAndSet(node)) {
+          // Assumption: a given tab group can only have one match,
+          // e.g. it is either a platform choice (macos/linux/windows)
+          // or an download method choice (homebrew, curl)
+          break
+        }
+      }
+    }
+  })
+
+  return tree
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/platform.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/platform.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Element } from 'hast'
+
+import { ChoiceState } from '../..'
+import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from '..'
+
+class Platform {
+  /** internal, the value should be namespaced and unique, but the particulars don't matter */
+  private readonly choiceGroup = 'org.kubernetes-sigs.kui/choice/platform'
+
+  private readonly platforms: Record<string, typeof process['platform']> = {
+    mac: 'darwin',
+    macos: 'darwin',
+    darwin: 'darwin',
+
+    linux: 'linux',
+
+    win: 'win32',
+    win32: 'win32',
+    windows: 'win32'
+  }
+
+  private readonly findPlatform = (str: string) => this.platforms[str.toLowerCase()]
+
+  /**
+   * This code assumes the given `node` satisfies `import('..').isTabGroup`.
+   *
+   * @return whether or not this tab group represents a "what platform are you on" choice group.
+   */
+  private isMatchingTabGroup(node: Element) {
+    return node.children
+      .filter(isTabWithProperties)
+      .map(getTabTitle)
+      .every(this.findPlatform)
+  }
+
+  private capitalize(str: string) {
+    return str[0].toUpperCase() + str.slice(1)
+  }
+
+  private rewriteTabsToUseCanonicalNames(node: Element) {
+    node.children.forEach(tab => {
+      if (isTabWithProperties(tab)) {
+        setTabTitle(tab, this.capitalize(this.findPlatform(getTabTitle(tab))))
+      }
+    })
+  }
+
+  /** Set the platform choice group to use the current host platform */
+  public populateChoice(choices: ChoiceState) {
+    choices.set(this.choiceGroup, process.platform)
+  }
+
+  /** Check if the given `node` is a tab group that we can inform */
+  public checkAndSet(node: Element) {
+    if (this.isMatchingTabGroup(node)) {
+      setTabGroup(node, this.choiceGroup)
+      this.rewriteTabsToUseCanonicalNames(node)
+      return true
+    }
+  }
+}
+
+export default new Platform()

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/hack.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/hack.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { START_OF_TIP, END_OF_TIP } from '../rehype-tip'
+import { START_OF_TAB, END_OF_TAB, PUSH_TABS } from '.'
+
+/** A placeholder marker to indicate markdown that uses indentation not to mean Tab or Tip content */
+const FAKE_END_MARKER = ''
+
+/**
+ * pymdown uses indentation to define tab content; remark-parse seems
+ * to turn these into <pre> blocks before we get control; hack it for
+ * now
+ */
+export default function hackIndentation(source: string): string {
+  let inTab: RegExp
+  let inBlockquote = false
+  let inCodeBlock = false
+  let blockquoteOrCodeBlockIndent: number
+  const endMarkers: string[] = []
+
+  const indentDepthOfContent: number[] = []
+
+  const unindent = (line: string) => {
+    if (!inBlockquote && !inCodeBlock) {
+      return line.replace(/^\s*/, '')
+    } else {
+      if (blockquoteOrCodeBlockIndent > 0) {
+        return line.replace(new RegExp(`^\\s{${blockquoteOrCodeBlockIndent}}`), '')
+      } else {
+        return line
+      }
+    }
+  }
+
+  const pop = (line: string, delta = 0) => {
+    const indentMatch = line.match(/^\s+/)
+    const curIndentDepth = indentDepthOfContent[indentDepthOfContent.length - 1]
+    const thisIndentDepth = !indentMatch ? 0 : ~~(indentMatch[0].length / 4)
+
+    let pop = ''
+    for (let idx = curIndentDepth; idx > thisIndentDepth + delta; idx--) {
+      indentDepthOfContent.pop()
+      const endMarker = endMarkers.pop()
+      if (endMarker) {
+        pop += `\n${endMarker}\n\n`
+      }
+    }
+
+    if (pop) {
+      if (endMarkers.length === 0) {
+        inTab = undefined
+      } else {
+        const indentDepth = indentDepthOfContent[indentDepthOfContent.length - 1]
+        inTab = new RegExp(
+          '^' +
+            Array(indentDepth * 4)
+              .fill(' ')
+              .join('')
+        )
+      }
+    }
+    return pop
+  }
+
+  const rewrite = source.split(/\n/).map(line => {
+    const tabStartMatch = line.match(/^(\s*)===\s+".*"/)
+    const tipStartMatch = line.match(/^(\s*)[?!][?!][?!](\+?)\s+(tip|todo|bug|info|note|warning|success|question)/i)
+    const startMatch = tabStartMatch || tipStartMatch
+
+    if (!inBlockquote && startMatch) {
+      const thisIndentation = startMatch[1] || ''
+      const indentDepth = indentDepthOfContent[indentDepthOfContent.length - 1] || 0
+      const thisIndentDepth = !thisIndentation ? 1 : ~~(thisIndentation.length / 4) + 1
+
+      const currentEndMarker = endMarkers.length === 0 ? undefined : endMarkers[endMarkers.length - 1]
+      const endMarker = tabStartMatch ? END_OF_TAB : END_OF_TIP
+
+      const possibleEndTab =
+        (indentDepth === thisIndentDepth && currentEndMarker === END_OF_TIP) || endMarker === END_OF_TIP
+          ? pop(line, 0)
+          : !(inTab && indentDepth > thisIndentDepth)
+          ? ''
+          : pop(line, 1)
+
+      const possibleNesting = !(
+        inTab &&
+        tabStartMatch &&
+        indentDepth < thisIndentDepth &&
+        endMarkers.find(_ => _ === END_OF_TAB)
+      )
+        ? ''
+        : `\n\n${PUSH_TABS}\n\n`
+
+      const startMarker = tabStartMatch ? START_OF_TAB : START_OF_TIP
+
+      if (thisIndentDepth > indentDepth + 1) {
+        // then the markdown is using indentation in ways beyond that
+        // which would be "normal" for pymdown, i.e. to indicate Tab
+        // or Tip content
+        endMarkers.push(FAKE_END_MARKER)
+        indentDepthOfContent.push(indentDepthOfContent[indentDepthOfContent.length - 1])
+      }
+
+      if (endMarker === END_OF_TIP || endMarkers.length === 0 || thisIndentDepth > indentDepth) {
+        endMarkers.push(endMarker)
+        indentDepthOfContent.push(thisIndentDepth)
+      }
+
+      inTab = new RegExp(
+        '^' +
+          Array(thisIndentDepth * 4)
+            .fill(' ')
+            .join('')
+      )
+
+      return `\n\n${possibleEndTab}${possibleNesting}${startMarker}\n\n` + unindent(line)
+    } else if (/^\s*```/.test(line)) {
+      const possibleEndOfTab = !inTab || inTab.test(line) ? '' : pop(line)
+
+      if (/(bash|sh|shell)/.test(line)) {
+        blockquoteOrCodeBlockIndent = line.search(/\S/)
+        inCodeBlock = true
+      } else if (inCodeBlock) {
+        inCodeBlock = false
+      } else if (!inBlockquote) {
+        blockquoteOrCodeBlockIndent = line.search(/\S/)
+        inBlockquote = true
+      } else {
+        inBlockquote = false
+      }
+      return possibleEndOfTab + unindent(line)
+    } else if (inTab) {
+      const unindented = unindent(line)
+
+      if (line.length === 0 || /^\s+$/.test(line) || inBlockquote || inTab.test(line)) {
+        // empty line, in blockquote, or still in tab
+        return unindented
+      } else {
+        // possibly pop the stack of indentation
+        return pop(line) + unindented
+      }
+    } else if (inBlockquote || inCodeBlock) {
+      return unindent(line)
+    }
+
+    return line
+  })
+
+  while (endMarkers.length > 0) {
+    const endMarker = endMarkers.pop()
+    if (endMarker) {
+      rewrite.push(endMarker)
+    }
+  }
+
+  return rewrite.join('\n')
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/index.ts
@@ -14,317 +14,60 @@
  * limitations under the License.
  */
 
-import { v4 } from 'uuid'
+import { Transformer } from 'unified'
+import { Element, ElementContent } from 'hast'
 
-import { Element } from 'hast'
+import isElementWithProperties from '../isElement'
 
-import { isImports } from '../remark-import'
-import { START_OF_TIP, END_OF_TIP } from '../rehype-tip'
+import { ChoiceState } from '..'
+import populateTabs from './populate'
+import identifyRecognizableTabGroups from './groups'
 
-/** A placeholder marker to indicate markdown that uses indentation not to mean Tab or Tip content */
-const FAKE_END_MARKER = ''
+export const START_OF_TAB = `<!-- ____KUI_START_OF_TAB____ -->`
+export const PUSH_TABS = `<!-- ____KUI_NESTED_TABS____ -->`
+export const END_OF_TAB = `<!-- ____KUI_END_OF_TAB____ -->`
 
-// const RE_TAB = /^(.|[\n\r])*===\s+"(.+)"\s*(\n(.|[\n\r])*)?$/
-const RE_TAB = /^===\s+"([^"]+)"/
-
-const START_OF_TAB = `<!-- ____KUI_START_OF_TAB____ -->`
-const PUSH_TABS = `<!-- ____KUI_NESTED_TABS____ -->`
-const END_OF_TAB = `<!-- ____KUI_END_OF_TAB____ -->`
-
-export function isTab(elt: Element): boolean {
-  return elt.properties['data-kui-tab-index'] !== undefined
+export function isTab(elt: ElementContent): boolean {
+  return isElementWithProperties(elt) && elt.properties['data-kui-tab-index'] !== undefined
 }
 
-export default function plugin(/* options */) {
-  return function transformer(tree) {
-    const tabStack = []
-    let currentTabs = []
-    const _flushTabs = children => {
-      if (currentTabs.length > 0) {
-        children.push({
-          type: 'element',
-          tagName: 'div',
-          children: currentTabs,
-          properties: {
-            depth: tabStack.length,
-            'data-kui-choice-group': v4(),
-            'data-kui-choice-nesting-depth': tabStack.length
-          }
-        })
-      }
-
-      if (tabStack.length === 0) {
-        currentTabs = []
-      } else {
-        currentTabs = tabStack.pop()
-      }
-    }
-
-    const flushTabs = children => {
-      if (tabStack.length > 0) {
-        const parentTabs = tabStack[tabStack.length - 1]
-        const lastParentTab = parentTabs[parentTabs.length - 1]
-        _flushTabs(lastParentTab.children)
-      } else {
-        _flushTabs(children)
-      }
-    }
-
-    const process = children =>
-      children.reduce((newChildren, child) => {
-        const addToTab = child => {
-          const cur = currentTabs[currentTabs.length - 1]
-          cur.children.push(child)
-          if (cur.position && child.position) {
-            cur.position.end.offset = child.position.end.offset
-          }
-          return newChildren
-        }
-
-        if (child.type === 'raw' && child.value === END_OF_TAB) {
-          flushTabs(newChildren)
-          return newChildren
-        } else if (child.type === 'raw' && child.value === START_OF_TAB) {
-          // we process this in the RE_TAB match below; this is for
-          // now only a breadcrumb to help with debugging
-          return newChildren
-        } else if (child.type === 'raw' && child.value === PUSH_TABS) {
-          if (currentTabs.length > 0) {
-            tabStack.push(currentTabs)
-            currentTabs = []
-          }
-        } else if (child.type === 'element' && child.tagName === 'div') {
-          if (currentTabs.length > 0 && isImports(child.properties)) {
-            const sub = transformer(child)
-            return addToTab(sub)
-          } else {
-            child.children = process(child.children)
-          }
-        } else if (child.type === 'element' && child.tagName === 'p') {
-          if (child.children.length > 0) {
-            if (
-              currentTabs.length > 0 &&
-              (child.type === 'raw' || child.children[0].type !== 'text' || !RE_TAB.test(child.children[0].value))
-            ) {
-              // a new paragraph that doesn't start a new tab; add to current tab
-              return addToTab(child)
-            }
-
-            child.children = child.children.reduce((newChildren, pchild) => {
-              if (pchild.type === 'text') {
-                const startMatch = pchild.value.match(RE_TAB)
-                if (startMatch) {
-                  if (startMatch.index !== 0) {
-                    // then we need to splice out some prefix text
-                    newChildren.push({ type: 'text', value: pchild.value.slice(0, startMatch.index) })
-                  }
-
-                  const rest = pchild.value.slice(startMatch.index + startMatch[0].length)
-
-                  const position = {
-                    start: {
-                      offset: child.position.start.offset + startMatch.index
-                    },
-                    end: {
-                      offset: child.position.end.offset + startMatch.index
-                    }
-                  }
-
-                  currentTabs.push({
-                    type: 'element',
-                    tagName: 'span', // do not use 'li'
-                    // here. something after us seems
-                    // to join nested tabs together
-                    properties: {
-                      title: startMatch[1],
-                      depth: tabStack.length,
-                      'data-kui-tab-index': currentTabs.length
-                    },
-                    children: rest ? [{ type: 'text', value: rest }] : [],
-                    position
-                  })
-                  return newChildren
-                }
-              }
-
-              if (currentTabs.length > 0) {
-                return addToTab(pchild)
-              } else {
-                newChildren.push(pchild)
-                return newChildren
-              }
-            }, [])
-          }
-          if (currentTabs.length > 0) {
-            return newChildren
-          }
-        } else if (currentTabs.length > 0) {
-          return addToTab(child)
-        }
-
-        // no rewrite
-        newChildren.push(child)
-
-        return newChildren
-      }, [])
-
-    if (tree.children && tree.children.length > 0) {
-      tree.children = process(tree.children)
-    }
-
-    while (currentTabs.length > 0) {
-      flushTabs(tree.children)
-    }
-    return tree
-  }
+export function isTabWithProperties(elt: ElementContent): elt is Element {
+  return isTab(elt)
 }
 
-/**
- * pymdown uses indentation to define tab content; remark-parse seems
- * to turn these into <pre> blocks before we get control; hack it for
- * now
- */
-export function hackIndentation(source: string): string {
-  let inTab: RegExp
-  let inBlockquote = false
-  let inCodeBlock = false
-  let blockquoteOrCodeBlockIndent: number
-  const endMarkers: string[] = []
+export function isTabGroup(elt: Element): boolean {
+  return elt.properties['data-kui-choice-group'] !== undefined
+}
 
-  const indentDepthOfContent: number[] = []
+export function setTabGroup(elt: Element, group: string) {
+  elt.properties['data-kui-choice-group'] = group
+}
 
-  const unindent = (line: string) => {
-    if (!inBlockquote && !inCodeBlock) {
-      return line.replace(/^\s*/, '')
-    } else {
-      if (blockquoteOrCodeBlockIndent > 0) {
-        return line.replace(new RegExp(`^\\s{${blockquoteOrCodeBlockIndent}}`), '')
-      } else {
-        return line
-      }
-    }
+export function getTabTitle(elt: Element): string {
+  return elt.properties.title.toString()
+}
+
+export function setTabTitle(elt: Element, title: string): string {
+  return (elt.properties.title = title)
+}
+
+export default function plugin(choices: ChoiceState) {
+  return function rehypeTabbed(tree: Parameters<Transformer>[0]): ReturnType<Transformer> {
+    // first, assemble the tabs into this tree structure, one of these per tab group:
+    // - div with properties {data-kui-choice-group, data-kui-choice-nesting-depth}
+    //   - span with properties {data-kui-tab-index=0}
+    //       children: content of first tab
+    //   - span with properties {data-kui-tab-index=1}
+    //       children: content of second tab
+    //   - span with properties {data-kui-tab-index=2}
+    //       children: content of third tab
+    //
+    const treeWithTabs = populateTabs(tree)
+
+    // second, analyze the tabs to see if we can identify recognizable
+    // tab groups, e.g. "choose your platform"
+    const treeWithTabsInRecognizableGroups = identifyRecognizableTabGroups(treeWithTabs, choices)
+
+    return treeWithTabsInRecognizableGroups
   }
-
-  const pop = (line: string, delta = 0) => {
-    const indentMatch = line.match(/^\s+/)
-    const curIndentDepth = indentDepthOfContent[indentDepthOfContent.length - 1]
-    const thisIndentDepth = !indentMatch ? 0 : ~~(indentMatch[0].length / 4)
-
-    let pop = ''
-    for (let idx = curIndentDepth; idx > thisIndentDepth + delta; idx--) {
-      indentDepthOfContent.pop()
-      const endMarker = endMarkers.pop()
-      if (endMarker) {
-        pop += `\n${endMarker}\n\n`
-      }
-    }
-
-    if (pop) {
-      if (endMarkers.length === 0) {
-        inTab = undefined
-      } else {
-        const indentDepth = indentDepthOfContent[indentDepthOfContent.length - 1]
-        inTab = new RegExp(
-          '^' +
-            Array(indentDepth * 4)
-              .fill(' ')
-              .join('')
-        )
-      }
-    }
-    return pop
-  }
-
-  const rewrite = source.split(/\n/).map(line => {
-    const tabStartMatch = line.match(/^(\s*)===\s+".*"/)
-    const tipStartMatch = line.match(/^(\s*)[?!][?!][?!](\+?)\s+(tip|todo|bug|info|note|warning|success|question)/i)
-    const startMatch = tabStartMatch || tipStartMatch
-
-    if (!inBlockquote && startMatch) {
-      const thisIndentation = startMatch[1] || ''
-      const indentDepth = indentDepthOfContent[indentDepthOfContent.length - 1] || 0
-      const thisIndentDepth = !thisIndentation ? 1 : ~~(thisIndentation.length / 4) + 1
-
-      const currentEndMarker = endMarkers.length === 0 ? undefined : endMarkers[endMarkers.length - 1]
-      const endMarker = tabStartMatch ? END_OF_TAB : END_OF_TIP
-
-      const possibleEndTab =
-        (indentDepth === thisIndentDepth && currentEndMarker === END_OF_TIP) || endMarker === END_OF_TIP
-          ? pop(line, 0)
-          : !(inTab && indentDepth > thisIndentDepth)
-          ? ''
-          : pop(line, 1)
-
-      const possibleNesting = !(
-        inTab &&
-        tabStartMatch &&
-        indentDepth < thisIndentDepth &&
-        endMarkers.find(_ => _ === END_OF_TAB)
-      )
-        ? ''
-        : `\n\n${PUSH_TABS}\n\n`
-
-      const startMarker = tabStartMatch ? START_OF_TAB : START_OF_TIP
-
-      if (thisIndentDepth > indentDepth + 1) {
-        // then the markdown is using indentation in ways beyond that
-        // which would be "normal" for pymdown, i.e. to indicate Tab
-        // or Tip content
-        endMarkers.push(FAKE_END_MARKER)
-        indentDepthOfContent.push(indentDepthOfContent[indentDepthOfContent.length - 1])
-      }
-
-      if (endMarker === END_OF_TIP || endMarkers.length === 0 || thisIndentDepth > indentDepth) {
-        endMarkers.push(endMarker)
-        indentDepthOfContent.push(thisIndentDepth)
-      }
-
-      inTab = new RegExp(
-        '^' +
-          Array(thisIndentDepth * 4)
-            .fill(' ')
-            .join('')
-      )
-
-      return `\n\n${possibleEndTab}${possibleNesting}${startMarker}\n\n` + unindent(line)
-    } else if (/^\s*```/.test(line)) {
-      const possibleEndOfTab = !inTab || inTab.test(line) ? '' : pop(line)
-
-      if (/(bash|sh|shell)/.test(line)) {
-        blockquoteOrCodeBlockIndent = line.search(/\S/)
-        inCodeBlock = true
-      } else if (inCodeBlock) {
-        inCodeBlock = false
-      } else if (!inBlockquote) {
-        blockquoteOrCodeBlockIndent = line.search(/\S/)
-        inBlockquote = true
-      } else {
-        inBlockquote = false
-      }
-      return possibleEndOfTab + unindent(line)
-    } else if (inTab) {
-      const unindented = unindent(line)
-
-      if (line.length === 0 || /^\s+$/.test(line) || inBlockquote || inTab.test(line)) {
-        // empty line, in blockquote, or still in tab
-        return unindented
-      } else {
-        // possibly pop the stack of indentation
-        return pop(line) + unindented
-      }
-    } else if (inBlockquote || inCodeBlock) {
-      return unindent(line)
-    }
-
-    return line
-  })
-
-  while (endMarkers.length > 0) {
-    const endMarker = endMarkers.pop()
-    if (endMarker) {
-      rewrite.push(endMarker)
-    }
-  }
-
-  return rewrite.join('\n')
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/populate.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/populate.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { v4 } from 'uuid'
+import { Node } from 'hast'
+
+import { isParent } from '../isElement'
+import { isImports } from '../remark-import'
+
+// const RE_TAB = /^(.|[\n\r])*===\s+"(.+)"\s*(\n(.|[\n\r])*)?$/
+const RE_TAB = /^===\s+"([^"]+)"/
+
+import { START_OF_TAB, END_OF_TAB, PUSH_TABS } from '.'
+
+export default function populateTabs(tree: Node): Node {
+  const tabStack = []
+  let currentTabs = []
+  const _flushTabs = children => {
+    if (currentTabs.length > 0) {
+      children.push({
+        type: 'element',
+        tagName: 'div',
+        children: currentTabs,
+        properties: {
+          depth: tabStack.length,
+          'data-kui-choice-group': v4(),
+          'data-kui-choice-nesting-depth': tabStack.length
+        }
+      })
+    }
+
+    if (tabStack.length === 0) {
+      currentTabs = []
+    } else {
+      currentTabs = tabStack.pop()
+    }
+  }
+
+  const flushTabs = children => {
+    if (tabStack.length > 0) {
+      const parentTabs = tabStack[tabStack.length - 1]
+      const lastParentTab = parentTabs[parentTabs.length - 1]
+      _flushTabs(lastParentTab.children)
+    } else {
+      _flushTabs(children)
+    }
+  }
+
+  const process = children =>
+    children.reduce((newChildren, child) => {
+      const addToTab = child => {
+        const cur = currentTabs[currentTabs.length - 1]
+        cur.children.push(child)
+        if (cur.position && child.position) {
+          cur.position.end.offset = child.position.end.offset
+        }
+        return newChildren
+      }
+
+      if (child.type === 'raw' && child.value === END_OF_TAB) {
+        flushTabs(newChildren)
+        return newChildren
+      } else if (child.type === 'raw' && child.value === START_OF_TAB) {
+        // we process this in the RE_TAB match below; this is for
+        // now only a breadcrumb to help with debugging
+        return newChildren
+      } else if (child.type === 'raw' && child.value === PUSH_TABS) {
+        if (currentTabs.length > 0) {
+          tabStack.push(currentTabs)
+          currentTabs = []
+        }
+      } else if (child.type === 'element' && child.tagName === 'div') {
+        if (currentTabs.length > 0 && isImports(child.properties)) {
+          const sub = populateTabs(child)
+          return addToTab(sub)
+        } else {
+          child.children = process(child.children)
+        }
+      } else if (child.type === 'element' && child.tagName === 'p') {
+        if (child.children.length > 0) {
+          if (
+            currentTabs.length > 0 &&
+            (child.type === 'raw' || child.children[0].type !== 'text' || !RE_TAB.test(child.children[0].value))
+          ) {
+            // a new paragraph that doesn't start a new tab; add to current tab
+            return addToTab(child)
+          }
+
+          child.children = child.children.reduce((newChildren, pchild) => {
+            if (pchild.type === 'text') {
+              const startMatch = pchild.value.match(RE_TAB)
+              if (startMatch) {
+                if (startMatch.index !== 0) {
+                  // then we need to splice out some prefix text
+                  newChildren.push({ type: 'text', value: pchild.value.slice(0, startMatch.index) })
+                }
+
+                const rest = pchild.value.slice(startMatch.index + startMatch[0].length)
+
+                const position = {
+                  start: {
+                    offset: child.position.start.offset + startMatch.index
+                  },
+                  end: {
+                    offset: child.position.end.offset + startMatch.index
+                  }
+                }
+
+                currentTabs.push({
+                  type: 'element',
+                  tagName: 'span', // do not use 'li'
+                  // here. something after us seems
+                  // to join nested tabs together
+                  properties: {
+                    title: startMatch[1],
+                    depth: tabStack.length,
+                    'data-kui-tab-index': currentTabs.length
+                  },
+                  children: rest ? [{ type: 'text', value: rest }] : [],
+                  position
+                })
+                return newChildren
+              }
+            }
+
+            if (currentTabs.length > 0) {
+              return addToTab(pchild)
+            } else {
+              newChildren.push(pchild)
+              return newChildren
+            }
+          }, [])
+        }
+        if (currentTabs.length > 0) {
+          return newChildren
+        }
+      } else if (currentTabs.length > 0) {
+        return addToTab(child)
+      }
+
+      // no rewrite
+      newChildren.push(child)
+
+      return newChildren
+    }, [])
+
+  if (isParent(tree) && tree.children.length > 0) {
+    tree.children = process(tree.children)
+
+    while (currentTabs.length > 0) {
+      flushTabs(tree.children)
+    }
+  }
+
+  return tree
+}

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/6.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/6.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Input, { Tree } from '../Input'
+import { importa, importd } from './1'
+
+const filename = 'guidebook-tree-model6.md'
+
+const messageForMacOS = 'echo MMM'
+const messageForLinux = 'echo LLL'
+const messageForWindows = 'echo WWW'
+
+const messageForElectron =
+  process.platform === 'linux' ? messageForLinux : process.platform === 'darwin' ? messageForMacOS : messageForWindows
+
+// here, we will squash away the choice
+const importgForElectron: Tree = { name: 'importg.md', children: [{ name: messageForElectron }] }
+
+// here, we won't squash away the choice
+const importgForBrowser: Tree = {
+  name: 'importg.md',
+  children: [
+    { name: 'Option 1: MacOS', children: [{ name: messageForMacOS }] },
+    { name: 'Option 2: Linux', children: [{ name: messageForLinux }] },
+    { name: 'Option 3: Windows', children: [{ name: messageForWindows }] }
+  ]
+}
+
+const importg: Tree =
+  (process.env.MOCHA_RUN_TARGET || 'electron') === 'electron' ? importgForElectron : importgForBrowser
+
+const tree: Input['tree'] = (command: string) => [
+  {
+    name: command === 'guide' ? filename : 'Tasks',
+    children: [importg, importa, importd]
+  }
+]
+
+const IN6: Input = {
+  input: require.resolve(`@kui-shell/plugin-client-common/tests/data/${filename}`),
+  tree
+}
+
+export default IN6

--- a/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/index.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/dependence-tree/inputs/index.ts
@@ -19,5 +19,6 @@ import IN2 from './2'
 import IN3 from './3'
 import IN4 from './4'
 import IN5 from './5'
+import IN6 from './6'
 
-export default [IN1, IN2, IN3, IN4, IN5]
+export default [IN1, IN2, IN3, IN4, IN5, IN6]

--- a/plugins/plugin-client-common/tests/data/guidebook-tree-model6.md
+++ b/plugins/plugin-client-common/tests/data/guidebook-tree-model6.md
@@ -1,0 +1,8 @@
+---
+imports:
+    - importg.md
+    - importa.md
+    - importd.md
+---
+
+::imports

--- a/plugins/plugin-client-common/tests/data/importg.md
+++ b/plugins/plugin-client-common/tests/data/importg.md
@@ -1,0 +1,14 @@
+=== "MacOS"
+    ```bash
+    echo MMM
+    ```
+
+=== "Linux"
+    ```bash
+    echo LLL
+    ```
+
+=== "Windows"
+    ```bash
+    echo WWW
+    ```


### PR DESCRIPTION
If a guidebook offers a MacOS/Linux/Windows choice, this is something we can squash down.

Same for a Homebrew/curl/... choice. If the user has `brew`, then this isn't a choice that needs to be made.

This PR adds support for choice squashing generally, and has impls for those two: platform and has-homebrew?

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
