### PR TITLE
fix(packages/core): headless-to-ui transition can result in errors in getAppPath

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -104,7 +104,7 @@ function createWindowWithArgv(executeThisArgvPlease?: string[]) {
 }
 
 /** Open a new Electron window */
-export function createWindow(
+export async function createWindow(
   noHeadless = false,
   executeThisArgvPlease?: string[],
   subwindowPlease?: boolean,
@@ -189,6 +189,8 @@ export function createWindow(
 
     // when jumping directly to the UI from bash, getAppPath() may
     // include dist/headless; if so, we need to back out of that
+    await promise // wait for `app` to be defined, since we're about to use it
+    if (!app) return // then we will go a different route to opening the electron window
     const appPath = app.getAppPath()
     const root = join(appPath, /headless$/.test(appPath) ? '../../' : '', 'node_modules/@kui-shell')
 


### PR DESCRIPTION
We are trying to use an undefined variable, but we will flow a different way, in this case. We just have a missing null pointer check in `spawn-electron`.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
