### PR TITLE
fix(plugins/plugin-client-common): improve spacing and typography in our Wizard wrapper

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
@@ -23,7 +23,7 @@
  */
 
 import React from 'react'
-import { Wizard, WizardProps } from '@patternfly/react-core'
+import { Title, TitleSizes, Wizard, WizardProps } from '@patternfly/react-core'
 
 import Icons from '../../../../spi/Icons'
 
@@ -66,9 +66,14 @@ export default class KWizard extends React.PureComponent<Props, State> {
   private title() {
     const label = this.props.title
     return (
-      <div className="kui--wizard-header-title pf-c-wizard__title" aria-label={label}>
+      <Title
+        headingLevel="h2"
+        size={TitleSizes['3xl']}
+        className="kui--wizard-header-title pf-c-wizard__title"
+        aria-label={label}
+      >
         {label}
-      </div>
+      </Title>
     )
   }
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -194,6 +194,7 @@ export default class Guide extends React.PureComponent<Props, State> {
               <Tile
                 isStacked
                 title={_.title}
+                className="kui--tile"
                 icon={<Icons icon="PlusSquare" />}
                 isSelected={this.state.choices && this.state.choices.get(choice.group) === _.title}
                 onClick={this.onChoice}
@@ -296,7 +297,7 @@ export default class Guide extends React.PureComponent<Props, State> {
 
     return (
       chips.length > 0 && (
-        <ChipGroup className="kui--chip-group" categoryName={strings('Choices')} numChips={8}>
+        <ChipGroup className="kui--chip-group" categoryName={strings('Your Choices')} numChips={8}>
           {chips}
         </ChipGroup>
       )

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -16,6 +16,7 @@
 
 @import 'mixins';
 @import '../Card/mixins';
+@import '../Text/mixins';
 @import '../Tree/mixins';
 @import '../Editor/mixins';
 @import '../Wizard/mixins';

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
@@ -83,9 +83,9 @@ $split-bgcolor: var(--color-repl-background);
     @include FlushToContainer;
   }
   @include WizardNav {
-    padding-left: $inset;
+    padding-left: #{0.5 * $inset};
   }
   @include WizardBody {
-    padding: $inset #{2 * $inset};
+    padding: $inset #{1.5 * $inset};
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Text/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Text/_mixins.scss
@@ -14,39 +14,8 @@
  * limitations under the License.
  */
 
-@mixin Guide {
-  .kui--guide {
+@mixin TextContent {
+  .pf-c-content {
     @content;
-  }
-}
-
-@mixin ChipGroup {
-  .kui--chip-group {
-    @content;
-  }
-}
-@mixin ChipGroupMain {
-  .pf-c-chip-group__main {
-    @content;
-  }
-}
-@mixin ChipGroupLabel {
-  .pf-c-chip-group__label {
-    @content;
-  }
-}
-
-@include Guide {
-  @include ChipGroup {
-    padding: 0;
-  }
-  @include ChipGroupLabel {
-    margin: 0;
-    text-align: right;
-  }
-  @include ChipGroupMain {
-    display: grid;
-    grid-template-columns: 7rem 1fr;
-    column-gap: 1rem;
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Tile/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tile/_mixins.scss
@@ -14,39 +14,8 @@
  * limitations under the License.
  */
 
-@mixin Guide {
-  .kui--guide {
+@mixin Tile {
+  .kui--tile {
     @content;
-  }
-}
-
-@mixin ChipGroup {
-  .kui--chip-group {
-    @content;
-  }
-}
-@mixin ChipGroupMain {
-  .pf-c-chip-group__main {
-    @content;
-  }
-}
-@mixin ChipGroupLabel {
-  .pf-c-chip-group__label {
-    @content;
-  }
-}
-
-@include Guide {
-  @include ChipGroup {
-    padding: 0;
-  }
-  @include ChipGroupLabel {
-    margin: 0;
-    text-align: right;
-  }
-  @include ChipGroupMain {
-    display: grid;
-    grid-template-columns: 7rem 1fr;
-    column-gap: 1rem;
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Wizard/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/_index.scss
@@ -15,6 +15,8 @@
  */
 
 @import 'mixins';
+@import '../Text/mixins';
+@import '../Tile/mixins';
 @import '../Progress/mixins';
 @import '../Terminal/mixins';
 
@@ -43,12 +45,6 @@
   }
 }
 
-@include WizardDescription {
-  p:first-child {
-    margin-top: 0;
-  }
-}
-
 @include WizardHeaderActionButtons {
   position: absolute;
   top: 1em;
@@ -57,23 +53,48 @@
 
 @include WizardHeader {
   position: relative;
-  padding: 2em;
+  padding: 1.5em;
 }
 
-@include WizardTitle {
-  font-family: var(--font-sans-serif-title);
-  font-size: var(--pf-global--FontSize--3xl);
-  margin-bottom: 1em;
+@include Wizard {
+  @include WizardDescription {
+    padding-top: 0.5em;
+    & > {
+      @include TextContent {
+        & > {
+          @include Markdown {
+            & > p {
+              font-size: 1rem;
+            }
+          }
+        }
+      }
+    }
+    p:first-child {
+      margin-top: 0;
+    }
+  }
+}
+
+@include WizardBody {
+  @include Tile {
+    height: 100%;
+  }
 }
 
 /** Place wizard header progress title beside bar */
 @include Wizard {
+  @include WizardTitle {
+    margin: 0;
+  }
+
   @include WizardHeader {
     @include WizardProgress {
       grid-template-rows: 1fr;
       grid-template-columns: 7em 1fr 3em;
 
       @include ProgressDescription {
+        text-align: right;
         grid-row: 1;
         grid-column: 1;
       }


### PR DESCRIPTION
We have a small wrapper over the PatternFly Wizard, to work around some issues with nesting a wizard inside of a flex region. But our typography and spacing is far off from what they have in their modal variant.

## After

<img width="1184" alt="wizard with improved spacing and typography" src="https://user-images.githubusercontent.com/4741620/162210561-be4b1f6f-4a6e-446c-a09a-9570da6cd7e0.png">

## Before

<img width="1185" alt="wizard prior to with improved spacing and typography" src="https://user-images.githubusercontent.com/4741620/162209045-98e25579-83f4-4095-9d8e-4d6c676c3c73.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
