### PR TITLE
fix: remove integration of unstable knative guidebooks

### DIFF
--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -23,57 +23,6 @@
       "label": "Iter8",
       "expanded": false,
       "submenu": [{ "notebook": "Load testing with SLO validation", "filepath": "/kui/iter8/tutorial1.md" }]
-    },
-    {
-      "label": "Knative",
-      "expanded": false,
-      "submenu": [
-        {
-          "label": "Getting Started",
-          "expanded": false,
-          "submenu": [
-            { "notebook": "Quick start", "filepath": "/kui/kubernetes/install-knative-quickstart.md" },
-            {
-              "label": "Serving",
-              "submenu": [
-                { "notebook": "Scaling to Zero", "filepath": "/kui/kubernetes/knative-first-autoscale.md" },
-                { "notebook": "Traffic Splitting", "filepath": "/kui/kubernetes/knative-traffic-splitting.md" }
-              ]
-            },
-            {
-              "label": "Eventing",
-              "submenu": [
-                {
-                  "notebook": "Introducing Knative Eventing",
-                  "filepath": "/kui/kubernetes/knative-introducing-eventing.md"
-                },
-                {
-                  "notebook": "Sources, Brokers, Triggers, Sinks",
-                  "filepath": "/kui/kubernetes/knative-eventing-components.md"
-                },
-                {
-                  "notebook": "Introducing the CloudEvents Player",
-                  "filepath": "/kui/kubernetes/knative-cloud-events-player.md"
-                },
-                {
-                  "notebook": "Creating your first Trigger",
-                  "filepath": "/kui/kubernetes/knative-first-trigger.md"
-                }
-              ]
-            },
-            { "notebook": "What's Next?", "filepath": "/kui/kubernetes/knative-whats-next.md" }
-          ]
-        },
-        {
-          "label": "Knative Serving Examples",
-          "expanded": false,
-          "submenu": [
-            { "notebook": "Hello World Deployment", "filepath": "/kui/kubernetes/knative-serving-hello-world.md" },
-            { "notebook": "Autoscaling Using Go", "filepath": "/kui/kubernetes/knative-serving-autoscaling-go.md" },
-            { "notebook": "Traffic Management", "filepath": "/kui/kubernetes/knative-serving-traffic-management.md" }
-          ]
-        }
-      ]
     }
   ]
 }

--- a/plugins/plugin-kubectl/src/non-headless-preload.ts
+++ b/plugins/plugin-kubectl/src/non-headless-preload.ts
@@ -74,7 +74,7 @@ export default async (registrar: PreloadRegistrar) => {
   notebookVFS.cp(
     undefined,
     [
-      'plugin://plugin-kubectl/notebooks/knative-what-is-it-good-for.md',
+      /* 'plugin://plugin-kubectl/notebooks/knative-what-is-it-good-for.md',
       'plugin://plugin-kubectl/notebooks/install-knative-quickstart.md',
       'plugin://plugin-kubectl/notebooks/knative-quickstart.json',
       'plugin://plugin-kubectl/notebooks/knative-first-autoscale.md',
@@ -86,7 +86,7 @@ export default async (registrar: PreloadRegistrar) => {
       'plugin://plugin-kubectl/notebooks/knative-whats-next.md',
       'plugin://plugin-kubectl/notebooks/knative-serving-hello-world.md',
       'plugin://plugin-kubectl/notebooks/knative-serving-autoscaling-go.md',
-      'plugin://plugin-kubectl/notebooks/knative-serving-traffic-management.md',
+      'plugin://plugin-kubectl/notebooks/knative-serving-traffic-management.md', */
       'plugin://plugin-kubectl/notebooks/create-jobs.md',
       'plugin://plugin-kubectl/notebooks/create-jobs.json',
       'plugin://plugin-kubectl/notebooks/crud-operations.md',


### PR DESCRIPTION
This PR does not remove them from the repo, just removes them from the default client UI.

This should alleviate some of the excessive GETs from github.com while building webpack; the knative guidebooks reference source material from github...

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
