### PR TITLE
feat: remove split position button from split header

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -1523,22 +1523,10 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       <React.Fragment>
         {this.state.splits.length > 1 && (
           <SplitHeader
-            position={scrollback.position}
             onRemove={scrollback.remove}
             onClear={scrollback.clear}
             onInvert={scrollback.invert}
             createdBy={scrollback.createdBy}
-            hasLeftStrip={this.props.hasLeftStrip}
-            hasRightStrip={this.props.hasRightStrip}
-            willToggleSplitPosition={
-              this.props.hasLeftStrip && this.props.hasRightStrip && scrollback.position === 'default'
-                ? undefined // have both strips already and this is a default split? no toggle for you!
-                : (this.props.hasLeftStrip || this.props.hasRightStrip) &&
-                  this.state.splits.length === 2 &&
-                  scrollback.position === 'default'
-                ? undefined // have 2 splits, and one of them is non-default, and this is a default? also no toggler for you
-                : scrollback.willToggleSplitPosition
-            }
           />
         )}
         <div className="kui--scrollback-block-list">

--- a/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/SplitHeader.tsx
@@ -22,24 +22,16 @@ import Tooltip from '../../spi/Tooltip'
 import { MutabilityContext } from '../../Client/MutabilityContext'
 
 import { CreatedBy } from './ScrollbackState'
-import SplitPosition, { SplitPositionProps } from './SplitPosition'
 
 import '../../../../web/scss/components/Terminal/SplitHeader.scss'
 
 const strings = i18n('plugin-client-common')
 
-type Props = SplitPositionProps &
-  CreatedBy & {
-    onRemove(): void
-    onInvert(): void
-    onClear(): void
-
-    /** Toggle whether we have a left or right strip split */
-    willToggleSplitPosition(): void
-
-    /** Position of the enclosing Split */
-    position: SplitPosition
-  }
+type Props = CreatedBy & {
+  onRemove(): void
+  onInvert(): void
+  onClear(): void
+}
 
 /** Render a header for the given split */
 export default class SplitHeader extends React.PureComponent<Props> {
@@ -56,53 +48,6 @@ export default class SplitHeader extends React.PureComponent<Props> {
             onClick={this.props.onRemove}
           >
             &#x2A2F;
-          </a>
-        </Tooltip>
-      )
-    )
-  }
-
-  private iconRotation() {
-    const goToDefault = ''
-    const goToLeft = ' kui--rotate-270'
-    const goToRight = ' kui--rotate-90'
-
-    if (this.props.position === 'default') {
-      // default->right if we have no right
-      // default->left if we have do have a right
-      if (this.props.hasRightStrip) {
-        return goToLeft
-      } else {
-        return goToRight
-      }
-    } else if (this.props.position === 'left-strip') {
-      // left always goes to default
-      return goToDefault
-    } else {
-      // right->left if we have no left
-      // right->default if we do have a left
-      if (!this.props.hasLeftStrip) {
-        return goToLeft
-      } else {
-        return goToDefault
-      }
-    }
-  }
-
-  private splitPositionToggleButton() {
-    return (
-      this.props.willToggleSplitPosition && (
-        <Tooltip content={strings('Toggle position')} position="bottom-end">
-          <a
-            href="#"
-            className="kui--tab-navigatable"
-            onMouseDown={this.stopFocusStealing}
-            onClick={this.props.willToggleSplitPosition}
-          >
-            <Icons
-              icon="TerminalOnly"
-              className={'kui--split-position-toggle kui--split-header-button' + this.iconRotation()}
-            />
           </a>
         </Tooltip>
       )
@@ -138,7 +83,6 @@ export default class SplitHeader extends React.PureComponent<Props> {
               <div className="flex-fill" />
               {this.invertButton()}
               {this.clearButton()}
-              {this.splitPositionToggleButton()}
               {this.closeButton()}
             </div>
           )

--- a/plugins/plugin-client-common/web/scss/components/Terminal/SplitHeader.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/SplitHeader.scss
@@ -41,7 +41,9 @@ body[kui-theme-style] {
   }
 
   @include SplitHeaderButton {
-    padding: 2px;
+    margin: 1px;
+    padding: 1px;
+
     &:hover {
       cursor: pointer;
       background-color: var(--color-base02);

--- a/plugins/plugin-core-support/src/test/core-support2/right-strip.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/right-strip.ts
@@ -27,7 +27,7 @@ import {
   splitViaButton
 } from './split-helpers'
 
-describe(`right strip splits ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+xdescribe(`right strip splits ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
   Util.closeAllExceptFirstTab.bind(this)()


### PR DESCRIPTION
I don't think this offers any value at this point. We will continue to support split positioning in markdown topmatter.

BREAKING CHANGE: removal of split position button from split header

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
