### PR TITLE
fix: switch to using `notarytool` when notiarizing on macOS

### DIFF
--- a/packages/builder/dist/electron/builders/notarize.js
+++ b/packages/builder/dist/electron/builders/notarize.js
@@ -23,6 +23,8 @@ function notarizationOptionsForOSX(name /*: string */) {
 
     return {
       appPath,
+      tool: 'notarytool',
+      teamId: process.env.ASC_PROVIDER, // team short name
       ascProvider: process.env.ASC_PROVIDER, // team short name
       appBundleId: process.env.APP_BUNDLE_ID, // app bundle id
       appleId: process.env.APPLEID, // login ID for your AppleID account


### PR DESCRIPTION
I don't know why it's not the default, but `electron-notarize` uses the "legacy" notarization method by default. This can take several minutes, in the best of times.

This PR enables use of the newer `notarytool`. My experiments so far show that it can notarize in seconds, versus minutes.

ref: https://github.com/electron/electron-notarize#method-notarizeopts-promisevoid

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
