### PR TITLE
feat: pass createWindow to electron-main plugins

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -459,7 +459,9 @@ export async function createWindow(
             const mod = await import('@kui-shell/plugin-' + webpackPath(message.module) + '/mdist/electron-main.js')
             debug('invoke got module')
 
-            const returnValue = await mod[message.main || 'main'](message.args, event.sender)
+            const returnValue = await mod[message.main || 'main'](message.args, event.sender, (argv: string[]) =>
+              createWindow(true, argv)
+            )
             debug('invoke got returnValue', returnValue)
 
             event.sender.send(


### PR DESCRIPTION
plugins are allowed to extend electron main process functionality, such as to add a tray menu. but we aren't passing them the capability to create new windows. this PR fills that gap.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
