### PR TITLE
fix(plugins/plugin-client-common): fix for nested tabs squishing

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -641,11 +641,6 @@ pre {
 
 @include MarkdownSecondaryTabs {
   padding-top: 0;
-
-  /** This is to snap the alignment back to the top of the enclosing
-  tabs, thus compensating for the top-padding of our Card wrapper (see
-  tabbed.tsx) */
-  margin-top: -1rem;
 }
 
 @include CodeBlock {


### PR DESCRIPTION
This is due to a change in the patternfly css. Nested tabs appear to overlap with the enclosing tabs.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
