### PR TITLE
fix(plugins/plugin-client-common): Guide does not properly format links

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
@@ -163,6 +163,6 @@ export default function toMarkdownString(root: Node) {
 
   return toMarkdown(toMdast(munge(JSON.parse(JSON.stringify(root)) as Node)))
     .replace(/(\\)+([=`-][=`-][=`-])/g, '$2')
-    .replace(/(\\)+([*<>`])/g, '$2')
+    .replace(/(\\)+([[\]()*<>`])/g, '$2')
     .replace(/&#x20;/g, ' ')
 }


### PR DESCRIPTION
This is an issue with more backslash escaping from toMarkdown

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
