### PR TITLE
fix(plugins/plugin-client-common): tab renaming is broken

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
@@ -146,7 +146,7 @@ export default class Tab extends React.PureComponent<Props, State> {
     return this.state.topTabNames === 'command' // && !document.body.classList.contains('kui--alternate')
   }
 
-  private readonly _onMouseDownNavItem = (evt: React.SyntheticEvent) => {
+  private readonly _onMouseDown = (evt: React.SyntheticEvent) => {
     evt.preventDefault()
     evt.stopPropagation()
   }
@@ -206,14 +206,18 @@ export default class Tab extends React.PureComponent<Props, State> {
         }
         data-tab-button-index={this.tabIndex}
         aria-label="tab"
-        onMouseDown={this._onMouseDownNavItem}
         onClick={this._onClickNavItem}
       >
         <input tabIndex={-1} className="kui--tab--label" defaultValue={title} onKeyPress={this._onKeyPress} />
 
         {this.props.closeable && (
           <React.Fragment>
-            <div className="kui--tab-close" ref={this.closeTabRef} onClick={this._onClickCloseButton}>
+            <div
+              className="kui--tab-close"
+              ref={this.closeTabRef}
+              onClick={this._onClickCloseButton}
+              onMouseDown={this._onMouseDown}
+            >
               <Icons icon="WindowClose" focusable="false" preserveAspectRatio="xMidYMid meet" aria-hidden="true" />
             </div>
             <Tooltip reference={this.closeTabRef} position="bottom">


### PR DESCRIPTION
Ugh, the onMouseDown preventDefault is preventing editability.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
