### PR TITLE
feat: core argv parser should parse out `-- <rest>` options

### DIFF
--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -278,7 +278,7 @@ class InProcessExecutor implements Executor {
 
     const allFlags = {
       configuration: Object.assign(
-        { 'camel-case-expansion': false },
+        { 'camel-case-expansion': false, 'populate--': true },
         (evaluator.options && evaluator.options.flags && evaluator.options.flags.configuration) ||
           (usage && usage.configuration) ||
           {}


### PR DESCRIPTION
This requires setting a special flag when using yargs-parser.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
