### PR TITLE
fix: allow electron-main plugins to incorporate template pngs into the webpack build

### DIFF
--- a/packages/webpack/headless-webpack.config.js
+++ b/packages/webpack/headless-webpack.config.js
@@ -286,7 +286,17 @@ const config = (
       { test: /\.py$/, use: 'file-loader' },
       { test: /\.ico$/, use: 'ignore-loader' },
       { test: /\.jpg$/, use: 'ignore-loader' },
-      { test: /\.png$/, use: 'ignore-loader' },
+
+      // handles template images for Tray menus
+      { test: x => x.endsWith('.png') && !/Template(@[^.]+)?\.png$/.test(x), use: 'ignore-loader' },
+      {
+        test: /Template(@[^.]+)?\.png$/,
+        type: 'asset/resource',
+        generator: {
+          filename: 'images/[name][ext]'
+        }
+      },
+
       { test: /\.svg$/, use: 'ignore-loader' },
       { test: /\.sh$/, use: 'raw-loader' },
       { test: /\.html$/, type: 'raw-loader' },


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
