### PR TITLE
fix(plugins/plugin-client-common): Search component may emit console errors

### DIFF
--- a/plugins/plugin-electron-components/web/scss/components/Search/Search.scss
+++ b/plugins/plugin-electron-components/web/scss/components/Search/Search.scss
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .kui--search {
   .pf-c-search-input__icon {
     z-index: 1000;
     color: var(--color-text-01);
   }
   .pf-c-search-input__text-input {
-    //font-family: var(--font-sans-serif);
+    min-height: 2.25rem;
     color: var(--color-text-01);
     background-color: transparent;
   }


### PR DESCRIPTION
There are two issues:
1) we are invoking the electron findInPage API with an empty string. it does not like this.
2) we are calling input.focus() in a render function. react does not like this.

I also noticed that we never unlisten from the document event listener (for cmd/ctrl+f)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
