### PR TITLE
fix: `oc get projects` fails

### DIFF
--- a/plugins/plugin-kubectl/oc/src/controller/oc/get/projects.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/oc/get/projects.ts
@@ -32,11 +32,18 @@ export default function registerOcProjectGet(registrar: Registrar) {
 
   registrar.listen(
     '/oc/projects',
-    args => args.REPL.qexec('oc get projects', undefined, undefined, args.execOptions),
+    args => args.REPL.qexec('oc get ns', undefined, undefined, args.execOptions),
     defaultFlags
   )
+  ;['project', 'projects', 'Project', 'Projects'].forEach(project => {
+    registrar.listen(
+      `/oc/get/${project}`,
+      args => args.REPL.qexec('oc get ns', undefined, undefined, args.execOptions),
+      defaultFlags
+    )
+  })
 
-  const aliases = ['project', 'projects', 'ns', 'namespace', 'namespaces']
+  const aliases = ['ns', 'namespace', 'namespaces']
   aliases.forEach(ns => {
     registrar.listen(`/oc/get/${ns}`, doGet('oc'), defaultFlags)
   })


### PR DESCRIPTION
Fixes #8928

This is an imperfect PR, in that the resulting Kui table shows "Namespace" in the title.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
