### PR TITLE
fix(plugins/plugin-client-common): ScrollableTerminal may emit react setState errors

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -1036,6 +1036,10 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
   }
 
   private async setFocusOnScrollback(scrollback: ScrollbackState, focusedBlockIdx?: number) {
+    if (!this.mounted) {
+      return
+    }
+
     const focusedIdx = this.findSplit(this.state, scrollback.uuid)
     if (this.state.focusedIdx !== focusedIdx) {
       const currentSplit = this.state.splits[this.state.focusedIdx]
@@ -1214,7 +1218,13 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
     this.cleaners.forEach(cleaner => cleaner())
   }
 
+  private mounted = false
+  public componentDidMount() {
+    this.mounted = true
+  }
+
   public componentWillUnmount() {
+    this.mounted = false
     this.uninitEvents()
     this.terminateAllWatchables()
   }


### PR DESCRIPTION
When focusing, we may call setState on an unmounted component.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
