### PR TITLE
fix: guide command should not open a new tab when in popup mode

### DIFF
--- a/plugins/plugin-client-common/src/controller/guide.ts
+++ b/plugins/plugin-client-common/src/controller/guide.ts
@@ -17,7 +17,15 @@
 import React from 'react'
 import { v4 } from 'uuid'
 import { basename } from 'path'
-import { Arguments, CommentaryResponse, ParsedOptions, Registrar, Util, encodeComponent } from '@kui-shell/core'
+import {
+  Arguments,
+  CommentaryResponse,
+  ParsedOptions,
+  Registrar,
+  Util,
+  encodeComponent,
+  isPopup
+} from '@kui-shell/core'
 
 import fetchMarkdownFile from './fetch'
 import { setTabReadonly } from './commentary' // TODO move to core?
@@ -59,7 +67,7 @@ async function guide(args: Arguments<HereOptions>) {
   try {
     const filepath = args.argvNoOptions[1]
 
-    if (!args.parsedOptions.here) {
+    if (!args.parsedOptions.here && !isPopup()) {
       await args.REPL.qexec(`tab new --cmdline "guide --here ${encodeComponent(filepath)}"`)
       return true
     }


### PR DESCRIPTION
There's no point in opening a new tab, if this is the first operation in a new window...

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
