### PR TITLE
feat: add GB_ as another safe proxy env prefix

### DIFF
--- a/packages/proxy/app/routes/exec.js
+++ b/packages/proxy/app/routes/exec.js
@@ -82,8 +82,9 @@ function main(cmdline, execOptions, server, port, hostname, existingSession, loc
 
     // pass through process.env.KUI_* to the user
     // see https://github.com/kubernetes-sigs/kui/issues/8120
+    // @starpit 20220712 added GB_ (guidebook) as a safe prefix
     for (const key in process.env) {
-      if (/^KUI_/.test(key) && !options.env[key]) {
+      if (/^(GB|KUI)_/.test(key) && !options.env[key]) {
         options.env[key] = process.env[key]
       }
     }


### PR DESCRIPTION
see https://github.com/kubernetes-sigs/kui/issues/8120
this PR extends the set of safe env prefices to pass through to the session to include all env vars prefixed by GB_

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
