### PR TITLE
feat(plugins/plugin-client-common): extract description for guidebook choices

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/CodeBlockProps.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/CodeBlockProps.ts
@@ -49,6 +49,7 @@ export type Source = {
 export type Choice = GroupMember &
   Source &
   Title &
+  Partial<Description> &
   Kind<'Choice'> & {
     /** Title and Source for the choice group */
     groupDetail: Partial<Title> & Source

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/compile.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/compile.ts
@@ -63,9 +63,10 @@ export default function compile(
   let currentNesting: Nesting[] = []
 
   const newChoice = (block: CodeBlockProps, parent: CodeBlockChoice, isDeepest: boolean) => ({
+    member: parent.member,
     graph: isDeepest ? seq(block) : emptySequence(),
     title: parent.title,
-    member: parent.member
+    description: parent.description
   })
 
   const newChoices = (block: CodeBlockProps, parent: CodeBlockChoice, isDeepest: boolean): Choice => ({

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/deadCodeElimination.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/deadCodeElimination.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { Graph, emptySequence, isSequence, isParallel, isSubTask, isTitledSteps, isChoice } from '.'
+import { Graph, Ordered, Unordered, emptySequence, isSequence, isParallel, isSubTask, isTitledSteps, isChoice } from '.'
 
 /** Remove any subgraphs that contain no code blocks */
-function dce<G extends Graph>(graph: G): G {
+function dce<T extends Unordered | Ordered, G extends Graph<T>>(graph: G): G {
   if (isSequence(graph)) {
     const sequence = graph.sequence.map(dce).filter(Boolean)
     if (sequence.length > 0) {
@@ -28,12 +28,12 @@ function dce<G extends Graph>(graph: G): G {
     if (parallel.length > 0) {
       return Object.assign({}, graph, { parallel })
     }
-  } else if (isSubTask(graph)) {
+  } else if (isSubTask<T>(graph)) {
     const subgraph = dce(graph.graph)
     if (subgraph) {
       return Object.assign({}, graph, { graph: subgraph })
     }
-  } else if (isTitledSteps(graph)) {
+  } else if (isTitledSteps<T>(graph)) {
     const steps = graph.steps
       .map(_ => {
         const subgraph = dce(_.graph)

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/index.ts
@@ -110,11 +110,11 @@ function sameSequence(A: Sequence = emptySequence(), B: Sequence = emptySequence
 type ChoiceGroup = string
 type ChoiceMember = number
 
-export type ChoicePart<T extends Unordered | Ordered = Unordered> = {
-  member: ChoiceMember
-  title: string
-  graph: Sequence<T>
-}
+export type ChoicePart<T extends Unordered | Ordered = Unordered> = Title &
+  Partial<Description> & {
+    member: ChoiceMember
+    graph: Sequence<T>
+  }
 
 export type Choice<T extends Unordered | Ordered = Unordered> = Source &
   T &

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/rehype-code-indexer.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/rehype-code-indexer.ts
@@ -47,6 +47,14 @@ function isImplicitlyOptional(_: Parent): _ is Element {
   return isElementWithProperties(_) && _.tagName === 'tip' && _.properties.open === false
 }
 
+/** @return the first child, if it is a paragraph  */
+function extractFirstParagraph(parent: Parent) {
+  const firstChild = parent.children[0]
+  if (firstChild && isElementWithProperties(firstChild) && firstChild.tagName === 'p') {
+    return toMarkdownString(firstChild)
+  }
+}
+
 /**
  * Scan backwards from `parent` in `grandparent`'s children for a
  * heading. If found, return that heading's string form, and collect
@@ -170,6 +178,7 @@ export default function plugin(uuid: string) {
                           source: toMarkdownString(_),
                           group,
                           title,
+                          description: extractFirstParagraph(_),
                           member,
                           groupDetail: findNearestEnclosingTitle(grandparent, parent)
                         })

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { Chip, ChipGroup, Flex, Tile, Wizard, WizardStep } from '@patternfly/react-core'
+import { Chip, ChipGroup, Grid, GridItem, Tile, Wizard, WizardStep } from '@patternfly/react-core'
 
 import order from '../code/graph/order'
 import compile from '../code/graph/compile'
@@ -178,24 +178,25 @@ export default class Guide extends React.PureComponent<Props, State> {
 
   private tilesForChoice(choice: Choice) {
     return this.stepContent(
-      <Flex>
-        {choice.choices.map((_, idx) => {
+      <Grid hasGutter span={4}>
+        {choice.choices.map(_ => {
           return (
-            <Tile
-              key={idx}
-              isStacked
-              title={_.title}
-              icon={<Icons icon="PlusSquare" />}
-              isSelected={this.state.choices && this.state.choices.get(choice.group) === _.title}
-              onClick={this.onChoice}
-              data-choice-group={choice.group}
-              data-choice-title={_.title}
-            >
-              {this.graph(_.graph)}
-            </Tile>
+            <GridItem key={_.title}>
+              <Tile
+                isStacked
+                title={_.title}
+                icon={<Icons icon="PlusSquare" />}
+                isSelected={this.state.choices && this.state.choices.get(choice.group) === _.title}
+                onClick={this.onChoice}
+                data-choice-group={choice.group}
+                data-choice-title={_.title}
+              >
+                {_.description && <Markdown nested source={_.description} />}
+              </Tile>
+            </GridItem>
           )
         })}
-      </Flex>
+      </Grid>
     )
   }
 


### PR DESCRIPTION
We look for tabs that have a first `<p>` child.

<img width="766" alt="choice tiles" src="https://user-images.githubusercontent.com/4741620/161579409-de743404-feef-472b-914e-d4fcf6bf16d9.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
