### PR TITLE
fix: monaco-editor cursor color now has low contrast

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.scss
+++ b/plugins/plugin-client-common/web/scss/components/Editor/theme-alignment.scss
@@ -170,7 +170,6 @@ body[kui-theme-style] .monaco-editor .view-overlays .current-line {
 
 /* cursor */
 body[kui-theme-style] .monaco-editor .cursor {
-  mix-blend-mode: color-burn;
   background-color: var(--color-support-01);
 }
 


### PR DESCRIPTION
Maybe from the recent monaco-editor version bumps

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
