### PR TITLE
fix(plugins/plugin-kubectl): deployments are red even though the pods may be yellow

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/deployment.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/deployment.ts
@@ -48,7 +48,8 @@ export async function doGetDeployment(args: Arguments<KubeOptions>) {
             const numerator = parseInt(match[1], 10)
             const denominator = parseInt(match[2], 10)
             attr.css =
-              numerator === denominator ? TrafficLight.Green : numerator === 0 ? TrafficLight.Red : TrafficLight.Yellow
+              numerator === denominator ? TrafficLight.Green : numerator === 0 ? TrafficLight.Gray : TrafficLight.Yellow
+            // ^^^ re: Gray, see #8976
           }
         }
       })


### PR DESCRIPTION
Fixes #8976

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
