### PR TITLE
feat: allow controllers to add class to top-level tabs

### DIFF
--- a/packages/core/src/webapp/tab.ts
+++ b/packages/core/src/webapp/tab.ts
@@ -33,8 +33,17 @@ export interface Tab extends HTMLDivElement {
   onActivate(handler: (isActive: boolean) => void): void
   offActivate(handler: (isActive: boolean) => void): void
 
+  /** Add a class to the nearest enclosing tab-like (e.g. Split) */
   addClass(cls: string): void
+
+  /** Add a class to the top-level enclosing tab-like (e.g. Tab) */
+  addTopClass(cls: string): void
+
+  /** Remove a class from the nearest enclosing tab-like (e.g. Split) */
   removeClass(cls: string): void
+
+  /** Remove a class from the top-level enclosing tab-like (e.g. Tab) */
+  removeTopClass(cls: string): void
 
   scrollToTop(): void
 

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -262,6 +262,7 @@ export default class TabContent extends React.PureComponent<Props, State> {
           }
         })
       }
+      tab.addTopClass = tab.addClass
 
       tab.removeClass = (cls: string) => {
         this.setState(curState => {
@@ -274,6 +275,7 @@ export default class TabContent extends React.PureComponent<Props, State> {
           }
         })
       }
+      tab.removeTopClass = tab.removeClass
 
       tab.setTitle = (title: string) => {
         if (this.props.willSetTitle) {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/KuiFrontmatter.ts
@@ -90,12 +90,16 @@ type KuiFrontmatter = Partial<WizardSteps> &
     /** Title of the Notebook */
     title?: string
 
-    layoutCount?: Record<string, number>
+    /** CSS class to add to the containing tab */
+    className?: string | string[]
 
     /**
      * A mapping that indicates which section (the `number` values) should be rendered in a given split position.
      */
     layout?: 'wizard' | Record<number | 'default', SplitPositionSpec>
+
+    /** Internal */
+    layoutCount?: Record<string, number>
   }
 
 export function hasWizardSteps(frontmatter: KuiFrontmatter): frontmatter is KuiFrontmatter & Required<WizardSteps> {

--- a/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/frontmatter.tsx
@@ -253,6 +253,22 @@ export function kuiFrontmatter(opts: { tab: Tab }) {
         setTimeout(() => opts.tab.setTitle(frontmatter.title))
       }
 
+      if (frontmatter.className) {
+        setTimeout(() => {
+          if (typeof frontmatter.className === 'string') {
+            opts.tab.addTopClass(frontmatter.className)
+          } else if (Array.isArray(frontmatter.className)) {
+            frontmatter.className.forEach(_ => opts.tab.addTopClass(_))
+          } else {
+            console.error(
+              'Syntax error in markdown frontmatter className attribute',
+              typeof frontmatter.className,
+              frontmatter.className
+            )
+          }
+        })
+      }
+
       preprocessCodeBlocksInContent(tree, frontmatter)
       preprocessWizard(tree, frontmatter)
     }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -643,9 +643,11 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
         scrollback.facade.splitCount = () => this.state.splits.length
         scrollback.facade.hasSideBySideTerminals = () => this.numDefaultSplits() > 1
 
+        scrollback.facade.addTopClass = this.props.tab.addClass
         scrollback.facade.addClass = (cls: string) => {
           ref.classList.add(cls)
         }
+        scrollback.facade.removeTopClass = this.props.tab.removeClass
         scrollback.facade.removeClass = (cls: string) => {
           ref.classList.remove(cls)
         }


### PR DESCRIPTION
Currently, we only allow controllers to add class to splits.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
