### PR TITLE
fix(packages/core): second windows should not be stuck with env vars from initial window

### DIFF
--- a/packages/core/src/main/main.ts
+++ b/packages/core/src/main/main.ts
@@ -42,7 +42,9 @@ export const main = async (argv: string[], env = process.env, execOptions?: Exec
     // then spawn the electron graphics
     debug('shortcut to graphics', argv)
     const { getCommand, initElectron } = await import(/* webpackChunkName: "electron-main" */ './spawn-electron')
-    const { argv: strippedArgv, subwindowPlease, subwindowPrefs } = getCommand(argv, async () => import('electron'))
+    const { argv: strippedArgv, subwindowPlease, subwindowPrefs } = getCommand(argv, process.cwd(), env, async () =>
+      import('electron')
+    )
     initElectron(
       strippedArgv,
       { isRunningHeadless },

--- a/packages/core/src/models/SubwindowPrefs.ts
+++ b/packages/core/src/models/SubwindowPrefs.ts
@@ -15,6 +15,8 @@
  */
 
 interface SubwindowPrefs {
+  cwd?: string
+  env?: Record<any, any>
   fullscreen?: boolean
   useContentSize?: boolean
   synonymFor?: object

--- a/packages/core/src/webapp/bootstrap/init-electron.ts
+++ b/packages/core/src/webapp/bootstrap/init-electron.ts
@@ -19,6 +19,8 @@ import { BrowserWindow } from 'electron'
 
 interface KuiWindow extends BrowserWindow {
   subwindow?: {
+    cwd?: string
+    env?: Record<any, any>
     fullscreen?: boolean
     viewName?: string
     title?: string
@@ -58,6 +60,13 @@ export async function preinit() {
     const remote = await import('@electron/remote')
     const window = remote && (remote.getCurrentWindow() as KuiWindow)
     const subwindow = window.subwindow
+
+    // so that electron's "second window" protocol can pass through
+    // the environment variables from second+ windows
+    if (subwindow && subwindow.env) {
+      process.env = subwindow.env
+    }
+
     if (subwindow && subwindow.fullscreen === true) {
       const titleOverride = typeof subwindow === 'string' ? subwindow : subwindow.title
       if (titleOverride && typeof titleOverride === 'string') {


### PR DESCRIPTION
Electron finally has support, via the `additionalData` protocol, for us to fix this.

ref: https://www.electronjs.org/docs/latest/api/app#apprequestsingleinstancelockadditionaldata

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
