### PR TITLE
test: edit commentary test is unstable

### DIFF
--- a/plugins/plugin-core-support/src/test/core-support/commentary-util.ts
+++ b/plugins/plugin-core-support/src/test/core-support/commentary-util.ts
@@ -34,14 +34,18 @@ export function startEditing(ctx: Common.ISuite) {
   })
 }
 
-/** set the monaco editor text */
-export async function type(ctx: Common.ISuite, text: string, inNotebook: boolean): Promise<void> {
+/** focus the monaco editor component */
+export async function focus(ctx: Common.ISuite, inNotebook: boolean): Promise<void> {
   const selector = `${lastOutput(inNotebook)} .monaco-editor-wrapper .view-lines`
   await ctx.app.client.$(selector).then(async _ => {
     await _.click()
     await _.waitForEnabled()
   })
+}
 
+/** set the monaco editor text */
+export async function type(ctx: Common.ISuite, text: string, inNotebook: boolean): Promise<void> {
+  await focus(ctx, inNotebook)
   await ctx.app.client.keys(text)
 }
 

--- a/plugins/plugin-core-support/src/test/core-support/commentary.ts
+++ b/plugins/plugin-core-support/src/test/core-support/commentary.ts
@@ -18,7 +18,7 @@ import { dirname } from 'path'
 import { Common, CLI, ReplExpect, Selectors, Util, Keys } from '@kui-shell/test'
 
 import { splitViaButton } from '../core-support2/split-helpers'
-import { lastOutput, typeAndVerify, verifyTextInMonaco } from './commentary-util'
+import { focus, lastOutput, typeAndVerify, verifyTextInMonaco } from './commentary-util'
 
 const ROOT = dirname(require.resolve('@kui-shell/plugin-core-support/package.json'))
 
@@ -180,6 +180,7 @@ describe('edit commentary', function(this: Common.ISuite) {
   const escapeCancel = (expect: string, inNotebook: boolean) => {
     it('should close the editor by typing Escape', async () => {
       try {
+        await focus(this, inNotebook)
         await this.app.client.keys('Escape')
         await this.app.client
           .$(`${lastOutput(inNotebook)} ${Selectors.COMMENTARY_EDITOR}`)


### PR DESCRIPTION
Apparently hitting escape when the editor compnent is *not* focused does not result in the editor compnent cancelling itself and disappearing.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
