### PR TITLE
feat(plugins/plugin-client-common): some groundwork for for running choice-free guidebooks

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -130,8 +130,8 @@ export default class Commentary extends React.PureComponent<Props, State> {
   private cancel() {
     return (
       <Button
-        kind="secondary"
-        size="small"
+        variant="secondary"
+        isSmall
         className="kui--tab-navigatable kui--commentary-button kui--commentary-cancel-button"
         onClick={this._onCancel}
       >
@@ -165,8 +165,8 @@ export default class Commentary extends React.PureComponent<Props, State> {
   private revert() {
     return (
       <Button
-        kind="tertiary"
-        size="small"
+        variant="tertiary"
+        isSmall
         className="kui--tab-navigatable kui--commentary-button kui--commentary-revert-button"
         onClick={this._onRevert}
       >
@@ -209,7 +209,7 @@ export default class Commentary extends React.PureComponent<Props, State> {
   private done() {
     return (
       <Button
-        size="small"
+        isSmall
         className="kui--tab-navigatable kui--commentary-button kui--commentary-done-button"
         onClick={this._onDone}
       >

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/Footer.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/Footer.tsx
@@ -25,31 +25,42 @@
 /**
  * Attribution: https://github.com/patternfly/patternfly-react/blob/%40patternfly/react-core%404.202.25/packages/react-core/src/components/Wizard/WizardFooterInternal.tsx
  * Additions by:
- *   - @starpit 20220412 Added `leftButtons` and `rightButtons` properties
+ *   - @starpit 20220412 Added `leftActions` and `rightContent` properties
  */
 
 import React from 'react'
 import { css } from '@patternfly/react-styles'
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard'
-import { Button, ButtonVariant, WizardStep } from '@patternfly/react-core'
+import { WizardStep } from '@patternfly/react-core'
+
+import Button, { Props as ButtonProps } from '../../../../spi/Button'
 
 import '../../../../../../web/scss/components/Wizard/Footer.scss'
 
-export type FooterButtons = {
-  /**
-   * Buttons to place left-aligned
-   * @author @starpit
-   */
-  leftButtons?: React.ReactNode | React.ReactNode[]
+export type KuiFooterExtraProps = {
+  /** Add a box shadow effect? [default: false] */
+  boxShadow?: boolean
 
   /**
-   * Extra buttons to place right-aligned
+   * Click handlers to be placed in normal button row
    * @author @starpit
    */
-  rightButtons?: React.ReactNode | React.ReactNode[]
+  leftButtons?: ButtonProps[]
+
+  /**
+   * Click handlers to be placed in normal button row, but right-aligned
+   * @author @starpit
+   */
+  rightButtons?: ButtonProps[]
+
+  /**
+   * Extra content to place above the normal button row
+   * @author @starpit
+   */
+  topContent?: React.ReactNode
 }
 
-export interface WizardFooterInternalProps extends FooterButtons {
+export interface WizardFooterInternalProps extends KuiFooterExtraProps {
   onNext: any
   onBack: any
   onClose: any
@@ -71,30 +82,40 @@ export const WizardFooterInternal: React.FunctionComponent<WizardFooterInternalP
   nextButtonText,
   backButtonText,
   cancelButtonText,
+
+  boxShadow,
   leftButtons,
-  rightButtons
+  rightButtons,
+  topContent
 }: WizardFooterInternalProps) => (
-  <footer className={css(styles.wizardFooter) + ' kui--wizard-footer'}>
-    <span className="kui--wizard-footer--left">
-      {leftButtons}
-      <Button variant={ButtonVariant.primary} type="submit" onClick={onNext} isDisabled={!isValid}>
-        {nextButtonText}
-      </Button>
-      {!activeStep.hideBackButton && (
-        <Button variant={ButtonVariant.secondary} onClick={onBack} isDisabled={firstStep}>
-          {backButtonText}
+  <footer className={css(styles.wizardFooter) + ' kui--wizard-footer'} data-has-box-shadow={boxShadow || undefined}>
+    {topContent && <span className="kui--wizard-footer--top">{topContent}</span>}
+
+    <span className="kui--wizard-footer--bottom">
+      <span className="kui--wizard-footer--bottom-left">
+        {leftButtons && leftButtons.map((_, idx) => <Button key={idx} {..._} />)}
+        <Button variant="primary" type="submit" onClick={onNext} isDisabled={!isValid}>
+          {nextButtonText}
         </Button>
-      )}
-      {!activeStep.hideCancelButton && (
-        <div className={styles.wizardFooterCancel}>
-          <Button variant={ButtonVariant.link} onClick={onClose}>
-            {cancelButtonText}
+        {!activeStep.hideBackButton && (
+          <Button variant="secondary" onClick={onBack} isDisabled={firstStep}>
+            {backButtonText}
           </Button>
-        </div>
+        )}
+        {!activeStep.hideCancelButton && (
+          <div className={styles.wizardFooterCancel}>
+            <Button variant="link" onClick={onClose}>
+              {cancelButtonText}
+            </Button>
+          </div>
+        )}
+      </span>
+      {rightButtons && (
+        <span className="kui--wizard-footer--bottom-right">
+          {rightButtons && rightButtons.map((_, idx) => <Button key={idx} {..._} />)}
+        </span>
       )}
     </span>
-
-    {rightButtons && <span className="kui--wizard-footer--right">{rightButtons}</span>}
   </footer>
 )
 WizardFooterInternal.displayName = 'WizardFooterInternal'

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/KWizard.tsx
@@ -27,7 +27,7 @@ import { i18n } from '@kui-shell/core'
 import { Title, TitleSizes, Wizard, WizardProps } from '@patternfly/react-core'
 
 import Icons from '../../../../spi/Icons'
-import Footer, { FooterButtons } from './Footer'
+import Footer, { KuiFooterExtraProps } from './Footer'
 
 import '../../../../../../web/scss/components/Wizard/PatternFly.scss'
 
@@ -42,9 +42,10 @@ type FooterState = {
   activeStep: number
 }
 
-type Props = WizardProps &
-  FooterButtons &
+export type Props = Omit<WizardProps, 'title'> &
+  KuiFooterExtraProps &
   Partial<HeaderState> & {
+    title: React.ReactNode
     descriptionFooter?: React.ReactNode
   }
 
@@ -55,7 +56,7 @@ export default class KWizard extends React.PureComponent<Props, State> {
     super(props)
 
     this.state = {
-      activeStep: this.props.startAtStep || 1,
+      activeStep: props.startAtStep || 1,
       collapsedHeader: props.collapsedHeader || false
     }
   }
@@ -80,7 +81,7 @@ export default class KWizard extends React.PureComponent<Props, State> {
         headingLevel="h2"
         size={TitleSizes['3xl']}
         className="kui--wizard-header-title pf-c-wizard__title"
-        aria-label={label}
+        aria-label={typeof label === 'string' ? label : 'wizard title'}
       >
         {label}
       </Title>
@@ -129,8 +130,10 @@ export default class KWizard extends React.PureComponent<Props, State> {
           nextButtonText={strings('Next')}
           backButtonText={strings('Back')}
           cancelButtonText={strings('Cancel')}
+          boxShadow={this.props.boxShadow}
           leftButtons={this.props.leftButtons}
           rightButtons={this.props.rightButtons}
+          topContent={this.props.topContent}
         />
       )
     }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
@@ -20,6 +20,7 @@ import { KResponse, CommentaryResponse, getPrimaryTabId } from '@kui-shell/core'
 
 import { Props } from '../../../Markdown'
 import { tryFrontmatter } from '../../frontmatter'
+import { CodeBlockResponseFn } from '../../components'
 
 import CodeBlock from '../../../../Views/Terminal/Block/Inputv2'
 
@@ -28,13 +29,13 @@ const SimpleEditor = React.lazy(() => import('../../../Editor/SimpleEditor'))
 type CodeBlockResponse = CommentaryResponse['props']['codeBlockResponses'][0]
 export { CodeBlockResponse }
 
-export default function code(
+export default function codeWrapper(
   mdprops: Props,
   uuid: string,
-  codeBlockResponses: (codeBlockIdx: number) => CodeBlockResponse & { replayed: boolean },
+  codeBlockResponses: CodeBlockResponseFn,
   spliceInCodeExecution: (status: 'done' | 'error', response: KResponse, codeIdx: number) => void
 ) {
-  return (props: CodeProps & { codeIdx: string }) => {
+  return function code(props: CodeProps & { codeIdx: string }) {
     if (props.inline) {
       return <code className={props.className}>{props.children}</code>
     }
@@ -90,7 +91,7 @@ export default function code(
             arg1={myCodeIdx}
             onResponse={spliceInCodeExecution}
             outputOnly={outputOnly}
-            executeImmediately={attributes.execute === 'now'}
+            executeImmediately={mdprops.executeImmediately || attributes.execute === 'now'}
             data-code-index={myCodeIdx}
             data-is-maximized={attributes.maximize}
           />

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/Guide.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react'
-import { i18n } from '@kui-shell/core'
+import { v4 } from 'uuid'
+import { i18n, Tab } from '@kui-shell/core'
 import { Chip, ChipGroup, Grid, GridItem, Progress, Tile, WizardStep } from '@patternfly/react-core'
 
 import order from '../code/graph/order'
@@ -36,12 +37,13 @@ import {
   sameGraph
 } from '../code/graph'
 
-import Wizard from '../Wizard/KWizard'
+import Wizard, { Props as WizardProps } from '../Wizard/KWizard'
 
 import Card from '../../../../spi/Card'
 import Icons from '../../../../spi/Icons'
 
-import Markdown, { Choices, onChoice, offChoice } from '../..'
+import { CodeBlockResponseFn } from '../../components'
+import Markdown, { Choices, onChoice, offChoice } from '../../../Markdown'
 import { Status, statusToClassName, statusToIcon } from '../../../ProgressStepper'
 
 import '../../../../../../web/scss/components/Wizard/Guide.scss'
@@ -51,11 +53,17 @@ const strings = i18n('plugin-client-common', 'code')
 type WizardStepWithGraph = { graph: Graph; step: WizardStep }
 
 type Props = Choices & {
+  /** Enclosing Kui Tab */
+  tab: Tab
+
   /** markdown document id */
   uuid: string
 
   /** Raw list of code blocks */
   blocks: CodeBlockProps[]
+
+  /** Status of code blocks */
+  codeBlockResponses: CodeBlockResponseFn
 }
 
 type State = Choices & {
@@ -67,9 +75,18 @@ type State = Choices & {
 
   /** validation status of each wizard step */
   wizardStepStatus: Status[]
+
+  /** Which of `wizardStepStatus` to display (indexed from 1) */
+  startAtStep: number
+
+  /** are we in the middle of a `this.startRun` automated execution? */
+  isRunning: boolean
 }
 
 export default class Guide extends React.PureComponent<Props, State> {
+  private readonly choiceIcon1 = (<Icons className="yellow-text" icon="Warning" />)
+  private readonly choiceIcon2 = (<Icons icon="PlusSquare" />)
+
   public constructor(props: Props) {
     super(props)
     this.state = Guide.getDerivedStateFromProps(props)
@@ -127,13 +144,13 @@ export default class Guide extends React.PureComponent<Props, State> {
     const frontier =
       noChangeToGraph && state && state.frontier ? state.frontier : Guide.computeChoiceFrontier(graph, choices)
 
+    const startAtStep = state ? state.startAtStep : 1
     const wizardStepStatus = noChangeToGraph && state ? state.wizardStepStatus : []
 
-    return { graph, frontier, choices, wizardStepStatus }
-  }
+    const isRunning = state ? state.isRunning : false
 
-  private readonly onChoiceFromAbove = ({ choices }: Choices) =>
-    setTimeout(() => this.setState({ frontier: undefined, wizardStepStatus: [], choices: Object.assign({}, choices) }))
+    return { graph, frontier, choices, wizardStepStatus, startAtStep, isRunning }
+  }
 
   public componentDidMount() {
     onChoice(this.onChoiceFromAbove)
@@ -143,24 +160,28 @@ export default class Guide extends React.PureComponent<Props, State> {
     offChoice(this.onChoiceFromAbove)
   }
 
-  private stepContent(inner: React.ReactNode) {
-    return <Card className="kui--markdown-tab-card">{inner}</Card>
+  /** @return a wrapper UI for the content of a wizard step */
+  private stepContent(actualContent: React.ReactNode) {
+    return <Card className="kui--markdown-tab-card">{actualContent}</Card>
   }
 
-  private graph(graph: Graph) {
+  /** @return a UI component to visualize the given `graph` */
+  private renderGraph(graph: Graph) {
     const source = hasSource(graph) ? graph.source : isLeafNode(graph) ? bodySource(graph) : ''
-    return this.stepContent(<Markdown nested source={source} choices={this.state.choices} />)
+    return this.stepContent(
+      <Markdown
+        tab={this.props.tab}
+        nested
+        source={source}
+        choices={this.state.choices}
+        executeImmediately={this.state.isRunning}
+      />
+    )
   }
 
-  private wizardStepDescription(description: string) {
-    return (
-      description && (
-        <div className="kui--wizard-nav-item-description">
-          {/* this.wizardCodeBlockSteps(stepIdx) */}
-          <div className="paragraph">{description}</div>
-        </div>
-      )
-    )
+  /** @return text to place below the wizard step title */
+  private wizardStepDescription(description: React.ReactNode) {
+    return description && <div className="kui--wizard-nav-item-description">{description}</div>
   }
 
   /**
@@ -172,7 +193,7 @@ export default class Guide extends React.PureComponent<Props, State> {
       graph,
       step: {
         name: extractTitle(graph) || <span className="red-text">Missing title</span>,
-        component: this.graph(graph),
+        component: this.renderGraph(graph),
         stepNavItemProps: {
           children: this.wizardStepDescription(extractDescription(graph))
         }
@@ -180,12 +201,28 @@ export default class Guide extends React.PureComponent<Props, State> {
     }
   }
 
+  /** A choice was made somewhere in the UI */
+  private readonly onChoiceFromAbove = ({ choices }: Choices) =>
+    setTimeout(() =>
+      this.setState({
+        frontier: undefined,
+        wizardStepStatus: [],
+        choices: Object.assign({}, choices)
+      })
+    )
+
+  /**
+   * A choice was made in *this* UI. The `this.props.choices.set()`
+   * will eventually find its way back to a call to
+   * `this.onChoiceFromAbove()`
+   */
   private readonly onChoice = (evt: React.MouseEvent) => {
     const group = evt.currentTarget.getAttribute('data-choice-group')
     const title = evt.currentTarget.getAttribute('data-choice-title')
     this.props.choices.set(group, title)
   }
 
+  /** @return UI that offers the user a choice */
   private tilesForChoice(choice: Choice) {
     return this.stepContent(
       <Grid hasGutter span={4}>
@@ -196,7 +233,7 @@ export default class Guide extends React.PureComponent<Props, State> {
                 isStacked
                 title={_.title}
                 className="kui--tile"
-                icon={<Icons icon="PlusSquare" />}
+                icon={this.choiceIcon2}
                 isSelected={this.state.choices && this.state.choices.get(choice.group) === _.title}
                 onClick={this.onChoice}
                 data-choice-group={choice.group}
@@ -214,11 +251,19 @@ export default class Guide extends React.PureComponent<Props, State> {
   /**
    * @return a `WizardStep` for a choice on the choice frontier
    */
-  private wizardStepForChoiceOnFrontier(graph: Choice): WizardStepWithGraph {
+  private wizardStepForChoiceOnFrontier(graph: Choice, isFirstChoice: boolean): WizardStepWithGraph {
     if (graph) {
       return {
         graph,
-        step: { name: graph.title, component: this.tilesForChoice(graph) }
+        step: {
+          name: graph.title,
+          component: this.tilesForChoice(graph),
+          stepNavItemProps: isFirstChoice && {
+            children: this.wizardStepDescription(
+              <span className="sub-text">{this.choiceIcon1} This step requires you to choose how to proceed</span>
+            )
+          }
+        }
       }
     }
   }
@@ -236,7 +281,10 @@ export default class Guide extends React.PureComponent<Props, State> {
     }
   }
 
-  /** Any UI bits that all wizard steps should have */
+  /**
+   * Modifiy the given `step` to include any UI bits that all wizard
+   * steps should have.
+   */
   private readonly addCommonWizardStepProperties = (step: WizardStep, idx: number) => {
     const status = this.state.wizardStepStatus[idx]
     const name = this.withStatus(step.name, status)
@@ -244,15 +292,18 @@ export default class Guide extends React.PureComponent<Props, State> {
     return Object.assign(step, { name, hideCancelButton: true })
   }
 
-  /**
-   * @return the `WizardStep` models for this Guide */
+  /** @return the `WizardStep` models for this Guide */
   private wizardSteps(): WizardStepWithGraph[] {
     // the steps will be the interleaved ((...prereqs, choice), ...)
     // dictated by the this.state.frontier model, which comes from
     // choice-frontier.ts; the flatMap just says we want to flatten
     // this nested interleaving down to a linear set of WizardSteps
-    return this.state.frontier.flatMap(({ prereqs, choice }): WizardStepWithGraph[] =>
-      [...prereqs.map(_ => this.wizardStepForPrereq(_)), this.wizardStepForChoiceOnFrontier(choice)].filter(Boolean)
+    const idxOfFirstChoice = this.state.frontier.findIndex(_ => _.choice)
+    return this.state.frontier.flatMap(({ prereqs, choice }, idx): WizardStepWithGraph[] =>
+      [
+        ...prereqs.map(_ => this.wizardStepForPrereq(_)),
+        this.wizardStepForChoiceOnFrontier(choice, idx === idxOfFirstChoice)
+      ].filter(Boolean)
     )
   }
 
@@ -277,6 +328,7 @@ export default class Guide extends React.PureComponent<Props, State> {
     return steps.map(_ => _.step)
   }
 
+  /** User clicked to remove a chip */
   private readonly removeChip = (evt: React.MouseEvent) => {
     const node = evt.currentTarget.parentElement
     if (node) {
@@ -306,6 +358,10 @@ export default class Guide extends React.PureComponent<Props, State> {
     )
   }
 
+  /**
+   * @return a progress bar UI that indicates how far along we are
+   * towards completion of the given `steps`
+   */
   private progress(steps: WizardStep[]) {
     const nTotal = steps.length
     const nError = this.state.wizardStepStatus.filter(_ => _ === 'error').length
@@ -344,12 +400,52 @@ export default class Guide extends React.PureComponent<Props, State> {
     return <div className="kui--markdown-major-paragraph">{this.progress(steps)}</div>
   }
 
+  private wizardTitle() {
+    return extractTitle(this.state.graph)
+    // {this.state.isRunning && <span className="small-left-pad">{statusToIcon('in-progress')}</span>}
+  }
+
+  private hasRemainingChoices() {
+    return !!this.state.frontier.find(_ => _.choice !== undefined)
+  }
+
+  /** Commence automated execution of code blocks */
+  private readonly startRun = () => {
+    this.setState(curState => {
+      const firstNotDoneStepIdx = curState.wizardStepStatus.findIndex(_ => _ !== 'success')
+
+      return {
+        isRunning: true,
+
+        // remember that startAtStep is 1-indexed
+        startAtStep: firstNotDoneStepIdx < 0 ? curState.startAtStep : firstNotDoneStepIdx + 1
+      }
+    })
+  }
+
+  /** Terminate automated execution of code blocks */
+  private readonly stopRun = () => {
+    this.setState({ isRunning: false })
+  }
+
+  private runAction(): WizardProps['rightButtons'][any] {
+    return (
+      !this.hasRemainingChoices() && {
+        className: 'kui--guidebook-run',
+        onClick: this.state.isRunning ? this.stopRun : this.startRun,
+        children: strings(this.state.isRunning ? 'Stop' : 'Run'),
+        isDisabled: this.hasRemainingChoices() // ??? this does not seem to take...
+      }
+    )
+  }
+
+  private actions(): Partial<WizardProps['rightButtons']> {
+    // return [this.runAction()].filter(Boolean)
+    return undefined
+  }
+
   private presentChoices() {
     const steps = this.validateStepsIfNeeded(this.wizardSteps()).map(this.addCommonWizardStepProperties)
-
-    // if you want to start at the first non-success step
-    // see https://github.com/kubernetes-sigs/kui/pull/8840
-    // const startAtStep = steps.findIndex((_, idx) => this.state.wizardStepStatus[idx] !== 'success')
 
     return steps.length === 0 ? (
       'Nothing to do!'
@@ -358,12 +454,16 @@ export default class Guide extends React.PureComponent<Props, State> {
         <div className="kui--wizard">
           <div className="kui--wizard-main-content">
             <Wizard
+              key={this.state.isRunning && v4()}
+              boxShadow
               hideClose
               steps={steps}
-              title={extractTitle(this.state.graph)}
+              title={this.wizardTitle()}
+              startAtStep={this.state.startAtStep}
               description={this.wizardDescription()}
               descriptionFooter={this.wizardDescriptionFooter(steps)}
-              rightButtons={this.chips()}
+              rightButtons={this.actions()}
+              topContent={this.chips()}
             />
           </div>
         </div>

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/index.tsx
@@ -15,11 +15,18 @@
  */
 
 import React from 'react'
-import { ChoiceState } from '../..'
+
+import { CodeBlockResponseFn } from '../../components'
+import { ChoiceState, Props as MarkdownProps } from '../../../Markdown'
 
 const Guide = React.lazy(() => import('./Guide'))
 
-export default function guidebookGuideWrapper(uuid: string, choices: ChoiceState) {
+export default function guidebookGuideWrapper(
+  mdprops: MarkdownProps,
+  uuid: string,
+  choices: ChoiceState,
+  codeBlockResponses: CodeBlockResponseFn
+) {
   return function guidebookGuide(props: { 'data-kui-code-blocks': string }) {
     const blocks = props['data-kui-code-blocks']
       ? JSON.parse(props['data-kui-code-blocks']).map(_ => JSON.parse(Buffer.from(_, 'base64').toString()))
@@ -28,7 +35,7 @@ export default function guidebookGuideWrapper(uuid: string, choices: ChoiceState
     return !blocks ? (
       <span className="all-pad">Nothing to do!</span>
     ) : (
-      <Guide uuid={uuid} blocks={blocks} choices={choices} />
+      <Guide tab={mdprops.tab} uuid={uuid} blocks={blocks} choices={choices} codeBlockResponses={codeBlockResponses} />
     )
   }
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
@@ -34,12 +34,14 @@ import _code, { CodeBlockResponse } from './code'
 
 import { Props, ChoiceState } from '../../Markdown'
 
+export type CodeBlockResponseFn = (codeBlockIdx: number) => CodeBlockResponse & { replayed: boolean }
+
 type Args = {
   mdprops: Props
   repl: REPL
   uuid: string
   choices: ChoiceState
-  codeBlockResponses: (codeBlockIdx: number) => CodeBlockResponse & { replayed: boolean }
+  codeBlockResponses: CodeBlockResponseFn
   spliceInCodeExecution: (
     status: CodeBlockResponse['status'],
     response: CodeBlockResponse['response'],
@@ -90,7 +92,7 @@ function components(args: Args) {
       tag,
       guidebookimports: guidebookimports(args.choices),
       tabbed: tabbed(args.uuid, args.choices),
-      guidebookguide: guidebookguide(args.uuid, args.choices)
+      guidebookguide: guidebookguide(args.mdprops, args.uuid, args.choices, args.codeBlockResponses)
     },
     typedComponents(args)
   )

--- a/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/index.tsx
@@ -121,6 +121,9 @@ export type Props = Partial<Choices> & {
   /** Render executable code blocks with the executable code block component [Default: true] */
   executableCodeBlocks?: boolean
 
+  /** Execute code blocks immediately? */
+  executeImmediately?: boolean
+
   /** Has the user clicked to execute a code block? */
   codeBlockResponses?: CodeBlockResponse[]
 
@@ -302,7 +305,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
       .map((_, idx) => fromState[idx] || fromProps[idx])
   }
 
-  private codeBlockHasBeenReplayed(codeBlockIdx: number) {
+  private codeBlockResponseWithReplayedBit(codeBlockIdx: number) {
     const fromProps = this.props.codeBlockResponses ? this.props.codeBlockResponses[codeBlockIdx] : undefined
     const fromState = this.state.codeBlockResponses[codeBlockIdx]
 
@@ -383,7 +386,7 @@ export default class Markdown extends React.PureComponent<Props, State> {
     uuid: this.uuid,
     choices: this.choices,
     spliceInCodeExecution: this.spliceInCodeExecution.bind(this),
-    codeBlockResponses: this.codeBlockHasBeenReplayed.bind(this)
+    codeBlockResponses: this.codeBlockResponseWithReplayedBit.bind(this)
   })
 
   /** `exec` controller */

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/TabCompletion.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/TabCompletion.tsx
@@ -363,7 +363,7 @@ class TabCompletionStateWithMultipleSuggestions extends TabCompletionState {
 
     return (
       <div className="kui--tab-completions--option" key={idx} data-value={value}>
-        <Button size="small" tabIndex={1} onClick={() => this.completeWith(idx)}>
+        <Button isSmall tabIndex={1} onClick={() => this.completeWith(idx)}>
           <React.Fragment>
             <span className="kui--tab-completions--option-partial">{preText}</span>
             <span className="kui--tab-completions--option-completion">{postText}</span>

--- a/plugins/plugin-client-common/src/components/spi/Button/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Button/impl/PatternFly.tsx
@@ -20,18 +20,5 @@ import { Button } from '@patternfly/react-core'
 import Props from '../model'
 
 export default function PatternFlyButton(props: Props) {
-  return (
-    <Button
-      id={props.id}
-      type={props.type}
-      onClick={props.onClick}
-      variant={props.kind}
-      isDisabled={props.isDisabled}
-      isSmall={props.size === 'small'}
-      tabIndex={props.tabIndex}
-      className={['kui--button', 'kui--tag', props.className].join(' ')}
-    >
-      {props.children}
-    </Button>
-  )
+  return <Button {...props} className={['kui--button', 'kui--tag', props.className].join(' ')} />
 }

--- a/plugins/plugin-client-common/web/scss/components/Button/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Button/_mixins.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Kubernetes Authors
+ * Copyright 2022 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { ButtonProps } from '@patternfly/react-core'
-
-type Props = ButtonProps
-
-export default Props
+@mixin Button {
+  .kui--button {
+    @content;
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/Wizard/Footer.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Footer.scss
@@ -23,20 +23,33 @@
 }
 
 @include WizardFooter {
-  flex-wrap: nowrap;
   align-items: center;
   justify-content: unset;
+
+  &[data-has-box-shadow] {
+    box-shadow: var(--pf-c-wizard__footer--BoxShadow);
+  }
+
+  & > * {
+    display: flex;
+    align-items: center;
+    flex-basis: 100%;
+  }
 }
 
-@include WizardFooterLeftButtons {
-  @include ButtonMargins;
+@include WizardFooterBottomContent {
+  & > * {
+    @include ButtonMargins;
+  }
 }
 
-@include WizardFooterRightButtons {
-  @include ButtonMargins;
-  margin-left: 1em;
+@include WizardFooterBottomLeftContent {
+  flex: 1;
+}
+
+@include WizardFooterTopContent {
   flex: 1;
   display: flex;
   flex-shrink: 0;
-  justify-content: flex-end;
+  order: -1;
 }

--- a/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
@@ -16,12 +16,20 @@
 
 @import 'mixins';
 @import '../Tile/mixins';
+@import '../Button/mixins';
 @import '../Terminal/Maximized';
 @import '../../Themes/mixins';
 
 @mixin Guide {
   .kui--guide {
     @content;
+  }
+}
+@mixin GuideRunButton {
+  @include Button {
+    &.kui--guidebook-run {
+      @content;
+    }
   }
 }
 
@@ -79,6 +87,13 @@
   @include ChipGroupLabel {
     margin: 0;
     text-align: right;
+  }
+}
+
+@include GuideRunButton {
+  &:not(:hover) {
+    color: var(--color-base00);
+    background-color: var(--color-base0F);
   }
 }
 

--- a/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/_mixins.scss
@@ -68,14 +68,32 @@
   }
 }
 
-@mixin WizardFooterLeftButtons {
-  .kui--wizard-footer--left {
+@mixin WizardFooterTopContent {
+  .kui--wizard-footer--top {
     @content;
   }
 }
 
-@mixin WizardFooterRightButtons {
-  .kui--wizard-footer--right {
+@mixin WizardFooterBottomContent {
+  .kui--wizard-footer--bottom {
+    @content;
+  }
+}
+
+@mixin WizardFooterBottomContent {
+  .kui--wizard-footer--bottom {
+    @content;
+  }
+}
+
+@mixin WizardFooterBottomLeftContent {
+  .kui--wizard-footer--bottom-left {
+    @content;
+  }
+}
+
+@mixin WizardFooterBottomRightContent {
+  .kui--wizard-footer--bottom-right {
     @content;
   }
 }

--- a/plugins/plugin-electron-components/src/components/Screenshot.tsx
+++ b/plugins/plugin-electron-components/src/components/Screenshot.tsx
@@ -169,10 +169,10 @@ export default class Screenshot extends React.PureComponent<Props, State> {
   private saveToDiskButton() {
     return (
       <div className="kui--button-set">
-        <Button size="small" className="screenshot-save-button" onClick={this.saveToDisk.bind(this)}>
+        <Button isSmall className="screenshot-save-button" onClick={this.saveToDisk.bind(this)}>
           {strings('Save to desktop')}
         </Button>
-        <Button size="small" kind="link" onClick={() => this.setState({ isActive: false, captured: undefined })}>
+        <Button isSmall kind="link" onClick={() => this.setState({ isActive: false, captured: undefined })}>
           {strings('Done')}
         </Button>
       </div>


### PR DESCRIPTION
This PR also
- fixes failures in run button for code blocks in guides
- adds a "this step needs a choice" UI to Guide

It does not yet enable the Run button.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
