### PR TITLE
feat(plugins/plugin-client-common): allow tabs to be renamed

### DIFF
--- a/packages/test/src/api/util.ts
+++ b/packages/test/src/api/util.ts
@@ -491,3 +491,24 @@ export function clickNewTabButton(ctx: Common.ISuite, expectedNewTabIndex: numbe
     .then(_ => _.waitForDisplayed())
     .then(() => CLI.waitForRepl(ctx.app)) // should have an active repl
 }
+
+export async function getTabTitle(ctx: Common.ISuite, tabTitleSelector: string) {
+  const tabTitle = await ctx.app.client.$(tabTitleSelector)
+  await tabTitle.waitForDisplayed({ timeout: CLI.waitTimeout })
+  const actualTabTitle = await tabTitle.getValue()
+  return actualTabTitle
+}
+
+export function expectCurrentTabTitle(
+  ctx: Common.ISuite,
+  expectedTabTitle: string,
+  tabTitleSelector = Selectors.CURRENT_TAB_TITLE
+) {
+  return ctx.app.client.waitUntil(
+    async () => {
+      const actualTabTitle = await getTabTitle(ctx, tabTitleSelector)
+      return actualTabTitle === expectedTabTitle
+    },
+    { timeout: CLI.waitTimeout }
+  )
+}

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
@@ -159,9 +159,21 @@ export default class Tab extends React.PureComponent<Props, State> {
     this.props.onCloseTab(this.props.idx)
   }
 
-  private title() {
+  private titleText() {
     const content = this.props.title ? this.props.title : strings('Tab')
     return decode(content) // decode html entities such as &mdash;
+  }
+
+  private get tabIndex() {
+    return this.props.idx + 1
+  }
+
+  private title() {
+    if (this.isUsingCommandName()) {
+      return this.state.title
+    } else {
+      return this.titleText() + ' ' + this.tabIndex
+    }
   }
 
   public render() {
@@ -179,17 +191,13 @@ export default class Tab extends React.PureComponent<Props, State> {
           (this.props.active ? ' kui--tab--active' : '') +
           (this.state.processing ? ' processing' : '')
         }
-        data-tab-button-index={this.props.idx + 1}
+        data-tab-button-index={this.tabIndex}
         aria-label="tab"
         onMouseDown={this._onMouseDownNavItem}
         onClick={this._onClickNavItem}
       >
-        <div className="kui--tab--label">
-          {this.isUsingCommandName() && this.state.title}
-          {!this.isUsingCommandName() && <span className="kui--tab--label-text">{this.title()} </span>}
-          {!this.isUsingCommandName() && <span className="kui--tab--label-index"></span>}
-        </div>
-        {/* TODO: button to toggle edit mode could */}
+        <input className="kui--tab--label" defaultValue={this.title()} />
+
         {this.props.closeable && (
           <React.Fragment>
             <div className="kui--tab-close" ref={this.closeTabRef} onClick={this._onClickCloseButton}>

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
@@ -164,6 +164,10 @@ export default class Tab extends React.PureComponent<Props, State> {
     return decode(content) // decode html entities such as &mdash;
   }
 
+  private get hasCustomLabel() {
+    return !!this.props.title
+  }
+
   private get tabIndex() {
     return this.props.idx + 1
   }
@@ -172,17 +176,20 @@ export default class Tab extends React.PureComponent<Props, State> {
     if (this.isUsingCommandName()) {
       return this.state.title
     } else {
-      return this.titleText() + ' ' + this.tabIndex
+      return this.titleText() + (this.hasCustomLabel ? '' : ' ' + this.tabIndex)
     }
   }
 
   public render() {
+    const title = this.title()
+
     return (
       <NavItem
+        key={title}
         href="#"
         data-tab-names={this.state.topTabNames}
         data-fresh={this.state.isFreshlyCreated}
-        data-custom-label={this.props.title ? true : undefined}
+        data-custom-label={this.hasCustomLabel || undefined}
         data-custom-label-text={this.props.title || undefined}
         isActive={this.props.active}
         styleChildren={false}
@@ -196,7 +203,7 @@ export default class Tab extends React.PureComponent<Props, State> {
         onMouseDown={this._onMouseDownNavItem}
         onClick={this._onClickNavItem}
       >
-        <input className="kui--tab--label" defaultValue={this.title()} />
+        <input tabIndex={-1} className="kui--tab--label" defaultValue={title} />
 
         {this.props.closeable && (
           <React.Fragment>

--- a/plugins/plugin-client-common/src/test/core/sidebar.ts
+++ b/plugins/plugin-client-common/src/test/core/sidebar.ts
@@ -16,6 +16,7 @@
 
 import { Common, CLI, Selectors, Util } from '@kui-shell/test'
 
+const timeout = { timeout: CLI.waitTimeout }
 const guidebookTitle = 'Welcome to Kui'
 
 describe(`sidebar ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
@@ -27,21 +28,19 @@ describe(`sidebar ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.
   it('should have a sidebar hamburger menu button', () =>
     this.app.client
       .$(Selectors.Sidebar.hamburgerButton)
-      .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+      .then(_ => _.waitForExist(timeout))
       .catch(Common.oops(this, true)))
 
   it('should have a hidden sidebar on load', () =>
     this.app.client
       .$(Selectors.Sidebar.contentContainerVisible(false))
-      .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+      .then(_ => _.waitForExist(timeout))
       .catch(Common.oops(this, true)))
 
   it('should show the sidebar on click of the hamburger', async () => {
     try {
       await this.app.client.$(Selectors.Sidebar.hamburgerButton).then(_ => _.click())
-      await this.app.client
-        .$(Selectors.Sidebar.contentContainerVisible(true))
-        .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+      await this.app.client.$(Selectors.Sidebar.contentContainerVisible(true)).then(_ => _.waitForExist(timeout))
     } catch (err) {
       await Common.oops(this, true)(err)
     }
@@ -50,7 +49,7 @@ describe(`sidebar ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.
   it(`should have an sidebar item for ${guidebookTitle}`, async () => {
     try {
       const item = await this.app.client.$(Selectors.Sidebar.item(guidebookTitle))
-      await item.waitForExist({ timeout: CLI.waitTimeout })
+      await item.waitForExist(timeout)
     } catch (err) {
       await Common.oops(this, true)(err)
     }
@@ -59,18 +58,13 @@ describe(`sidebar ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.
   it(`should show the ${guidebookTitle} guidebook on click`, async () => {
     try {
       const item = await this.app.client.$(Selectors.Sidebar.item(guidebookTitle))
-      await item.waitForExist({ timeout: CLI.waitTimeout })
+      await item.waitForExist(timeout)
       await item.click()
 
-      await this.app.client
-        .$(Selectors.TOP_TAB_WITH_TITLE(guidebookTitle))
-        .then(_ => _.waitForExist({ timeout: CLI.waitTimeout }))
+      await this.app.client.$(Selectors.TOP_TAB_WITH_TITLE(guidebookTitle)).then(_ => _.waitForExist(timeout))
 
       // confirm it is the current tab
-      await this.app.client.waitUntil(async () => {
-        const text = await this.app.client.$(Selectors.CURRENT_TAB_TITLE).then(_ => _.getText())
-        return text === guidebookTitle
-      })
+      await Util.expectCurrentTabTitle(this, guidebookTitle)
     } catch (err) {
       await Common.oops(this, true)(err)
     }

--- a/plugins/plugin-client-common/src/test/core/splits-in-markdown.ts
+++ b/plugins/plugin-client-common/src/test/core/splits-in-markdown.ts
@@ -110,18 +110,13 @@ async function verifySplit(this: Common.ISuite, { position, content, contentBloc
       const clear = TestUtil.doClear.bind(this)
 
       it('should clear the console from scratch', () => clear())
-      it(`should load the markdown and show ${IN1.splits.length} splits`, async () => {
+      it(`should load the markdown and show ${markdown.splits.length} splits`, async () => {
         try {
           await CLI.command(`commentary -f ${encodeComponent(markdown.input)}`, this.app)
 
           // check Tab Title
           if (markdown.title) {
-            await this.app.client.waitUntil(async () => {
-              const tabTitle = await this.app.client.$(Selectors.CURRENT_TAB_TITLE)
-              await tabTitle.waitForDisplayed({ timeout: CLI.waitTimeout })
-              const actualTabTitle = await tabTitle.getText()
-              return actualTabTitle === markdown.title
-            })
+            await TestUtil.expectCurrentTabTitle(this, markdown.title)
           }
 
           await Util.promiseEach(markdown.splits, async split => {

--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
@@ -70,7 +70,6 @@ $tab-label-font-size: 0.875rem;
   }
 
   @include Tab {
-    counter-increment: tab-index;
     display: flex;
     align-items: center;
     position: relative;
@@ -105,15 +104,6 @@ $tab-label-font-size: 0.875rem;
         @include TabLabel {
           color: var(--color-base0C);
         }
-      }
-    }
-
-    /** The "1" suffix of "Tab 1", which we exclude for tabs with custom labels */
-    [data-tab-names='fixed'],
-    [data-fresh='true'] {
-      &:not([data-custom-label]) .kui--tab--label:after {
-        content: counter(tab-index);
-        transition: font-size 150ms ease-in-out;
       }
     }
 

--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
@@ -133,6 +133,10 @@ $tab-label-font-size: 0.875rem;
       }
     }
     @include TabLabel {
+      /* for input */
+      border: none;
+      background: transparent;
+
       font-size: inherit;
       color: var(--color-text-02);
       padding: 0;

--- a/plugins/plugin-client-default/src/test/core/background-tab-open.ts
+++ b/plugins/plugin-client-default/src/test/core/background-tab-open.ts
@@ -19,7 +19,7 @@
  *
  */
 
-import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+import { Common, CLI, ReplExpect, Selectors, Util } from '@kui-shell/test'
 
 /** TODO could we extract this directly from welcome.json? */
 const nSplitsInWelcomeNotebook = 2
@@ -34,8 +34,8 @@ describe(`Background tab open onload ${process.env.MOCHA_RUN_TARGET || ''}`, fun
       await this.app.client.waitUntil(
         async () => {
           const [actualTitle1, actualTitle2] = await Promise.all([
-            this.app.client.$(Selectors.CURRENT_TAB_TITLE).then(_ => _.getText()), // intentional: check CURRENT, not N(1)
-            this.app.client.$(Selectors.TAB_TITLE_N(2)).then(_ => _.getText())
+            Util.getTabTitle(this, Selectors.CURRENT_TAB_TITLE), // intentional: check CURRENT, not N(1)
+            Util.getTabTitle(this, Selectors.TAB_TITLE_N(2))
           ])
           if (++idx > 5) {
             console.error(`Still waiting for tab titles; actualTitle1=${actualTitle1} actualTitle2=${actualTitle2}`)

--- a/plugins/plugin-core-support/src/test/core-support/tab-management.ts
+++ b/plugins/plugin-core-support/src/test/core-support/tab-management.ts
@@ -208,15 +208,7 @@ describe('core new tab with custom title', function(this: Common.ISuite) {
         .then(() => this.app.client.$(Selectors.TAB_SELECTED_N(N)))
         .then(_ => _.waitForDisplayed())
         .then(() => (again ? Promise.resolve() : CLI.waitForSession(this))) // should have an active repl
-        .then(() =>
-          this.app.client.waitUntil(
-            async () => {
-              const actualTitle = await this.app.client.$(Selectors.CURRENT_TAB_TITLE).then(_ => _.getText())
-              return actualTitle === expectedTitle
-            },
-            { timeout: CLI.waitTimeout }
-          )
-        )
+        .then(() => Util.expectCurrentTabTitle(this, expectedTitle))
         .catch(Common.oops(this, true)))
   }
 


### PR DESCRIPTION
This PR does get fancy, for now. It only allows tabs to be renamed in an emphemeral way. Tab renamings will not, with this PR, survive a reload of Kui, nor will they "stick" to a second window.

One does so by clicking on the tab name. You will then see a normal html input effect.

Users of the future: if you want durable tab names, open an issue and we can look into this somewhat more complex scenario.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
