### PR TITLE
fix(plugins/plugin-electron-components): Search should lazily load patternfly component

### DIFF
--- a/plugins/plugin-electron-components/src/components/Search.tsx
+++ b/plugins/plugin-electron-components/src/components/Search.tsx
@@ -15,10 +15,11 @@
  */
 
 import React from 'react'
-import { SearchInput } from '@patternfly/react-core'
 import { FoundInPageResult, FindInPageOptions } from 'electron'
 
 import '../../web/scss/components/Search/Search.scss'
+
+const SearchInput = React.lazy(() => import('@patternfly/react-core').then(_ => ({ default: _.SearchInput })))
 
 type Props = {}
 


### PR DESCRIPTION

We don't need the underlying patternfly component on initial page load (and probably rarely, even after that).

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
