### PR TITLE
fix(packages/core): regression due to title work, new windows may result in null pointer exception

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -184,7 +184,7 @@ export async function createWindow(
         {},
         styles,
         {
-          title: subwindowPrefs.title || productName,
+          title: (subwindowPrefs && subwindowPrefs.title) || productName,
           width: width || styles.width || 1280,
           height: height || styles.height || 960,
           webPreferences: {


### PR DESCRIPTION
The work from https://github.com/kubernetes-sigs/kui/pull/8942
does not guard against `subwindowPrefs` being undefined

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
