### PR TITLE
feat(plugins/plugin-client-common): refinements to wizard header guidebook spacing

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
@@ -17,7 +17,7 @@
 /**
  * This component offers a fairly thin wrapper over PatternFly's Wizard, with a few extra features:
  *
- * 1. specifies an inverted color context for the header
+ * 1. allows control of header theming
  * 2. adds a minimize/maximize toggler to the header
  *
  */
@@ -79,7 +79,7 @@ export default class KWizard extends React.PureComponent<Props, State> {
   private header() {
     return (
       <React.Fragment>
-        <div className="kui--wizard-header kui--inverted-color-context">
+        <div className="kui--wizard-header">
           {this.headerActions()}
           {this.title()}
           {this.description()}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -333,7 +333,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       (position !== 'default'
         ? this.state.splits.find(_ => _.position === position)
         : this.state.splits.filter(_ => _.position === 'default')[count]) ||
-      this.makePositionedSplit(position, { createdBy: 'kui', hasActiveInput })
+      this.makePositionedSplit(position, { createdBy: 'kui', hasActiveInput, maximized })
 
     if (split) {
       this.splice(
@@ -379,7 +379,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
   public readonly modify = (
     sbuuid: string,
     node: React.ReactNode,
-    { hasActiveInput, inverseColors }: InjectorOptions
+    { hasActiveInput, inverseColors, maximized = false }: InjectorOptions
   ): React.ReactNode => {
     this.setState(curState => {
       const sbidx = this.findSplit(this.state, sbuuid)
@@ -387,6 +387,10 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
         return null
       } else {
         const splits = curState.splits.slice()
+
+        if (typeof maximized === 'boolean') {
+          splits[sbidx].maximized = maximized
+        }
 
         if (typeof inverseColors === 'boolean') {
           splits[sbidx].inverseColors = inverseColors
@@ -1506,6 +1510,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       'data-position': scrollback.position,
       key: tab.uuid,
       'data-scrollback-id': tab.uuid,
+      'data-is-maximized': scrollback.maximized || undefined,
       'data-has-maximized-block': !!scrollback.blocks.find(isMaximized) || undefined,
       ref: scrollback.tabRefFor,
       onClick: scrollback.onClick, // fancier for bottom input (just below, too)? !this.props.noActiveInput ? scrollback.onClick : undefined,

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollbackState.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollbackState.ts
@@ -38,7 +38,11 @@ export type CreatedBy = {
   createdBy: 'user' | 'kui' | 'default'
 }
 
-export type ScrollbackOptions = NewSplitRequest['options'] & Partial<CreatedBy>
+export type ScrollbackOptions = NewSplitRequest['options'] &
+  Partial<CreatedBy> & {
+    /** eliminate outer padding */
+    maximized?: boolean
+  }
 
 type ScrollbackState = ScrollbackOptions &
   Required<CreatedBy> & {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitInjector.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitInjector.ts
@@ -18,7 +18,7 @@ import React from 'react'
 import SplitPosition from './SplitPosition'
 
 export interface InjectorOptions {
-  /** @deprecated */
+  /** Eliminate padding/margins around outer content */
   maximized?: boolean
 
   /** Use inverse colors in the split? */

--- a/plugins/plugin-client-common/src/controller/guide.ts
+++ b/plugins/plugin-client-common/src/controller/guide.ts
@@ -67,7 +67,9 @@ async function guide(args: Arguments<HereOptions>) {
   const data = `---
 layout:
     1: left
-    2: default
+    2: 
+        position: default
+        maximized: true
 imports:
     - ${Util.expandHomeDir(filepath)}
 ---

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Maximized.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Maximized.scss
@@ -35,3 +35,11 @@
     @content;
   }
 }
+
+@mixin MaximizedSplit {
+  @include Scrollback {
+    &[data-is-maximized] {
+      @content;
+    }
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
@@ -17,7 +17,10 @@
 /** Scrollback styling */
 
 @import 'mixins';
-@import './Block';
+@import 'Block';
+@import 'Maximized';
+@import '../Card/mixins';
+@import '../Wizard/mixins';
 
 $split-padding: 0.5em;
 $split-gutter-gap: 6px;
@@ -57,5 +60,31 @@ $split-bgcolor: var(--color-repl-background);
   @include ScrollbackBlockListInner {
     flex: 1;
     overflow: auto;
+  }
+}
+@include MaximizedSplit {
+  @include ScrollbackBlockList {
+    @include FlushToContainer;
+  }
+  @include Block {
+    @include FlushToContainer;
+    @include BlockInput {
+      @include FlushToContainer;
+    }
+    @include BlockOutput {
+      @include FlushToContainer;
+    }
+  }
+  @include Commentary {
+    @include FlushToContainer;
+  }
+  @include CardBody {
+    @include FlushToContainer;
+  }
+  @include WizardNav {
+    padding-left: $inset;
+  }
+  @include WizardBody {
+    padding: $inset #{2 * $inset};
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -54,6 +54,11 @@ $repl-context-margin-right: 0.5em;
 /** Hover hysteresis for showing action buttons */
 $action-hover-delay: 210ms;
 
+@mixin FlushToContainer {
+  margin: 0;
+  padding: 0;
+}
+
 @mixin Scrollback {
   .kui--scrollback {
     @content;

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -17,7 +17,6 @@
 @import 'common';
 @import 'dark-mixins';
 @import '@kui-shell/plugin-client-common/web/scss/Themes/mixins';
-@import '@kui-shell/plugin-client-common/web/scss/components/Wizard/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/Sidecar/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/StatusStripe/mixins';
@@ -178,9 +177,5 @@ body[kui-theme='Light'] {
   }
   @include CommentaryEditor {
     @include InvertColors;
-  }
-  @include WizardHeader {
-    @include Dark;
-    @include Reset;
   }
 }

--- a/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
@@ -18,7 +18,6 @@
 @import 'common';
 @import 'dark';
 @import 'light';
-@import '@kui-shell/plugin-client-common/web/scss/components/Wizard/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/StatusStripe/mixins';
 @import '@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins';
 
@@ -37,9 +36,6 @@ body.kui--patternfly4[kui-theme='PatternFly4 Light'][kui-theme-style] {
     @include InvertLightToDark;
   }
   @include CommentaryEditor {
-    @include InvertLightToDark;
-  }
-  @include WizardHeader {
     @include InvertLightToDark;
   }
 }


### PR DESCRIPTION
1. Try not using inverted color for wizard header
2. maximize the content so that the wizard header is snapped to the bounding container
3. a few minor fixes to themes that were still hard-wiring inverted colors for wizard headers

## Proposed

The `guide` command will do this by default. If you want it in other guidebooks, e.g.:

```markdown
---
layout:
    1: left
    2: 
        position: default
        maximized: true
---

left content

---

right content that will be "maximized"

```

<img width="1272" alt="wizard header light and maximized" src="https://user-images.githubusercontent.com/4741620/161612877-96464f63-4807-4f46-8635-51ef5d97e920.png">

## Existing

<img width="1272" alt="wizard header dark and not maximized" src="https://user-images.githubusercontent.com/4741620/161613188-e103d99f-db81-49f5-ad62-19aaff296f5d.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
