### PR TITLE
fix(plugins/plugin-client-common): guide wizard should start at first non-complete step

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
@@ -98,13 +98,19 @@ export default class KWizard extends React.PureComponent<Props, State> {
   }
 
   public render() {
-    const { steps } = this.props
+    const { steps, startAtStep } = this.props
 
+    // re: key={startAtStep} see https://github.com/patternfly/patternfly-react/issues/7184
     return (
       <div className="kui--wizard" data-collapsed-header={this.state.collapsedHeader || undefined}>
         {this.header()}
         <div className="kui--wizard-main-content">
-          <Wizard steps={steps.length === 0 ? [{ name: '', component: '' }] : steps} footer={this.footer()} />
+          <Wizard
+            key={startAtStep}
+            steps={steps.length === 0 ? [{ name: '', component: '' }] : steps}
+            startAtStep={startAtStep}
+            footer={this.footer()}
+          />
         </div>
       </div>
     )

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -296,7 +296,7 @@ export default class Guide extends React.PureComponent<Props, State> {
 
     return (
       chips.length > 0 && (
-        <ChipGroup className="kui--chip-group" categoryName="Choices" numChips={8}>
+        <ChipGroup className="kui--chip-group" categoryName={strings('Choices')} numChips={8}>
           {chips}
         </ChipGroup>
       )
@@ -348,6 +348,9 @@ export default class Guide extends React.PureComponent<Props, State> {
   private presentChoices() {
     const steps = this.validateStepsIfNeeded(this.wizardSteps()).map(this.addCommonWizardStepProperties)
 
+    // start at the first non-success step
+    const startAtStep = steps.findIndex((_, idx) => this.state.wizardStepStatus[idx] !== 'success')
+
     return steps.length === 0 ? (
       'Nothing to do!'
     ) : (
@@ -357,6 +360,7 @@ export default class Guide extends React.PureComponent<Props, State> {
             <Wizard
               hideClose
               steps={steps}
+              startAtStep={startAtStep < 0 ? 1 : startAtStep + 1}
               title={extractTitle(this.state.graph)}
               description={this.wizardDescription()}
               descriptionFooter={this.wizardDescriptionFooter(steps)}


### PR DESCRIPTION
Right now, it always starts at the first step.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
