### PR TITLE
fix: Xterm UI may miss whitespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -761,9 +761,9 @@
       "link": true
     },
     "node_modules/@kui-shell/xterm-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-1.0.1.tgz",
-      "integrity": "sha512-odM2KFn52bIY7HiAV/pyXEcIRENKuD3w9nzzxNUoKu54BycI+RX93QlwA9YbseZZJpFaTAtCunIzEwvE+JlceA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-1.0.2.tgz",
+      "integrity": "sha512-3+vpz8sAwkDbzjZRckNBodyodBRdTz97s/nVYknnVEu2sUmjFQKat9fmoSr1MRqGRs99YaC1mBVUl5jNToRWqA==",
       "dependencies": {
         "xterm": "4.10.0"
       }
@@ -18667,7 +18667,7 @@
       "version": "11.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kui-shell/xterm-helpers": "1.0.1",
+        "@kui-shell/xterm-helpers": "1.0.2",
         "cookie": "0.4.2",
         "debug": "4.3.4",
         "globby": "11.0.4",
@@ -19368,7 +19368,7 @@
     "@kui-shell/plugin-bash-like": {
       "version": "file:plugins/plugin-bash-like",
       "requires": {
-        "@kui-shell/xterm-helpers": "1.0.1",
+        "@kui-shell/xterm-helpers": "1.0.2",
         "cookie": "0.4.2",
         "debug": "4.3.4",
         "globby": "11.0.4",
@@ -19583,9 +19583,9 @@
       }
     },
     "@kui-shell/xterm-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-1.0.1.tgz",
-      "integrity": "sha512-odM2KFn52bIY7HiAV/pyXEcIRENKuD3w9nzzxNUoKu54BycI+RX93QlwA9YbseZZJpFaTAtCunIzEwvE+JlceA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-1.0.2.tgz",
+      "integrity": "sha512-3+vpz8sAwkDbzjZRckNBodyodBRdTz97s/nVYknnVEu2sUmjFQKat9fmoSr1MRqGRs99YaC1mBVUl5jNToRWqA==",
       "requires": {
         "xterm": "4.10.0"
       },

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -24,7 +24,7 @@
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
   "dependencies": {
-    "@kui-shell/xterm-helpers": "1.0.1",
+    "@kui-shell/xterm-helpers": "1.0.2",
     "cookie": "0.4.2",
     "debug": "4.3.4",
     "globby": "11.0.4",

--- a/plugins/plugin-bash-like/src/pty/copy.ts
+++ b/plugins/plugin-bash-like/src/pty/copy.ts
@@ -46,6 +46,7 @@ function sameStyle(cell1: IBufferCell, cell2: IBufferCell): boolean {
     cell1.isItalic() === cell2.isItalic() &&
     cell1.isDim() === cell2.isDim() &&
     cell1.isUnderline() === cell2.isUnderline() &&
+    cell1.isStrikethrough() === cell2.isStrikethrough() &&
     cell1.isBlink() === cell2.isBlink() &&
     cell1.isInvisible() === cell2.isInvisible()
   ) {

--- a/plugins/plugin-client-common/src/components/Content/Scalar/XtermDom.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/XtermDom.tsx
@@ -30,17 +30,19 @@ export default class XtermDom extends React.PureComponent<Props> {
       // directly into the row element.
       const cell = cells[0]
       if (cell.classList && cell.classList.length === 0 && cell.style && Object.keys(cell.style).length === 0) {
-        return cell.innerText.length === 0 ? '\u00a0' : cell.innerText
+        const text = cell.innerText || cell.textContent || '\u00a0' // whitespace seems to be in textContent
+        return text
       }
     }
 
     return cells.map((cell, idx) => {
-      const className = cell.classList ? cell.classList.join(' ') : ''
-      const style = cell.style || {}
+      const text = cell.innerText || cell.textContent || '\u00a0' // whitespace seems to be in textContent
 
-      return (
-        <span key={idx} className={className} style={style}>
-          {cell.innerText}
+      return cell.classList.length === 0 && !cell.style ? (
+        text
+      ) : (
+        <span key={idx} className={cell.classList.join(' ')} style={cell.style || {}}>
+          {text || '\u00a0'}
         </span>
       )
     })


### PR DESCRIPTION
we aren't properly handling the whitespace that xterm.js places in the `textContent` field.

This PR also adds support for strikethrough text.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
