### PR TITLE
fix(plugins/plugin-client-common): optimize population of platform/arch/etc. choice detection

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/arch.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/arch.ts
@@ -21,7 +21,7 @@ import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from '..'
 
 class Arch {
   /** internal, the value should be namespaced and unique, but the particulars don't matter */
-  private readonly choiceGroup = 'org.kubernetes-sigs.kui/choice/arch'
+  public readonly choiceGroup = 'org.kubernetes-sigs.kui/choice/arch'
 
   private readonly archs: Record<string, typeof process['arch']> = {
     intel: 'x64',

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/homebrew.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/homebrew.ts
@@ -24,8 +24,8 @@ import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from '..'
 const debug = Debug('rehype-tabbed/gruops/homebrew')
 
 class Homebrew {
-  /** internal, the value should be namespaced and unique, but the particulars don't matter */
-  private readonly choiceGroup = 'org.kubernetes-sigs.kui/choice/has-homebrew?'
+  /** the value should be namespaced and unique, but the particulars don't matter */
+  public readonly choiceGroup = 'org.kubernetes-sigs.kui/choice/has-homebrew?'
 
   /** this helps with processing and optimizing based on the existence of homebrew on the user's system */
   private readonly canonicalName = 'Homebrew'

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/index.ts
@@ -39,7 +39,9 @@ export default function identifyRecognizableTabGroups(tree: Node, choices: Choic
     return
   }
 
-  providers.forEach(_ => _.populateChoice(choices))
+  providers
+    .filter(_ => !choices.contains(_.choiceGroup)) // already set?
+    .forEach(_ => _.populateChoice(choices))
 
   visit(tree, 'element', node => {
     if (isTabGroup(node)) {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/platform.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tabbed/groups/platform.ts
@@ -21,7 +21,7 @@ import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from '..'
 
 class Platform {
   /** internal, the value should be namespaced and unique, but the particulars don't matter */
-  private readonly choiceGroup = 'org.kubernetes-sigs.kui/choice/platform'
+  public readonly choiceGroup = 'org.kubernetes-sigs.kui/choice/platform'
 
   private readonly platforms: Record<string, typeof process['platform']> = {
     mac: 'darwin',


### PR DESCRIPTION


1) we were recomputing these platform settings on every render
2) the default react batching doesn't seem to be sufficient for this use case, resulting in multiple recomputations of the task graph

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
