### PR TITLE
chore: export some mising types from plugin-client-common

### DIFF
--- a/plugins/plugin-client-common/src/index.ts
+++ b/plugins/plugin-client-common/src/index.ts
@@ -65,11 +65,13 @@ export const LeftNavSidecar = React.lazy(() => import('./components/Views/Sideca
 // SPI
 export const Alert = React.lazy(() => import('./components/spi/Alert'))
 export const Button = React.lazy(() => import('./components/spi/Button'))
+export { Props as ButtonProps } from './components/spi/Button'
 export const Card = React.lazy(() => import('./components/spi/Card'))
 export const Popover = React.lazy(() => import('./components/spi/Popover'))
 export const Select = React.lazy(() => import('./components/spi/Select'))
 export const Tag = React.lazy(() => import('./components/spi/Tag'))
 export const Icons = React.lazy(() => import('./components/spi/Icons'))
+export { SupportedIcon } from './components/spi/Icons'
 export const DropDown = React.lazy(() => import('./components/spi/DropDown'))
 export { Action as DropDownAction } from './components/spi/DropDown/model'
 export { default as Tooltip } from './components/spi/Tooltip'


### PR DESCRIPTION
ButtonProps, SupportedIcon

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
