### PR TITLE
fix(plugins/plugin-kubectl): in split screen mode, PVC and PV tables horizontally overflow

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -81,6 +81,15 @@ export const outerCSSForKey = {
   // api-resources
   APIGROUP: 'hide-with-sidecar',
 
+  // PVC and PV
+  VOLUME: 'hide-with-sidecar kui--hide-in-narrower-windows',
+  STORAGECLASS: 'hide-with-sidecar kui--hide-in-narrower-windows',
+  'ACCESS MODES': 'hide-with-sidecar kui--hide-in-narrower-windows',
+
+  // PV
+  CLAIM: 'hide-with-sidecar kui--hide-in-narrower-windows',
+  'RECLAIM POLICY': 'hide-with-sidecar kui--hide-in-narrower-windows',
+
   REVISION: 'hide-with-sidecar', // helm ls
   AGE: 'hide-with-sidecar', // e.g. helm status and kubectl get svc
   'PORT(S)': 'entity-name-group entity-name-group-narrow hide-with-sidecar', // helm status for services


### PR DESCRIPTION
Fixes #8978

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
