### PR TITLE
fix: if productName contains spaces, headless bundle files have spaces

### DIFF
--- a/packages/webpack/headless-webpack.config.js
+++ b/packages/webpack/headless-webpack.config.js
@@ -176,7 +176,13 @@ kuiPluginExternals.forEach(_ => {
   externals[_] = _
 })
 
-const config = (entry, target, extraPlugins = [], filename = productName.toLowerCase(), nameSuffix = '') => ({
+const config = (
+  entry,
+  target,
+  extraPlugins = [],
+  filename = productName.toLowerCase().replace(/\s/g, '-'),
+  nameSuffix = ''
+) => ({
   context: process.env.CLIENT_HOME,
   stats: {
     // while developing, you should set this to true


### PR DESCRIPTION
we already turn "MyProduct" into "myproduct.js" as a bundle file name. i think it also makes sense to turn "My Product" into "my-product.js", to avoid downstream complications with filenames with spaces.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
