### PR TITLE
fix(plugins/plugin-s3): delay loading s3 vfs bits

### DIFF
--- a/plugins/plugin-s3/src/preload.ts
+++ b/plugins/plugin-s3/src/preload.ts
@@ -16,10 +16,12 @@
 
 import { Capabilities } from '@kui-shell/core'
 
-export default async function preloadS3Plugin() {
-  const vfsPromise = Capabilities.inBrowser()
-    ? import('./vfs/browser').then(_ => _.default())
-    : import('./vfs').then(_ => _.default())
+export default function preloadS3Plugin() {
+  setTimeout(() => {
+    /* const vfsPromise = */ Capabilities.inBrowser()
+      ? import('./vfs/browser').then(_ => _.default())
+      : import('./vfs').then(_ => _.default())
+  }, 200)
 
-  await vfsPromise
+  // await vfsPromise
 }


### PR DESCRIPTION
Load time optimization for the common case (not using s3 vfs).

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
