### PR TITLE
fix(plugins/plugin-client-common): improve guide command handling of wizard description

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -235,14 +235,18 @@ export default class Guide extends React.PureComponent<Props, State> {
 
   /** UI to indicate what choices the user has already made */
   private chips() {
+    const chips = this.state.choices.entries().map(([key, value]) => (
+      <Chip key={key} ouiaId={key} onClick={this.removeChip}>
+        {value}
+      </Chip>
+    ))
+
     return (
-      <ChipGroup numChips={6}>
-        {this.state.choices.entries().map(([key, value]) => (
-          <Chip key={key} ouiaId={key} onClick={this.removeChip}>
-            {value}
-          </Chip>
-        ))}
-      </ChipGroup>
+      chips.length > 0 && (
+        <div className="kui--markdown-major-paragraph">
+          <ChipGroup numChips={6}>{chips}</ChipGroup>
+        </div>
+      )
     )
   }
 
@@ -251,7 +255,7 @@ export default class Guide extends React.PureComponent<Props, State> {
 
     return (
       <React.Fragment>
-        {descriptionContent && <div className="paragraph">{descriptionContent}</div>}
+        {descriptionContent && <Markdown nested source={descriptionContent} />}
 
         {this.chips()}
       </React.Fragment>

--- a/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
@@ -114,7 +114,8 @@ ${tabContent}
           .map(_ => indent(_))
           .join('\n')
 
-        node['value'] = `!!!${open ? '+' : ''} ${className} "${title}"
+        node['value'] = `
+!!!${open ? '+' : ''} ${className} "${title}"
 
 ${tipContent}
 `
@@ -131,9 +132,24 @@ ${tipContent}
   return root
 }
 
+/**
+ * We need to back out some <span className="paragraph"> back to
+ * <p>. We might have done this in other places to avoid nested <p>.
+ */
+function paragraphs(root: Node) {
+  visit(root, 'element', node => {
+    if (isElementWithProperties(node) && node.tagName === 'span' && node.properties.className === 'paragraph') {
+      node.tagName = 'p'
+      delete node.properties.className
+    }
+  })
+
+  return root
+}
+
 /** This is the small bit of munging we need to do */
 function munge(root: Node) {
-  return stringifyTabs(pruneComments(pruneImports(root)))
+  return paragraphs(stringifyTabs(pruneComments(pruneImports(root))))
 }
 
 /**


### PR DESCRIPTION
we weren't picking up a description for the guide command's auto-generated wizard

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
