### PR TITLE
feat(plugins/plugin-client-common): add `ansi` language tag support for markdown code blocks

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
@@ -22,6 +22,7 @@ import { Props } from '../../../Markdown'
 import { tryFrontmatter } from '../../frontmatter'
 import { CodeBlockResponseFn } from '../../components'
 
+import Ansi from '../../../Scalar/Ansi'
 import CodeBlock from '../../../../Views/Terminal/Block/Inputv2'
 
 const SimpleEditor = React.lazy(() => import('../../../Editor/SimpleEditor'))
@@ -48,6 +49,10 @@ export default function codeWrapper(
     // react-markdown v6+ places the language in the className
     const match = /language-(\w+)/.exec(props.className || '')
     const language = match ? match[1] : undefined
+
+    if (language === 'ansi') {
+      return <Ansi>{body}</Ansi>
+    }
 
     if (mdprops.nested && props.codeIdx && mdprops.executableCodeBlocks !== false) {
       // onContentChange={body => this.splice(codeWithResponseFrontmatter(body, attributes.response), props.node.position.start.offset, props.node.position.end.offset)}


### PR DESCRIPTION
This allows us to display ansi-colored text. e.g.

```ansi
--8<-- "some-log-file-with-ansi-characters.txt"
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
