### PR TITLE
fix(plugins/plugin-client-common): pty output paragraphs have too much spacing

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -566,9 +566,10 @@ $tip-toggle-opacity-2: 0.6;
 }
 
 /** see https://github.com/kubernetes-sigs/kui/pull/8808 */
-.kui--markdown-from-repl {
-  & > p:first-child {
+.kui--markdown-from-repl.marked-content {
+  & > p {
     margin-top: 0;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
PTY content is picking up rules from patternfly.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
