### PR TITLE
fix(plugins/plugin-client-common): Guide can have blank steps

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/choice-frontier.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/choice-frontier.ts
@@ -18,10 +18,10 @@ import { v4 } from 'uuid'
 
 import {
   Choice,
-  CodeBlockProps,
   Graph,
   hasKey,
   hasTitle,
+  isLeafNode,
   isSubTask,
   isChoice,
   isSequence,
@@ -52,9 +52,14 @@ function key(graph: Graph) {
  *  the user has already indicated a selection for that choice.
  */
 
-export function findCodeBlockFrontier(graph: Graph, choices: ChoiceState): CodeBlockProps[] {
+export function findCodeBlockFrontier(graph: Graph, choices: ChoiceState): Graph[] {
   if (isSubTask(graph)) {
-    return findCodeBlockFrontier(graph.graph, choices)
+    const children = findCodeBlockFrontier(graph.graph, choices)
+    if (children.every(isLeafNode)) {
+      return [graph]
+    } else {
+      return children
+    }
   } else if (isChoice(graph)) {
     if (graph.group in choices) {
       const whatTheUserChose = chooseIndex(graph, choices)

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/graph/index.ts
@@ -215,6 +215,10 @@ type InteriorNode<T extends Unordered | Ordered = Unordered> =
 
 type LeafNode<T extends Unordered | Ordered = Unordered> = CodeBlockProps & T
 
+export function isLeafNode<T extends Unordered | Ordered = Unordered>(graph: Graph<T>): graph is LeafNode<T> {
+  return typeof (graph as LeafNode<T>).body === 'string'
+}
+
 export type Graph<T extends Unordered | Ordered = Unordered> = InteriorNode<T> | LeafNode<T>
 
 export type OrderedGraph = Graph<Ordered>
@@ -304,6 +308,12 @@ export function choose<T extends Unordered | Ordered = Unordered>(
   choices: 'default-path' | ChoiceState = 'default-path'
 ): Graph<T> {
   return graph.choices[chooseIndex(graph, choices)].graph
+}
+
+export function bodySource(graph: LeafNode): string {
+  return `\`\`\`${graph.language}
+${graph.body}
+\`\`\``
 }
 
 export function hasSource(graph: Graph): graph is Graph & Source {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -30,6 +30,8 @@ import {
   OrderedGraph,
   extractTitle,
   extractDescription,
+  isLeafNode,
+  bodySource,
   hasSource,
   sameGraph
 } from '../code/graph'
@@ -146,9 +148,8 @@ export default class Guide extends React.PureComponent<Props, State> {
   }
 
   private graph(graph: Graph) {
-    if (hasSource(graph)) {
-      return this.stepContent(<Markdown nested source={graph.source} choices={this.state.choices} />)
-    }
+    const source = hasSource(graph) ? graph.source : isLeafNode(graph) ? bodySource(graph) : ''
+    return this.stepContent(<Markdown nested source={source} choices={this.state.choices} />)
   }
 
   private wizardStepDescription(description: string) {
@@ -170,7 +171,7 @@ export default class Guide extends React.PureComponent<Props, State> {
     return {
       graph,
       step: {
-        name: extractTitle(graph),
+        name: extractTitle(graph) || <span className="red-text">Missing title</span>,
         component: this.graph(graph),
         stepNavItemProps: {
           children: this.wizardStepDescription(extractDescription(graph))


### PR DESCRIPTION
The "just find all code blocks" fallback isn't handling the case where all we have is code blocks, with no titles. It presents wizard steps, one per code block, none of which have a title.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
