### PR TITLE
feat(plugins/plugin-s3): allow dynamic enabling of s3 plugin

### DIFF
--- a/plugins/plugin-s3/src/index.ts
+++ b/plugins/plugin-s3/src/index.ts
@@ -25,4 +25,4 @@ export {
 export { default as eventBus } from './vfs/events'
 export { minioConfig, mounts as getCurrentMounts, Mount } from './vfs/responders'
 
-export { default as isEnabled } from './isEnabled'
+export { enable, default as isEnabled } from './isEnabled'

--- a/plugins/plugin-s3/src/isEnabled.ts
+++ b/plugins/plugin-s3/src/isEnabled.ts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
+let enabled = process.env.KUI_S3 !== 'false'
+
 /**
  * Allow clients to selectively disable plugin-s3; e.g. perhaps
  * plugin-s3 is not needed in headless mode.
  */
 export default function isEnabled() {
-  return process.env.KUI_S3 !== 'false'
+  return enabled
+}
+
+export function enable() {
+  enabled = true
+
+  return import('./preload').then(_ => _.default())
 }


### PR DESCRIPTION
Recently, we added a feature to plugin-s3 to allow clients to selective disable the plugin (by setting KUI_S3=false). This was done to allow certain modes, e.g. a headless mode, to avoid the costs of the plugin-s3 preloader.

However, this choice was not revocable, later in the run. Let's add that feature. This PR adds an `enable()` async function to plugin-s3.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
