### PR TITLE
fix(plugins/plugin-client-common): non-pty output can have extra whitespace at top

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -138,6 +138,9 @@ export type Props = Partial<Choices> & {
   /** css class for top-level element */
   className?: string
 
+  /** extra css classes for top-level element */
+  extraClassName?: string
+
   /** Do not linkify external links */
   noExternalLinks?: boolean
 
@@ -443,7 +446,8 @@ export default class Markdown extends React.PureComponent<Props, State> {
             data-is-nested={this.props.nested || undefined}
             className={
               this.props.className ||
-              'padding-content marked-content page-content' +
+              'padding-content marked-content page-content ' +
+                (this.props.extraClassName || '') +
                 (!this.props.nested ? ' scrollable scrollable-x scrollable-auto' : '')
             }
           >

--- a/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
@@ -141,6 +141,7 @@ export default class Scalar extends React.PureComponent<Props, State> {
         return (
           <Markdown
             tab={tab}
+            extraClassName="kui--markdown-from-repl"
             source={message.replace(/\\/g, '\\\\').replace(/\n/g, '\n\n')}
             onRender={this._onRender}
           />

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -561,6 +561,13 @@ $tip-toggle-opacity-2: 0.6;
   }
 }
 
+/** see https://github.com/kubernetes-sigs/kui/pull/8808 */
+.kui--markdown-from-repl {
+  & > p:first-child {
+    margin-top: 0;
+  }
+}
+
 @include MarkdownTabContentCard {
   /** Nested tabs */
   @include MarkdownTabContentCard {


### PR DESCRIPTION
this is a regression from some css tweaks for paragraphs in guidebook markdown

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
