### PR TITLE
fix(plugins/plugin-s3): don't prefetch minio npm

### DIFF
--- a/plugins/plugin-s3/src/preload.ts
+++ b/plugins/plugin-s3/src/preload.ts
@@ -15,21 +15,11 @@
  */
 
 import { Capabilities } from '@kui-shell/core'
-// import { notebookVFS } from '@kui-shell/plugin-core-support'
 
 export default async function preloadS3Plugin() {
-  // intentionally async prefetch of a slow-loading npm
-  import('minio')
-
   const vfsPromise = Capabilities.inBrowser()
     ? import('./vfs/browser').then(_ => _.default())
     : import('./vfs').then(_ => _.default())
-
-  /* if (!Capabilities.isHeadless()) {
-    // mount notebooks
-    notebookVFS.mkdir({ argvNoOptions: ['mkdir', '/kui/s3'] })
-    notebookVFS.cp(undefined, ['plugin://plugin-s3/notebooks/welcome.json'], '/kui/s3/')
-  } */
 
   await vfsPromise
 }


### PR DESCRIPTION
For some reason, we are doing this for all Kui users.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
