### PR TITLE
fix(plugins/plugin-client-common): code blocks in tips in guide are misformatted

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/toMarkdownString.ts
@@ -115,12 +115,14 @@ ${tabContent}
         const { className, title, open } = node.properties
 
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        const tipContent = toMarkdownString(u('element', { tagName: 'p' }, node.children))
+        const tipContent = toMarkdownString(u('element', { tagName: 'div' }, node.children))
           .split(/\n/)
           .map(_ => indent(_))
           .join('\n')
-        // ^^^ re: the <p> wrapper: otherwise, toMarkdown will oddly
-        // render each child as if it were a div ¯\_(ツ)_/¯
+        // ^^^ re: the <div> wrapper: we need some wrapper over the
+        // children; we can't use <p> since nested paragraphs is not
+        // allowed (and, worse, mdast-util-to-markdown misformats
+        // them). It also misformats if we use a <span> wrapper.
 
         node['value'] = `
 ???${open ? '+' : ''} ${className} "${title}"


### PR DESCRIPTION
We are creating a situation with nested paragraphs, which mdast-util-to-markdown does not like.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
