### PR TITLE
fix(plugins/plugin-electron-components): UpdateChecker initial delay is 0ms

### DIFF
--- a/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
+++ b/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
@@ -49,7 +49,7 @@ const FEED = () => `${baseUrl()}/releases/latest`
 const DEFAULT_INTERVAL = 24 * 60 * 60 * 1000
 
 /** By default, wait 1 minute after statup for the first check */
-const DEFAULT_LAG = 0 * 60 * 1000
+const DEFAULT_LAG = 60 * 60 * 1000
 
 /** Remember that the version "duly noted" the availability of particular version in localStorage, using this key */
 const DULY_NOTED_KEY = 'kui-shell.org/UpdateChecker/DulyNoted'


### PR DESCRIPTION


This is a regression from some earlier debugging. This component should wait 60 seconds before checking for available Kui updates.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
