### PR TITLE
feat: add KuiHeader mixin

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_mixins.scss
@@ -16,6 +16,12 @@
 
 $height: 3em;
 
+@mixin KuiHeader {
+  .kui--top-tab-stripe-header {
+    @content;
+  }
+}
+
 @mixin TopTabStripe {
   .pf-c-page,
   .kui--top-tab-stripe-header {


### PR DESCRIPTION
The current TopTabStripe mixin is too general. This new mixin specifies only the header.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
