### PR TITLE
test: stop using quay.io/bitnami/nginx

### DIFF
--- a/plugins/plugin-kubectl/src/test/k8s1/apply-multi-file.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/apply-multi-file.ts
@@ -17,7 +17,9 @@
 import { Common, CLI, ReplExpect, SidecarExpect, Selectors } from '@kui-shell/test'
 import {
   openSidecarByList,
+  remotePodName,
   remotePodYaml,
+  remotePodName2,
   remotePodYaml2,
   waitForRed,
   createNS,
@@ -27,7 +29,7 @@ import {
 
 const synonyms = ['kubectl']
 const dashFs = ['-f']
-const resources = ['nginx', 'nginx2']
+const resources = [remotePodName, remotePodName2]
 
 describe(`kubectl apply multi-file ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))

--- a/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec-via-table.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec-via-table.ts
@@ -50,7 +50,7 @@ wdescribe(`kubectl exec basic stuff via table ${process.env.MOCHA_RUN_TARGET || 
 
   it('should exec ls through pty', () => {
     return CLI.command(`kubectl exec ${podName} -n ${ns} -- ls`, this.app)
-      .then(ReplExpect.okWithString('index.html'))
+      .then(ReplExpect.okWithString('bin'))
       .catch(Common.oops(this, true))
   })
 

--- a/plugins/plugin-kubectl/src/test/k8s3/run.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/run.ts
@@ -48,7 +48,7 @@ describe(`kubectl run ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Com
     allocateNS(this, ns)
 
     it(`should create pod/deployment from ${kubectl} run`, () => {
-      return CLI.command(`${kubectl} run nginx --image quay.io/bitnami/nginx -n ${ns}`, this.app)
+      return CLI.command(`${kubectl} run nginx --image nginx -n ${ns}`, this.app)
         .then(
           ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME('nginx') })
         )

--- a/plugins/plugin-kubectl/tests/data/k8s/bunch/deployment.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/bunch/deployment.yaml
@@ -32,6 +32,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: quay.io/bitnami/nginx:1.18.0
+        image: nginx:1.18.0
         ports:
         - containerPort: 80

--- a/plugins/plugin-kubectl/tests/data/k8s/bunch/hpa.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/bunch/hpa.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: travelapp-container
-        image: quay.io/bitnami/nginx:latest
+        image: nginx:latest
         ports:
         - containerPort: 3000
 ---

--- a/plugins/plugin-kubectl/tests/data/k8s/bunch/pod.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/bunch/pod.yaml
@@ -25,6 +25,6 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx:1.18.0
+    image: nginx:1.18.0
     ports:
     - containerPort: 80

--- a/plugins/plugin-kubectl/tests/data/k8s/crashy.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/crashy.yaml
@@ -21,5 +21,5 @@ metadata:
 spec:
   containers:
   - name: crashy
-    image: quay.io/bitnami/nginx:1.18.0
+    image: nginx:1.18.0
     command: ["/bin/sh", "-c", "echo logtest; sleep 5; echo exiting; exit"]

--- a/plugins/plugin-kubectl/tests/data/k8s/diff/modified-crashy.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/diff/modified-crashy.yaml
@@ -23,5 +23,5 @@ metadata:
 spec:
   containers:
   - name: crashy
-    image: quay.io/bitnami/nginx:1.18.0
+    image: nginx:1.18.0
     command: ["/bin/sh", "-c", "echo logtest; sleep 5; echo exiting; exit"]

--- a/plugins/plugin-kubectl/tests/data/k8s/event-generator.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/event-generator.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
     command:

--- a/plugins/plugin-kubectl/tests/data/k8s/headless/pod.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/headless/pod.yaml
@@ -24,6 +24,6 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80

--- a/plugins/plugin-kubectl/tests/data/k8s/headless/pod2.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/headless/pod2.yaml
@@ -24,6 +24,6 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80

--- a/plugins/plugin-kubectl/tests/data/k8s/hpa.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/hpa.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: travelapp-container
-        image: quay.io/bitnami/nginx:latest
+        image: nginx:latest
         ports:
         - containerPort: 3000
 ---

--- a/plugins/plugin-kubectl/tests/data/k8s/job.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/job.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: pi
-        image: quay.io/bitnami/nginx
+        image: nginx
         command: ["echo",  "hi"]
       restartPolicy: Never
   backoffLimit: 4

--- a/plugins/plugin-kubectl/tests/data/k8s/kubectl-logs-two-containers.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/kubectl-logs-two-containers.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     command: ["/bin/sh", "-c", "while true; do echo nginx-`date +'%M:%S'`; sleep 1; done"]
   - name: vim
     image: quay.io/starpit/alpine-vim

--- a/plugins/plugin-kubectl/tests/data/k8s/many-pods-with-duplicates.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/many-pods-with-duplicates.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -36,7 +36,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -49,7 +49,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -62,7 +62,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -75,7 +75,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -88,7 +88,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -101,7 +101,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -114,7 +114,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -127,7 +127,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -140,7 +140,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -153,7 +153,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -166,7 +166,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -179,7 +179,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -192,7 +192,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -205,7 +205,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -218,7 +218,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -231,7 +231,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -244,7 +244,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -257,7 +257,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -270,6 +270,6 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80

--- a/plugins/plugin-kubectl/tests/data/k8s/many-pods.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/many-pods.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -36,7 +36,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -49,7 +49,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -62,7 +62,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -75,7 +75,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -88,7 +88,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -101,7 +101,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -114,7 +114,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -127,7 +127,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -140,7 +140,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -153,7 +153,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -166,7 +166,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -179,7 +179,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -192,7 +192,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -205,7 +205,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -218,7 +218,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -231,7 +231,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -244,7 +244,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -257,7 +257,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80
 ---
@@ -270,6 +270,6 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: quay.io/bitnami/nginx
+    image: nginx
     ports:
     - containerPort: 80

--- a/plugins/plugin-kubectl/tests/data/k8s/tab-completion-2.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/tab-completion-2.yaml
@@ -23,6 +23,6 @@
  spec:
    containers:
      - name: nginx
-       image: quay.io/bitnami/nginx
+       image: nginx
        ports:
          - containerPort: 90

--- a/plugins/plugin-kubectl/tests/data/k8s/tab-completion.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/tab-completion.yaml
@@ -23,6 +23,6 @@
  spec:
    containers:
      - name: nginx
-       image: quay.io/bitnami/nginx
+       image: nginx
        ports:
          - containerPort: 88

--- a/plugins/plugin-kubectl/tests/lib/k8s/utils.d.ts
+++ b/plugins/plugin-kubectl/tests/lib/k8s/utils.d.ts
@@ -130,5 +130,11 @@ declare function waitForTerminalText(this: Common.ISuite, res: ReplExpect.AppAnd
 /** URL of remote pod yaml */
 declare const remotePodYaml: string
 
+/** Name of remote pod */
+declare const remotePodName: string
+
 /** URL of second remote pod yaml */
 declare const remotePodYaml2: string
+
+/** Name of remote pod2 */
+declare const remotePodName2: string

--- a/plugins/plugin-kubectl/tests/lib/k8s/utils.js
+++ b/plugins/plugin-kubectl/tests/lib/k8s/utils.js
@@ -309,8 +309,14 @@ exports.waitForTerminalText = async function(res, checker) {
 
 /** URL of remote pod yaml */
 exports.remotePodYaml =
-  'https://raw.githubusercontent.com/IBM/kui/master/plugins/plugin-kubectl/tests/data/k8s/headless/pod.yaml'
+  'https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/simple-pod.yaml'
+
+/** Name of remote pod */
+exports.remotePodName = 'nginx'
 
 /** URL of remote pod yaml */
 exports.remotePodYaml2 =
-  'https://raw.githubusercontent.com/IBM/kui/master/plugins/plugin-kubectl/tests/data/k8s/headless/pod2.yaml'
+  'https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/lifecycle-events.yaml'
+
+/** Name of remote pod2 */
+exports.remotePodName2 = 'lifecycle-demo'


### PR DESCRIPTION
Hmm, bitnami seems to have removed (or made private?) all of their images.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
