### PR TITLE
fix(plugins/plugin-bash-like): xterm alt buffer mode often not full screen

### DIFF
--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -276,6 +276,12 @@ class Resizer {
     }
 
     const { rows, cols } = this.getSize(flush)
+    if (isNaN(rows) || isNaN(cols)) {
+      // see https://github.com/kubernetes-sigs/kui/pull/8925
+      setTimeout(() => this.resize(flush, force), 50)
+      return
+    }
+
     if (this.terminal.rows !== rows || this.terminal.cols !== cols || force) {
       debug('resize', cols, rows, this.terminal.cols, this.terminal.rows, this.inAltBufferMode())
       try {


### PR DESCRIPTION


This is due to a race condition in the initial `getSize()` call. We aren't handling isNaN on all paths.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
