### PR TITLE
feat: improved support for passing through window titles for new windows

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -184,7 +184,7 @@ export async function createWindow(
         {},
         styles,
         {
-          title: productName,
+          title: subwindowPrefs.title || productName,
           width: width || styles.width || 1280,
           height: height || styles.height || 960,
           webPreferences: {
@@ -442,7 +442,8 @@ export async function createWindow(
                 {
                   width: message.width,
                   height: message.height,
-                  initialTabTitle: message.title,
+                  title: message.title,
+                  initialTabTitle: message.initialTabTitle || message.title,
                   quietExecCommand: message.quietExecCommand !== undefined ? message.quietExecCommand : false
                 },
                 true

--- a/packages/core/src/models/SubwindowPrefs.ts
+++ b/packages/core/src/models/SubwindowPrefs.ts
@@ -22,6 +22,7 @@ interface SubwindowPrefs {
   synonymFor?: object
   width?: number
   height?: number
+  title?: string
   initialTabTitle?: string
   quietExecCommand?: boolean
   position?: () => Promise<{ x: number; y: number }>

--- a/packages/core/src/webapp/bootstrap/client.ts
+++ b/packages/core/src/webapp/bootstrap/client.ts
@@ -24,7 +24,8 @@ type ClientRender = (
   isPopup: boolean,
   commandLine?: string[],
   initialTabTitle?: string,
-  quietExecCommand?: boolean
+  quietExecCommand?: boolean,
+  windowTitle?: string
 ) => void
 
 export default ClientRender

--- a/packages/core/src/webapp/bootstrap/init-electron.ts
+++ b/packages/core/src/webapp/bootstrap/init-electron.ts
@@ -105,11 +105,16 @@ export async function render(client: Client, root: Element) {
   const maybeExecuteThis = argv && argv.length > 0 ? argv : undefined
   const fullShell = maybeExecuteThis && maybeExecuteThis.length === 1 && maybeExecuteThis[0] === 'shell'
 
+  if (prefs && prefs.title) {
+    document.title = prefs.title
+  }
+
   client(
     root,
     !!prefs && prefs.fullscreen,
     !fullShell ? maybeExecuteThis : undefined,
     prefs ? prefs.initialTabTitle : undefined,
-    prefs ? prefs.quietExecCommand : undefined
+    prefs ? prefs.quietExecCommand : undefined,
+    prefs ? prefs.title : undefined
   )
 }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -34,7 +34,8 @@ function renderMain(
   isPopup: boolean,
   commandLine?: string[],
   initialTabTitle?: string,
-  quietExecCommand?: boolean
+  quietExecCommand?: boolean,
+  title?: string
 ) {
   // re: noBootstrap; since we do the bootstrapping here, we don't
   // need the Client to do anything more
@@ -43,6 +44,7 @@ function renderMain(
       noBootstrap
       isPopup={isPopup}
       commandLine={commandLine}
+      title={title}
       initialTabTitle={initialTabTitle}
       quietExecCommand={quietExecCommand}
     />,

--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -61,6 +61,9 @@ export type Props = Partial<KuiConfiguration> &
 
     /** initial tab title */
     initialTabTitle?: string
+
+    /** document/window title */
+    title?: string
   }
 
 type State = KuiConfiguration & {


### PR DESCRIPTION
We weren't allowing the `new-window` main API to pass through a desired window title.

```typescript
    const { ipcRenderer } = await import("electron")
    ipcRenderer.send(
      "synchronous-message",
      JSON.stringify({
        operation: "new-window",
        title: productName + " Popup",
        initialTabTitle: "Hello There",
        width,
        height,
        argv: ["my", "command", myCommandArg1],
      })
    )
```
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
