### PR TITLE
fix(plugins/plugin-client-common): use inner scrolling for guide wizard body

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
@@ -105,6 +105,10 @@ export default class KWizard extends React.PureComponent<Props, State> {
   public render() {
     const { steps, startAtStep } = this.props
 
+    // hmm there doesn't seem to be a better way to get the last
+    // step's Next button to be disabled; it isn't by default
+    steps[steps.length - 1].enableNext = false
+
     // re: key={startAtStep} see https://github.com/patternfly/patternfly-react/issues/7184
     return (
       <div className="kui--wizard" data-collapsed-header={this.state.collapsedHeader || undefined}>

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
@@ -20,6 +20,7 @@
 @import 'Block';
 @import 'Maximized';
 @import '../Card/mixins';
+@import '../Text/mixins';
 @import '../Wizard/mixins';
 
 $split-padding: 0.5em;
@@ -82,10 +83,25 @@ $split-bgcolor: var(--color-repl-background);
   @include CardBody {
     @include FlushToContainer;
   }
-  @include WizardNav {
-    padding-left: #{0.5 * $inset};
+
+  /** Allow inner scrolling */
+  @include ScrollbackBlockListInner {
+    overflow: hidden;
   }
-  @include WizardBody {
-    padding: $inset #{1.5 * $inset};
+  @include BlockOutput {
+    height: 100%;
+  }
+  @include CommandOutput {
+    height: 100%;
+    flex-wrap: unset;
+  }
+  @include CardBody {
+    height: 100%;
+  }
+  @include TextContent {
+    height: 100%;
+  }
+  @include Markdown {
+    height: 100%;
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+@import 'mixins';
+@import '../Tile/mixins';
+@import '../Terminal/Maximized';
+
 @mixin Guide {
   .kui--guide {
     @content;
@@ -39,6 +43,7 @@
 @include Guide {
   @include ChipGroup {
     padding: 0;
+    --pf-c-chip-group--m-category--BackgroundColor: transparent;
   }
   @include ChipGroupLabel {
     margin: 0;
@@ -48,5 +53,34 @@
     display: grid;
     grid-template-columns: 7rem 1fr;
     column-gap: 1rem;
+  }
+}
+
+@include Guide {
+  @include Tile {
+    height: 100%;
+    background-color: var(--color-base01);
+    --pf-c-tile__body--Color: var(--color-text-01);
+    --pf-c-tile__icon--Color: var(--color-text-01);
+    --pf-c-tile__title--Color: var(--color-text-01);
+  }
+}
+
+@include MaximizedSplit {
+  @include Guide {
+    height: 100%;
+  }
+  @include Wizard {
+    height: 100%;
+  }
+  @include WizardMainContent {
+    height: 100%;
+    overflow: hidden;
+  }
+  @include WizardNav {
+    padding-left: #{0.5 * $inset};
+  }
+  @include WizardBody {
+    padding: #{1.5 * $inset};
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/PatternFly.scss
@@ -38,26 +38,6 @@
       margin-bottom: 0;
     }
   }
-
-  @include WizardBody {
-    padding-top: 0;
-    padding-bottom: 0;
-    padding-right: 0;
-  }
-
-  .pf-c-wizard__outer-wrap {
-    padding-left: 0;
-  }
-  .pf-c-wizard__inner-wrap {
-    flex-direction: row;
-  }
-  @include WizardNav {
-    height: auto;
-    width: 16rem;
-    min-width: 16rem;
-    max-width: 16rem;
-    position: unset;
-  }
 }
 
 @include WizardFooter {

--- a/plugins/plugin-client-common/web/scss/components/Wizard/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/_index.scss
@@ -16,7 +16,6 @@
 
 @import 'mixins';
 @import '../Text/mixins';
-@import '../Tile/mixins';
 @import '../Progress/mixins';
 @import '../Terminal/mixins';
 
@@ -73,12 +72,6 @@
     p:first-child {
       margin-top: 0;
     }
-  }
-}
-
-@include WizardBody {
-  @include Tile {
-    height: 100%;
   }
 }
 


### PR DESCRIPTION
This PR also restores the default PatternFly border behavior around the nav and footer.

<img width="1440" alt="guide wizard with improved borders" src="https://user-images.githubusercontent.com/4741620/162242596-71451f3d-8486-42d5-b2fd-0dc5a96c9606.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
