### PR TITLE
fix(plugins/plugin-kubectl): regression in events drilldown

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/modes/Events.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/Events.tsx
@@ -41,7 +41,7 @@ function hasEvents(resource: KubeResource): boolean {
  */
 function command(_, resource: KubeResource, args: { argvNoOptions: string[]; parsedOptions: ParsedOptions }) {
   // limit events to those intersecting with the giving resource
-  const filter = `involvedObject.apiVersion=${resource.apiVersion},involvedObject.kind=${resource.kind},involvedObject.name=${resource.metadata.name},involvedObject.namespace=${resource.metadata.namespace},involvedObject.resourceVersion=${resource.metadata.resourceVersion}`
+  const filter = `involvedObject.apiVersion=${resource.apiVersion},involvedObject.kind=${resource.kind},involvedObject.name=${resource.metadata.name},involvedObject.namespace=${resource.metadata.namespace},involvedObject.uid=${resource.metadata.uid}`
 
   // this is the command that will fetch the events table; we specify a watchable table
   const argv = [


### PR DESCRIPTION
Recently #9001 added a resourceVersion join key to the events drilldown query. This PR switches us over to `uid`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
