### PR TITLE
feat: export `CardResponse` to allow for consistent wrappering of "commentary" responses

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react'
 import { EventEmitter } from 'events'
+import { TextContent } from '@patternfly/react-core'
 import { CommentaryResponse, Tab, i18n } from '@kui-shell/core'
 
 import Card from '../spi/Card'
@@ -342,7 +343,9 @@ export class ReactCommentary extends React.PureComponent<ReactProps> {
     return (
       <div className="kui--commentary">
         <span className="kui--commentary-card">
-          <Card>{this.props.children}</Card>
+          <Card>
+            <TextContent>{this.props.children}</TextContent>
+          </Card>
         </span>
       </div>
     )

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/Imports.tsx
@@ -16,8 +16,8 @@
 
 import Debug from 'debug'
 import React from 'react'
+import { TreeView, TreeViewProps } from '@patternfly/react-core'
 import { encodeComponent, pexecInCurrentTab } from '@kui-shell/core'
-import { TreeView, TreeViewProps, TextContent } from '@patternfly/react-core'
 
 import {
   sameGraph,
@@ -308,11 +308,9 @@ class LabelWithStatus extends React.PureComponent<LabelWithStatusProps> {
 export default function guidebookImports(props: Props) {
   return (
     <ReactCommentary>
-      <TextContent>
-        <div className="padding-content marked-content page-content" data-is-nested>
-          <Imports {...props} />
-        </div>
-      </TextContent>
+      <div className="padding-content marked-content page-content" data-is-nested>
+        <Imports {...props} />
+      </div>
     </ReactCommentary>
   )
 }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react'
 import { ChoiceState, isWizard } from 'madwizard'
-import { TextContent } from '@patternfly/react-core'
 
 import SplitInjector from '../../../Views/Terminal/SplitInjector'
 import SplitPosition from '../../../Views/Terminal/SplitPosition'
@@ -74,15 +73,13 @@ export default function divWrapper(mdprops: MarkdownProps, uuid: string, choices
           {injector => {
             const node = (
               <ReactCommentary>
-                <TextContent>
-                  <div className="padding-content marked-content page-content" data-is-nested>
-                    {isWizard(props) ? (
-                      <Wizard uuid={uuid} {...props} choices={choices} />
-                    ) : (
-                      props.children || (placeholder ? <span className="italic sub-text">{placeholder}</span> : '')
-                    )}
-                  </div>
-                </TextContent>
+                <div className="padding-content marked-content page-content" data-is-nested>
+                  {isWizard(props) ? (
+                    <Wizard uuid={uuid} {...props} choices={choices} />
+                  ) : (
+                    props.children || (placeholder ? <span className="italic sub-text">{placeholder}</span> : '')
+                  )}
+                </div>
               </ReactCommentary>
             )
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/guide/index.tsx
@@ -20,18 +20,15 @@ import { Props as GuideProps } from './Guide'
 // import { CodeBlockResponseFn } from '../../components'
 // import { ChoiceState } from '../../../Markdown'
 
-import { TextContent } from '@patternfly/react-core'
 const ReactCommentary = React.lazy(() => import('../../../Commentary').then(_ => ({ default: _.ReactCommentary })))
 const Guide = React.lazy(() => import('./Guide'))
 
 export default function guidebookGuideWrapper(props: GuideProps) {
   return (
     <ReactCommentary>
-      <TextContent>
-        <div className="padding-content marked-content page-content" data-is-nested>
-          <Guide {...props} />
-        </div>
-      </TextContent>
+      <div className="padding-content marked-content page-content" data-is-nested>
+        <Guide {...props} />
+      </div>
     </ReactCommentary>
   )
 }

--- a/plugins/plugin-client-common/src/index.ts
+++ b/plugins/plugin-client-common/src/index.ts
@@ -67,6 +67,9 @@ export const Alert = React.lazy(() => import('./components/spi/Alert'))
 export const Button = React.lazy(() => import('./components/spi/Button'))
 export { Props as ButtonProps } from './components/spi/Button'
 export const Card = React.lazy(() => import('./components/spi/Card'))
+export const CardResponse = React.lazy(() =>
+  import('./components/Content/Commentary').then(_ => ({ default: _.ReactCommentary }))
+)
 export const Popover = React.lazy(() => import('./components/spi/Popover'))
 export const Select = React.lazy(() => import('./components/spi/Select'))
 export const Tag = React.lazy(() => import('./components/spi/Tag'))


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
