### PR TITLE
fix: guidebook streaming output disappears

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -436,7 +436,7 @@ export default class CodeBlock<T1, T2, T3> extends StreamingConsumer<Props<T1, T
         <div className="repl-output repl-result-has-content">
           <div className="result-vertical">
             <div className="repl-result">
-              {this.state.execution === 'processing' && this.streamingOutput()}
+              {/* this.state.execution === 'processing' && */ this.streamingOutput()}
               {this.nonstreamingOutput()}
             </div>
           </div>


### PR DESCRIPTION
If a guidebook executes a command that streams output and then returns `true`, expecting the streaming output to persist... this is not the case.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
