### PR TITLE
feat(plugins/plugin-client-common): when renaming a tab, Enter should blur input

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
@@ -153,6 +153,12 @@ export default class Tab extends React.PureComponent<Props, State> {
 
   private readonly _onClickNavItem = () => this.props.onSwitchTab(this.props.idx)
 
+  private readonly _onKeyPress = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+    if (evt.key === 'Enter') {
+      evt.currentTarget.blur()
+    }
+  }
+
   private readonly _onClickCloseButton = (evt: React.SyntheticEvent) => {
     evt.stopPropagation()
     evt.preventDefault()
@@ -203,7 +209,7 @@ export default class Tab extends React.PureComponent<Props, State> {
         onMouseDown={this._onMouseDownNavItem}
         onClick={this._onClickNavItem}
       >
-        <input tabIndex={-1} className="kui--tab--label" defaultValue={title} />
+        <input tabIndex={-1} className="kui--tab--label" defaultValue={title} onKeyPress={this._onKeyPress} />
 
         {this.props.closeable && (
           <React.Fragment>


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
