### PR TITLE
feat(plugins/plugin-client-common): allow markdown images to point to client images

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/img.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/img.tsx
@@ -37,8 +37,16 @@ function handleImage(mdprops: Props, props: ImgProps, key?: string) {
   const srcIsHttp = /^http/i.test(src)
   const isHttp = srcIsHttp || baseUrlIsHttp
   const isLocal = !isHttp && !allContentIsRemote(mdprops)
+  const isClientRelativeMatch = !isHttp && src.match(/^@kui-shell\/client\/(images|icons)\/(.+)\.svg$/)
 
-  if (isLocal) {
+  if (isClientRelativeMatch) {
+    const subdir = isClientRelativeMatch[1]
+    if (subdir === 'icons') {
+      src = require('@kui-shell/client/icons/' + isClientRelativeMatch[2] + '.svg')
+    } else {
+      src = require('@kui-shell/client/images/' + isClientRelativeMatch[2] + '.svg')
+    }
+  } else if (isLocal) {
     const absoluteSrc = isAbsolute(src)
       ? src
       : join(mdprops.fullpath ? dirname(mdprops.fullpath) : mdprops.baseUrl || process.cwd(), src)


### PR DESCRIPTION
e.g.

```markdown
<img alt="CodeFlare Icon" src="@kui-shell/client/icons/svg/codeflare.svg" width="200" height="200" />
```

Restrictions:
- only svgs for now
- the subdirectory must either be "icons" or "images" (it was "icons" in the above example)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
