### PR TITLE
feat(plugins/plugin-client-common): wizard footer should allow for extra buttons

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/Footer.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/Footer.tsx
@@ -22,14 +22,34 @@
  * SOFTWARE.
  */
 
-/** See https://github.com/patternfly/patternfly-react/blob/%40patternfly/react-core%404.202.25/packages/react-core/src/components/Wizard/WizardFooterInternal.tsx */
+/**
+ * Attribution: https://github.com/patternfly/patternfly-react/blob/%40patternfly/react-core%404.202.25/packages/react-core/src/components/Wizard/WizardFooterInternal.tsx
+ * Additions by:
+ *   - @starpit 20220412 Added `leftButtons` and `rightButtons` properties
+ */
 
 import React from 'react'
 import { css } from '@patternfly/react-styles'
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard'
 import { Button, ButtonVariant, WizardStep } from '@patternfly/react-core'
 
-export interface WizardFooterInternalProps {
+import '../../../../../../web/scss/components/Wizard/Footer.scss'
+
+export type FooterButtons = {
+  /**
+   * Buttons to place left-aligned
+   * @author @starpit
+   */
+  leftButtons?: React.ReactNode | React.ReactNode[]
+
+  /**
+   * Extra buttons to place right-aligned
+   * @author @starpit
+   */
+  rightButtons?: React.ReactNode | React.ReactNode[]
+}
+
+export interface WizardFooterInternalProps extends FooterButtons {
   onNext: any
   onBack: any
   onClose: any
@@ -50,24 +70,31 @@ export const WizardFooterInternal: React.FunctionComponent<WizardFooterInternalP
   activeStep,
   nextButtonText,
   backButtonText,
-  cancelButtonText
+  cancelButtonText,
+  leftButtons,
+  rightButtons
 }: WizardFooterInternalProps) => (
-  <footer className={css(styles.wizardFooter)}>
-    <Button variant={ButtonVariant.primary} type="submit" onClick={onNext} isDisabled={!isValid}>
-      {nextButtonText}
-    </Button>
-    {!activeStep.hideBackButton && (
-      <Button variant={ButtonVariant.secondary} onClick={onBack} isDisabled={firstStep}>
-        {backButtonText}
+  <footer className={css(styles.wizardFooter) + ' kui--wizard-footer'}>
+    <span className="kui--wizard-footer--left">
+      {leftButtons}
+      <Button variant={ButtonVariant.primary} type="submit" onClick={onNext} isDisabled={!isValid}>
+        {nextButtonText}
       </Button>
-    )}
-    {!activeStep.hideCancelButton && (
-      <div className={styles.wizardFooterCancel}>
-        <Button variant={ButtonVariant.link} onClick={onClose}>
-          {cancelButtonText}
+      {!activeStep.hideBackButton && (
+        <Button variant={ButtonVariant.secondary} onClick={onBack} isDisabled={firstStep}>
+          {backButtonText}
         </Button>
-      </div>
-    )}
+      )}
+      {!activeStep.hideCancelButton && (
+        <div className={styles.wizardFooterCancel}>
+          <Button variant={ButtonVariant.link} onClick={onClose}>
+            {cancelButtonText}
+          </Button>
+        </div>
+      )}
+    </span>
+
+    {rightButtons && <span className="kui--wizard-footer--right">{rightButtons}</span>}
   </footer>
 )
 WizardFooterInternal.displayName = 'WizardFooterInternal'

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
@@ -26,8 +26,8 @@ import React from 'react'
 import { i18n } from '@kui-shell/core'
 import { Title, TitleSizes, Wizard, WizardProps } from '@patternfly/react-core'
 
-import Footer from './Footer'
 import Icons from '../../../../spi/Icons'
+import Footer, { FooterButtons } from './Footer'
 
 import '../../../../../../web/scss/components/Wizard/PatternFly.scss'
 
@@ -43,6 +43,7 @@ type FooterState = {
 }
 
 type Props = WizardProps &
+  FooterButtons &
   Partial<HeaderState> & {
     descriptionFooter?: React.ReactNode
   }
@@ -128,6 +129,8 @@ export default class KWizard extends React.PureComponent<Props, State> {
           nextButtonText={strings('Next')}
           backButtonText={strings('Back')}
           cancelButtonText={strings('Cancel')}
+          leftButtons={this.props.leftButtons}
+          rightButtons={this.props.rightButtons}
         />
       )
     }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -296,9 +296,10 @@ export default class Guide extends React.PureComponent<Props, State> {
       </Chip>
     ))
 
+    // categoryName={strings('Your Choices')}
     return (
       chips.length > 0 && (
-        <ChipGroup className="kui--chip-group" categoryName={strings('Your Choices')} numChips={8}>
+        <ChipGroup className="kui--chip-group kui--inverted-color-context" numChips={8}>
           {chips}
         </ChipGroup>
       )
@@ -340,11 +341,7 @@ export default class Guide extends React.PureComponent<Props, State> {
   }
 
   private wizardDescriptionFooter(steps: WizardStep[]) {
-    return (
-      <div className="kui--markdown-major-paragraph">
-        {this.chips()} {this.progress(steps)}
-      </div>
-    )
+    return <div className="kui--markdown-major-paragraph">{this.progress(steps)}</div>
   }
 
   private presentChoices() {
@@ -366,6 +363,7 @@ export default class Guide extends React.PureComponent<Props, State> {
               title={extractTitle(this.state.graph)}
               description={this.wizardDescription()}
               descriptionFooter={this.wizardDescriptionFooter(steps)}
+              rightButtons={this.chips()}
             />
           </div>
         </div>

--- a/plugins/plugin-client-common/web/scss/components/Wizard/Footer.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Footer.scss
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import 'mixins';
+
+@mixin ButtonMargins {
+  & > *:not(:last-child) {
+    margin-right: var(--pf-c-wizard__footer--child--MarginRight);
+  }
+}
+
+@include WizardFooter {
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: unset;
+}
+
+@include WizardFooterLeftButtons {
+  @include ButtonMargins;
+}
+
+@include WizardFooterRightButtons {
+  @include ButtonMargins;
+  margin-left: 1em;
+  flex: 1;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-end;
+}

--- a/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
@@ -17,6 +17,7 @@
 @import 'mixins';
 @import '../Tile/mixins';
 @import '../Terminal/Maximized';
+@import '../../Themes/mixins';
 
 @mixin Guide {
   .kui--guide {
@@ -39,6 +40,36 @@
     @content;
   }
 }
+@mixin Chip {
+  .pf-c-chip {
+    @content;
+  }
+}
+@mixin ChipOverflow {
+  &.pf-m-overflow {
+    @content;
+  }
+}
+@mixin ChipLabel {
+  .pf-c-chip__text {
+    @content;
+  }
+}
+
+@include InvertedColors {
+  @include Chip {
+    --pf-c-chip--BackgroundColor: var(--color-base02);
+    svg {
+      color: var(--color-text-02);
+    }
+    @include ChipOverflow {
+      --pf-c-chip--m-overflow__text--Color: var(--color-brand-03);
+    }
+  }
+  @include ChipLabel {
+    --pf-c-chip__text--Color: var(--color-text-01);
+  }
+}
 
 @include Guide {
   @include ChipGroup {
@@ -48,11 +79,6 @@
   @include ChipGroupLabel {
     margin: 0;
     text-align: right;
-  }
-  @include ChipGroupMain {
-    display: grid;
-    grid-template-columns: 7rem 1fr;
-    column-gap: 1rem;
   }
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
@@ -63,7 +63,19 @@
 }
 
 @mixin WizardFooter {
-  .pf-c-wizard__footer {
+  .kui--wizard-footer.pf-c-wizard__footer {
+    @content;
+  }
+}
+
+@mixin WizardFooterLeftButtons {
+  .kui--wizard-footer--left {
+    @content;
+  }
+}
+
+@mixin WizardFooterRightButtons {
+  .kui--wizard-footer--right {
     @content;
   }
 }


### PR DESCRIPTION
- updates the wizard Footer.tsx component to allow callers to slot in extra buttons
- updates Guide's use of Footer to place the choice chips in the footer, rather than in the header
- updates the chips to use an inverted color scheme
- reverts to default patternfly wizard footer button placement: next and back are now again left-aligned
<img width="1347" alt="chips in footer" src="https://user-images.githubusercontent.com/4741620/163008703-33983cd3-e4ec-46f0-81fe-6bdd2d3bc57b.png">

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
