### PR TITLE
fix(plugins/plugin-client-common): topmatter imports in content from guide command mis-rendered

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/rehype-wizard.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Wizard/rehype-wizard.ts
@@ -20,8 +20,8 @@ import { visit } from 'unist-util-visit'
 import { Content, Element, Parent, Root } from 'hast'
 import { visitParents } from 'unist-util-visit-parents'
 
+import isElementWithProperties from '../../isElement'
 import { WizardSteps, PositionProps } from '../../KuiFrontmatter'
-import isElementWithProperties, { isElement } from '../../isElement'
 import { GroupMember as CodeBlockGroupMember } from './CodeBlockProps'
 import { isImports, visitImportContainers } from '../../remark-import'
 
@@ -169,18 +169,6 @@ function transformer(ast: Root) {
           wizard.title =
             (node.properties['data-kui-title'] || ' ') +
             (node.properties['data-kui-description'] ? ': ' + node.properties['data-kui-description'] : '')
-
-          // Ugh, work around nested <p>. The div comes from us, so that
-          // part is safe (sections in the markdown become this div; and
-          // this is the first section). We also have to avoid having
-          // <div> under <p>. The offending parent <p> comes from
-          // PatternFly's Wizard header description :(
-          node.tagName = 'span' // top-most div -> span
-          node.children = node.children.map(child =>
-            !isElement(child) || child.tagName !== 'p'
-              ? child
-              : Object.assign({}, child, { tagName: 'span', properties: { className: 'paragraph' } })
-          )
 
           wizard.description = node
         } else {


### PR DESCRIPTION
When using the `guide` command against a markdown source file that has an `imports` section in its topmatter... if that imported file is not imported anywhere else, it will be mis-rendered in Guide's wizard: tabs and tips will not have the proper indentation (or, it will not be preserved properly when round-tripping from ast back to source).

This is due to a now-unnecessary div->span hack we do in rehype-wizard.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
