### PR TITLE
feat: allow guidebooks to selectively include fields from source material

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/filter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/filter.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { dump as dumpToYaml } from 'js-yaml'
+
+function dump(field: any, language: string): string {
+  if (/ya?ml/.test(language)) {
+    return dumpToYaml(field)
+  } else if (typeof field === 'string') {
+    return field
+  } else if (field === undefined || field === null) {
+    return 'null'
+  } else {
+    return JSON.stringify(field, undefined, 2)
+  }
+}
+
+function filterIn(json: Record<string, any>, include: string, language: string) {
+  return dump(json[include], language)
+}
+
+function filterOut(json: Record<string, any>, exclude: string[], language: string) {
+  exclude.forEach(key => {
+    delete json[key]
+  })
+  return dump(json, language)
+}
+
+function asFilter(filter: string | string[]): string[] {
+  if (typeof filter === 'string') {
+    return [filter]
+  } else {
+    return filter
+  }
+}
+
+export default function bodyAndLanguage(body: string, language: string, attributes: Record<string, any>) {
+  if (language === 'json' && (attributes.include || attributes.exclude || attributes.language)) {
+    try {
+      const json = JSON.parse(body)
+
+      const languageForView =
+        attributes.language || (attributes.languageFrom && json[attributes.languageFrom]) || language
+
+      const bodyForView =
+        (attributes.include
+          ? filterIn(json, attributes.include, languageForView)
+          : attributes.exclude
+          ? filterOut(json, asFilter(attributes.exclude), languageForView)
+          : body) || ''
+
+      return { bodyForView, languageForView }
+    } catch (err) {
+      console.error('Error parsing json', body, err)
+    }
+  }
+
+  return { bodyForView: body, languageForView: language }
+}

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/code/index.tsx
@@ -18,6 +18,8 @@ import React from 'react'
 import { CodeProps } from 'react-markdown/lib/ast-to-react'
 import { KResponse, CommentaryResponse, getPrimaryTabId } from '@kui-shell/core'
 
+import bodyAndLanguage from './filter'
+
 import { Props } from '../../../Markdown'
 import { tryFrontmatter } from '../../frontmatter'
 import { CodeBlockResponseFn } from '../../components'
@@ -103,6 +105,8 @@ export default function codeWrapper(
         </React.Fragment>
       )
     } else {
+      const { bodyForView, languageForView } = bodyAndLanguage(body, language, attributes)
+
       return (
         <div className={'paragraph' + (mdprops.executableCodeBlocks === false ? ' kui--inverted-color-context' : '')}>
           {!language ? (
@@ -113,8 +117,8 @@ export default function codeWrapper(
             <code className="kui--code--editor">
               <SimpleEditor
                 tabUUID={tabUUID}
-                content={code}
-                contentType={language}
+                content={bodyForView}
+                contentType={languageForView}
                 fontSize={12}
                 simple
                 minHeight={0}


### PR DESCRIPTION
## Limiting content to a given field

```json
---
include: thisField
---
--8<-- "foo.json"
```

## Excluding fields

```json
---
exclude:
	- thisField
	- thatField
---
--8<-- "foo.json"
```

## Recasting as yaml

```json
---
language: yaml
---
--8<-- "foo.json"
```

## Getting language from a source field

```json
---
languageFrom: language
include: source
---
--8<-- "foo.json"
```

Where an example foo.json might be

```json
{
  "language: "python",
  "source": "...some python code",
  "thisField": ...,
  "thatField": ...
}
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
