### PR TITLE
fix(plugins/plugin-client-common): improve Missing titles in guide steps

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tip/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/rehype-tip/index.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import { Node, Element } from 'hast'
 import { i18n } from '@kui-shell/core'
+
+import isElementWithProperties from '../isElement'
 
 const strings = i18n('plugin-client-common', 'markdown')
 
@@ -24,6 +27,22 @@ const RE_TIP_END = /^(.*)"\s*(\n(.|[\n\r])*)?$/
 
 export const START_OF_TIP = `<!-- ____KUI_START_OF_TIP____ -->`
 export const END_OF_TIP = `<!-- ____KUI_END_OF_TIP____ -->`
+
+export function isTip(node: Node): node is Element {
+  return isElementWithProperties(node) && node.tagName === 'tip'
+}
+
+export function getTipTitle(elt: Element) {
+  return elt.properties.title.toString()
+}
+
+export function isTipWithFullTitle(node: Node): node is Element {
+  return isTip(node) && !!node.properties.fullTitle
+}
+
+export function isTipWithoutFullTitle(node: Node): node is Element {
+  return isTip(node) && !node.properties.fullTitle
+}
 
 export default function plugin(/* options */) {
   return function transformer(tree) {
@@ -108,6 +127,7 @@ export default function plugin(/* options */) {
                     properties: {
                       className: startMatch[3].toLowerCase(), // e.g. tip, todo, bug, warning, ...
                       float: startMatch[6] ? 'left' : startMatch[7] ? 'right' : undefined,
+                      hasFullTitle: !!startMatch[5],
                       title: startMatch[5] || strings(startMatch[3]),
                       open: !!startMatch[2] || startMatch[1] === '!!!'
                     },
@@ -127,6 +147,7 @@ export default function plugin(/* options */) {
                       tagName: 'tip',
                       properties: {
                         className: startMatch[3].toLowerCase(), // e.g. tip, todo, bug, warning, ...
+                        hasFullTitle: !!startMatch[5],
                         title: startMatch[5] || strings(startMatch[3]),
                         open: !!startMatch[2] || startMatch[1] === '!!!',
                         partial: true

--- a/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
@@ -21,6 +21,7 @@ import { Node } from 'hast-util-to-mdast/lib'
 import { visit, CONTINUE, SKIP } from 'unist-util-visit'
 import { toMarkdown } from 'mdast-util-to-markdown'
 
+import { isTip } from './rehype-tip'
 import { isImports } from './remark-import'
 import indent, { indentAll } from './indent'
 import isElementWithProperties from './isElement'
@@ -109,7 +110,7 @@ ${tabContent}
         delete node.children
         delete node.properties
         return SKIP
-      } else if (node.tagName === 'tip') {
+      } else if (isTip(node)) {
         const { className, title, open } = node.properties
 
         const tipContent = node.children


### PR DESCRIPTION
This PR detects when we don't have enough context for a code block, and if so looks for the nearest enclosing heading (or tip title) to add that missing context.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
