### PR TITLE
fix: Ctrl/Cmd+W in windows opened to be non-kui does nothing

### DIFF
--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -21,6 +21,7 @@ import { Menu, MenuItemConstructorOptions } from 'electron'
 
 import open from './open'
 import tellRendererToExecute from './tell'
+import ISubwindowPrefs from '../models/SubwindowPrefs'
 import loadClientNotebooksMenuDefinition from './load'
 import { openNotebook, clientNotebooksDefinitionToElectron } from './notebooks'
 import { isOfflineClient, isReadOnlyClient } from '..'
@@ -43,7 +44,16 @@ const newSplit = () => tellRendererToExecute('split')
  * tell the current window to close the current tab
  *
  */
-const closeTab = () => tellRendererToExecute('tab close -A')
+const closeTab = (
+  _: import('electron').MenuItem,
+  browserWindow: import('electron').BrowserWindow & { subwindow: ISubwindowPrefs }
+) => {
+  if (browserWindow.subwindow && browserWindow.subwindow._notAKuiWindow) {
+    browserWindow.close()
+  } else {
+    tellRendererToExecute('tab close -A')
+  }
+}
 
 const isDarwin = process.platform === 'darwin'
 const closeAccelerator = isDarwin ? 'Command+W' : 'Control+Shift+W'

--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -222,6 +222,18 @@ export async function createWindow(
           position
         )
 
+        // if we are opening a random URL, then we cannot use a
+        // frameless window; otherwise, it is unlikely the window will
+        // be moveable
+        if (typeof executeThisArgvPlease === 'string') {
+          delete opts.frame
+          delete opts.titleBarStyle
+          if (!subwindowPrefs) {
+            subwindowPrefs = {}
+          }
+          subwindowPrefs._notAKuiWindow = true
+        }
+
         // if user ups zoom level, reloads, we're stuck at a higher zoom
         // see https://github.com/electron/electron/issues/10572
         // note that this requires show: false above

--- a/packages/core/src/models/SubwindowPrefs.ts
+++ b/packages/core/src/models/SubwindowPrefs.ts
@@ -33,6 +33,9 @@ interface SubwindowPrefs {
   /** Use this as the initial title for the first tab */
   initialTabTitle?: string
 
+  /** Internal: this is not a Kui window */
+  _notAKuiWindow?: boolean
+
   quietExecCommand?: boolean
   position?: () => Promise<{ x: number; y: number }>
   bringYourOwnWindow?: () => void


### PR DESCRIPTION
if the client is using Kui to show a random web page, Kui's main menu.ts still intercepts Ctrl/Cmd+w as a request to close a Kui tab.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
