### PR TITLE
feat: allow clients to specify that some, or all node_modules should persist in electron builds

### DIFF
--- a/packages/builder/dist/electron/builders/electron.js
+++ b/packages/builder/dist/electron/builders/electron.js
@@ -76,16 +76,23 @@ const ignore = [
   /plugins/,
   /\.scss$/,
   /\.woff$/,
-  /tmp\//,
   /CHANGELOG\.md/,
   /tsconfig\..*/,
   /package-lock\.json/,
   /\/docs/,
-  /\/node_modules\/(?!(@electron|@electron\/remote|node-pty\/build|@kui-shell\/build))/,
-  /\/tools/,
-  /\/bin/,
-  /\/design/,
-  /\/dist\/webpack/
+  ...(process.env.KUI_KEEP_NODE_MODULES
+    ? []
+    : [
+        new RegExp(
+          `/node_modules/(?!(@electron|@electron/remote|node-pty/build|@kui-shell/build${
+            process.env.KUI_KEEP_NODE_MODULE ? '|' + process.env.KUI_KEEP_NODE_MODULE : ''
+          }))`
+        )
+      ]),
+  /^\/tools/,
+  /^\/bin/,
+  /^\/design/,
+  /^\/dist\/webpack/
 ]
 
 /**


### PR DESCRIPTION
## Feature

If clients, when building an electron distribution, specify `KUI_KEEP_NODE_MODULES`, then *all* node_modules will be kept in the electron builds. By specifying `KUI_KEEP_NODE_MODULE`, then clients may choose a list of node_modules to keep; generally this may be a regular expression, except that it is not allowed to use ^ or $ symbols.

## History

Right now, we exclude almost all node_modules from the electron build, allowing only a tiny and fixed subset through (those to facilitate the build itself). This is because the webpack bundles include all of the actual logic...

However, it can be helpful for clients to have access to a subset of node_modules, of their design.

Also, our exclusion list has some items intended to exclude directories in the main Kui repo, but without a `^` in the regexp, and thus excluding any directories with these names...

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
