### PR TITLE
feat: allow plugin-s3 to be selectively disabled

### DIFF
--- a/plugins/plugin-client-common/src/test/core/markdown/wizards.ts
+++ b/plugins/plugin-client-common/src/test/core/markdown/wizards.ts
@@ -82,13 +82,11 @@ const IN3: Input = {
   expectedSplitCount: 1,
   expectedCodeBlockTasks: 19,
   steps: [
-    { name: 'TestRewritingOfStepName', body: 'This topic describes', description: '', codeBlocks: [] },
-    { name: 'Before you begin', body: 'Before you can get started', description: 'TestDescription2', codeBlocks: [] },
-    { name: 'Install the Knative CLI', body: 'provides a quick and easy interface', description: '', codeBlocks: [] },
+    { name: 'TestRewritingOfStepName', body: 'provides a quick and easy interface', description: '', codeBlocks: [] },
     {
       name: 'Install the Knative quickstart plugin',
       body: 'To get started, install the Knative',
-      description: 'This gives you a kn quickstart command',
+      description: 'TestDescription2',
       codeBlocks: []
     },
     {

--- a/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md
+++ b/plugins/plugin-client-common/tests/data/wizard-steps-in-topmatter.md
@@ -1,14 +1,11 @@
 ---
 wizard:
     steps:
-        - match: Install Knative using quickstart
-          name: TestRewritingOfStepName
-        - name: Before you begin
-          description: TestDescription2
         - name: Prepare local Kubernetes cluster
-        - Install the Knative CLI
+        - match: Install the Knative CLI
+          name: TestRewritingOfStepName
         - name: Install the Knative quickstart plugin
-          description: This gives you a kn quickstart command
+          description: TestDescription2
         - name: Run the Knative quickstart plugin
           description: This will quickly set up Knative against kind or minikube
         - Next steps

--- a/plugins/plugin-s3/ibm/src/plugin.ts
+++ b/plugins/plugin-s3/ibm/src/plugin.ts
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
+import { isEnabled } from '@kui-shell/plugin-s3'
 import { CommandHandler, KResponse, ParsedOptions, Registrar, UsageModel } from '@kui-shell/core'
-
-import validateConfig from './controller/validate'
-import findServiceInstances from './controller/find'
-import findAndBindCredentials from './controller/bind'
-import setEndpoint from './controller/endpoint'
-import defaultRegion from './controller/defaultRegion'
 
 function On(this: Registrar, command: string, handler: CommandHandler<KResponse, ParsedOptions>, usage?: UsageModel) {
   ;['cos', 'cloud-object-storage'].forEach(cos => {
@@ -29,7 +24,19 @@ function On(this: Registrar, command: string, handler: CommandHandler<KResponse,
 }
 
 export default async (registrar: Registrar) => {
+  if (!isEnabled()) {
+    return
+  }
+
   const on = On.bind(registrar)
+
+  const [validateConfig, findServiceInstances, findAndBindCredentials, setEndpoint, defaultRegion] = await Promise.all([
+    import('./controller/validate').then(_ => _.default),
+    import('./controller/find').then(_ => _.default),
+    import('./controller/bind').then(_ => _.default),
+    import('./controller/endpoint').then(_ => _.default),
+    import('./controller/defaultRegion').then(_ => _.default)
+  ])
 
   on('service-instances', findServiceInstances)
   on('bind', findAndBindCredentials)

--- a/plugins/plugin-s3/ibm/src/preload.ts
+++ b/plugins/plugin-s3/ibm/src/preload.ts
@@ -15,15 +15,23 @@
  */
 
 import Debug from 'debug'
-import { addProviderInitializer } from '@kui-shell/plugin-s3'
+import { isEnabled } from '@kui-shell/plugin-s3'
 
 export async function registerCapability() {
+  if (!isEnabled()) {
+    return
+  }
+
   const debug = Debug('plugin-s3/ibm/register')
   debug('registering ibm s3 provider 1')
 
   try {
-    const ibmcloud = await import('./s3provider').then(_ => _.default)
+    const [ibmcloud, addProviderInitializer] = await Promise.all([
+      import('./s3provider').then(_ => _.default),
+      import('@kui-shell/plugin-s3').then(_ => _.addProviderInitializer)
+    ])
     debug('registering ibm s3 provider 2', ibmcloud)
+
     addProviderInitializer(ibmcloud)
   } catch (err) {
     debug('registering ibm s3 provider error', err)

--- a/plugins/plugin-s3/src/isEnabled.ts
+++ b/plugins/plugin-s3/src/isEnabled.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Kubernetes Authors
+ * Copyright 2022 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-export {
-  MinioConfig,
-  Provider as S3Provider,
-  addProviderInitializer,
-  ProviderInitializer,
-  UnsupportedS3ProviderError
-} from './providers'
-
-export { default as eventBus } from './vfs/events'
-export { minioConfig, mounts as getCurrentMounts, Mount } from './vfs/responders'
-
-export { default as isEnabled } from './isEnabled'
+/**
+ * Allow clients to selectively disable plugin-s3; e.g. perhaps
+ * plugin-s3 is not needed in headless mode.
+ */
+export default function isEnabled() {
+  return process.env.KUI_S3 !== 'false'
+}

--- a/plugins/plugin-s3/src/plugin.ts
+++ b/plugins/plugin-s3/src/plugin.ts
@@ -15,10 +15,11 @@
  */
 
 import { Registrar } from '@kui-shell/core'
-
-import browse from './browse'
-import forwarder from './vfs/browser/forwarder'
+import isEnabled from './isEnabled'
 
 export default async function(registrar: Registrar) {
-  await Promise.all([forwarder(registrar), browse(registrar)])
+  if (isEnabled()) {
+    const [browse, forwarder] = await Promise.all([import('./browse'), import('./vfs/browser/forwarder')])
+    await Promise.all([forwarder.default(registrar), browse.default(registrar)])
+  }
 }

--- a/plugins/plugin-s3/src/preload.ts
+++ b/plugins/plugin-s3/src/preload.ts
@@ -15,8 +15,13 @@
  */
 
 import { Capabilities } from '@kui-shell/core'
+import isEnabled from './isEnabled'
 
 export default async function preloadS3Plugin() {
+  if (!isEnabled()) {
+    return
+  }
+
   const vfsPromise = Capabilities.inBrowser()
     ? import('./vfs/browser').then(_ => _.default())
     : import('./vfs').then(_ => _.default())


### PR DESCRIPTION
This one has a high startup cost, and some clients do not need this functionality in headless mode. Clients that set the environment variable `KUI_S3=false` will avoid those startup costs.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
