### PR TITLE
fix(plugins/plugin-client-common): tiles in guide should have width:100%

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
+++ b/plugins/plugin-client-common/web/scss/components/Wizard/Guide.scss
@@ -99,6 +99,7 @@
 
 @include Guide {
   @include Tile {
+    width: 100%;
     height: 100%;
     background-color: var(--color-base01);
     --pf-c-tile__body--Color: var(--color-text-01);


### PR DESCRIPTION
We already have a height:100% rule. Together, this will give us the desired space-filling grid.
<img width="1392" alt="guide tiles" src="https://user-images.githubusercontent.com/4741620/163402643-4f5af036-975a-419a-8fb6-d77ab8bad963.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
