### PR TITLE
fix(plugins/plugin-client-common): clean up Guide header

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -43,6 +43,8 @@ import Icons from '../../../../spi/Icons'
 import Markdown, { Choices } from '../..'
 import { Status, statusToClassName, statusToIcon } from '../../../ProgressStepper'
 
+import '../../../../../../web/scss/components/Wizard/Guide.scss'
+
 const strings = i18n('plugin-client-common', 'code')
 
 type WizardStepWithGraph = { graph: Graph; step: WizardStep }
@@ -284,9 +286,9 @@ export default class Guide extends React.PureComponent<Props, State> {
 
     return (
       chips.length > 0 && (
-        <div className="kui--markdown-major-paragraph">
-          <ChipGroup numChips={6}>{chips}</ChipGroup>
-        </div>
+        <ChipGroup className="kui--chip-group" categoryName="Choices" numChips={8}>
+          {chips}
+        </ChipGroup>
       )
     )
   }
@@ -304,35 +306,32 @@ export default class Guide extends React.PureComponent<Props, State> {
     const variant = nDone === nTotal ? 'success' : nError > 0 ? 'danger' : undefined
 
     return (
-      <div className="kui--markdown-major-paragraph">
-        <Progress
-          aria-label="wizard progress"
-          className="kui--wizard-progress"
-          min={0}
-          max={nTotal}
-          value={nDone}
-          title={strings('Completed Tasks')}
-          label={label}
-          valueText={label}
-          size="sm"
-          variant={variant}
-          measureLocation="outside"
-        />
-      </div>
+      <Progress
+        aria-label="wizard progress"
+        className="kui--wizard-progress"
+        min={0}
+        max={nTotal}
+        value={nDone}
+        title={strings('Completed Tasks')}
+        label={label}
+        valueText={label}
+        size="sm"
+        variant={variant}
+        measureLocation="outside"
+      />
     )
   }
 
   private wizardDescription() {
     const descriptionContent = extractDescription(this.state.graph)
-
-    return <React.Fragment>{descriptionContent && <Markdown nested source={descriptionContent} />}</React.Fragment>
+    return descriptionContent && <Markdown nested source={descriptionContent} />
   }
 
   private wizardDescriptionFooter(steps: WizardStep[]) {
     return (
-      <React.Fragment>
+      <div className="kui--markdown-major-paragraph">
         {this.chips()} {this.progress(steps)}
-      </React.Fragment>
+      </div>
     )
   }
 
@@ -342,15 +341,17 @@ export default class Guide extends React.PureComponent<Props, State> {
     return steps.length === 0 ? (
       'Nothing to do!'
     ) : (
-      <div className="kui--wizard">
-        <div className="kui--wizard-main-content">
-          <Wizard
-            hideClose
-            steps={steps}
-            title={extractTitle(this.state.graph)}
-            description={this.wizardDescription()}
-            descriptionFooter={this.wizardDescriptionFooter(steps)}
-          />
+      <div className="kui--guide">
+        <div className="kui--wizard">
+          <div className="kui--wizard-main-content">
+            <Wizard
+              hideClose
+              steps={steps}
+              title={extractTitle(this.state.graph)}
+              description={this.wizardDescription()}
+              descriptionFooter={this.wizardDescriptionFooter(steps)}
+            />
+          </div>
         </div>
       </div>
     )

--- a/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@mixin Guide {
+  .kui--guide {
+    @content;
+  }
+}
+
+@mixin ChipGroup {
+  .kui--chip-group {
+    @content;
+  }
+}
+@mixin ChipGroupMain {
+  .pf-c-chip-group__main {
+    @content;
+  }
+}
+@mixin ChipGroupLabel {
+  .pf-c-chip-group__label {
+    @content;
+  }
+}
+
+@include Guide {
+  @include ChipGroup {
+    padding: 0;
+  }
+  @include ChipGroupLabel {
+    text-align: right;
+  }
+  @include ChipGroupMain {
+    display: grid;
+    grid-template-columns: 7rem 1fr;
+    column-gap: 1rem;
+  }
+}


### PR DESCRIPTION
align the Choices and Completed Tasks

<img width="1199" alt="guidebook with choices and Completed Tasks" src="https://user-images.githubusercontent.com/4741620/161865510-f45fa007-36f2-4562-934e-620b38b3d542.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
