### PR TITLE
fix: tooltip for theme switcher is annoying and not helping

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/Settings.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/Settings.tsx
@@ -15,11 +15,9 @@
  */
 
 import React from 'react'
-import { encodeComponent, Events, i18n, pexecInCurrentTab, Settings as Setting, Themes, Util } from '@kui-shell/core'
+import { encodeComponent, Events, pexecInCurrentTab, Settings as Setting, Themes, Util } from '@kui-shell/core'
 
 import DropdownWidget, { Props as DropdownWidgetProps } from './DropdownWidget'
-
-const strings = i18n('plugin-client-common')
 
 type Props = Pick<DropdownWidgetProps, 'position'>
 
@@ -67,13 +65,6 @@ export default class Settings extends React.PureComponent<Props, State> {
       return <React.Fragment />
     }
 
-    return (
-      <DropdownWidget
-        noPadding
-        id="kui--settings-widget"
-        title={strings('Switch theme')}
-        actions={this.state.actions}
-      />
-    )
+    return <DropdownWidget noPadding id="kui--settings-widget" actions={this.state.actions} />
   }
 }


### PR DESCRIPTION
I think it's pretty obvious what it is? And the tooltip, being in the corner and almost as big as the component itself, is rather annoyingly in the way more often than not.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
