### PR TITLE
fix(plugins/plugin-client-common): Guide should not auto-advance on render

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -350,8 +350,9 @@ export default class Guide extends React.PureComponent<Props, State> {
   private presentChoices() {
     const steps = this.validateStepsIfNeeded(this.wizardSteps()).map(this.addCommonWizardStepProperties)
 
-    // start at the first non-success step
-    const startAtStep = steps.findIndex((_, idx) => this.state.wizardStepStatus[idx] !== 'success')
+    // if you want to start at the first non-success step
+    // see https://github.com/kubernetes-sigs/kui/pull/8840
+    // const startAtStep = steps.findIndex((_, idx) => this.state.wizardStepStatus[idx] !== 'success')
 
     return steps.length === 0 ? (
       'Nothing to do!'
@@ -362,7 +363,6 @@ export default class Guide extends React.PureComponent<Props, State> {
             <Wizard
               hideClose
               steps={steps}
-              startAtStep={startAtStep < 0 ? 1 : startAtStep + 1}
               title={extractTitle(this.state.graph)}
               description={this.wizardDescription()}
               descriptionFooter={this.wizardDescriptionFooter(steps)}


### PR DESCRIPTION
We are trying to be clever. The Guide auto-advances to the first non-completed step. This causes glitches. For example, if it takes a few seconds to determine which steps are completed... Or if the user clicks to some other step before we determine which steps are completed.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
