### PR TITLE
feat: createWindow API should accept options for the new window

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -285,3 +285,5 @@ export {
 } from './api/Client'
 
 export * from './api/window-events'
+
+export type CreateWindowFunction = (argv: string[], prefs?: import('./models/SubwindowPrefs').default) => void

--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -477,8 +477,10 @@ export async function createWindow(
             const mod = await import('@kui-shell/plugin-' + webpackPath(message.module) + '/mdist/electron-main.js')
             debug('invoke got module')
 
-            const returnValue = await mod[message.main || 'main'](message.args, event.sender, (argv: string[]) =>
-              createWindow(true, argv)
+            const returnValue = await mod[message.main || 'main'](
+              message.args,
+              event.sender,
+              (argv: string[], prefs?: ISubwindowPrefs) => createWindow(true, argv, undefined, prefs)
             )
             debug('invoke got returnValue', returnValue)
 


### PR DESCRIPTION
```typescript
{
  title: string
  width: number
  height: number
}
```

This PR also exports a `CreateWindowFunction` type from `@kui-shell/core`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
