### PR TITLE
fix(plugins/plugin-client-common): improved handling of wizard step titles with colons

### DIFF
--- a/plugins/plugin-client-common/notebooks/wizard.md
+++ b/plugins/plugin-client-common/notebooks/wizard.md
@@ -8,7 +8,7 @@ WizardDescription
 
 ---
 
-## Step1Title: Step1Description
+## Step1Title:: Step1Description
 
 Step1Body
 
@@ -21,7 +21,7 @@ echo aaa
 
 ---
 
-## Step2Title: Step2Description
+## Step2Title:: Step2Description
 
 Step2Body
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/rehype-wizard.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/rehype-wizard.ts
@@ -118,7 +118,7 @@ function transformer(ast: Root) {
         )
 
         if (idx === firstNonCommentIdx) {
-          const [title, description] = node.children[0].value.split(/\s*:\s*/)
+          const [title, description] = node.children[0].value.split(/\s*::\s*/)
           parent.properties['data-kui-title'] = title
           parent.properties['data-kui-description'] = description
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
@@ -142,7 +142,7 @@ function preprocessWizardSteps(tree /*: Root */, frontmatter: KuiFrontmatter, ig
               if (typeof matchingStep !== 'string') {
                 firstChild.value =
                   (matchingStep.name || firstChild.value) +
-                  (matchingStep.description ? ': ' + matchingStep.description : '')
+                  (matchingStep.description ? ':: ' + matchingStep.description : '')
               }
             }
           }

--- a/plugins/plugin-client-common/tests/data/wizard-with-splits.md
+++ b/plugins/plugin-client-common/tests/data/wizard-with-splits.md
@@ -14,7 +14,7 @@ WizardDescriptionWithSplits
 
 ---
 
-## Step1Title: Step1Description
+## Step1Title:: Step1Description
 
 Step1Body
 
@@ -27,7 +27,7 @@ echo aaa
 
 ---
 
-## Step2Title: Step2Description
+## Step2Title:: Step2Description
 
 Step2Body
 


### PR DESCRIPTION

We were interpreting the title as "Title: Description". But some source material legitimately have titles with colons, e.g. "Optional: Do this".

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
