### PR TITLE
fix: xterm copy-out logic is erratic with line wrapping

### DIFF
--- a/plugins/plugin-bash-like/src/pty/copy.ts
+++ b/plugins/plugin-bash-like/src/pty/copy.ts
@@ -116,9 +116,9 @@ export default function copy(terminal: Terminal): XtermResponse['rows'] {
   const current = terminal.buffer.active.getNullCell()
 
   const nLines = lastFullLineIdx(terminal, current) + 1
-  let prevRow: XtermResponseCell[]
-  for (let idx = 0; idx < nLines; idx++) {
-    const line = terminal.buffer.active.getLine(idx)
+  let prevRow: XtermResponseCell[] = undefined // eslint-disable-line
+  for (let ridx = 0; ridx < nLines; ridx++) {
+    const line = terminal.buffer.active.getLine(ridx)
 
     if (line.isWrapped && prevRow !== undefined) {
       squashRow(line, previous, current, prevRow)


### PR DESCRIPTION
when capturing the output of the pty, line wrapping causes odd behavior, with lines squashed together strangely

this might be due to some webpack or typescript behavior for variables declared but never defined before first use? we were assuming it was `undefined`, but... this doesn't appear to be the case? in any case, we shouldn't be using variables with no defined value.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
