### PR TITLE
fix(plugins/plugin-client-common): sidecar delete button from right split executes command in left split

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Confirm.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Confirm.tsx
@@ -81,6 +81,9 @@ export default class Confirm extends React.PureComponent<Props, State | ActiveSt
     }
   }
 
+  private readonly _onSubmit = this.onConfirm.bind(this, true)
+  private readonly _onClose = this.onConfirm.bind(this, false)
+
   public render() {
     if (!isActive(this.state)) {
       return <React.Fragment />
@@ -93,8 +96,8 @@ export default class Confirm extends React.PureComponent<Props, State | ActiveSt
           title={strings('pleaseConfirm')}
           primaryButtonText={strings('yesIAmSure')}
           secondaryButtonText={strings('cancel')}
-          onSubmit={() => this.onConfirm(true)}
-          onClose={() => this.onConfirm(false)}
+          onSubmit={this._onSubmit}
+          onClose={this._onClose}
         >
           <p className="bx--modal-content__text">{strings('aboutToExecute')}</p>
           <p className="bx--modal-content__text">

--- a/plugins/plugin-client-common/src/controller/confirm.ts
+++ b/plugins/plugin-client-common/src/controller/confirm.ts
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Events,
-  getPrimaryTabId,
-  Registrar,
-  ExecType,
-  UsageModel,
-  i18n,
-  pexecInCurrentTab
-} from '@kui-shell/core'
+import { Events, getPrimaryTabId, Registrar, ExecType, UsageModel, i18n, pexecInCurrentTab } from '@kui-shell/core'
 
 const strings = i18n('plugin-core-support')
 
@@ -65,7 +57,7 @@ export default async (commandTree: Registrar) => {
           if (!confirmed) {
             reject(strings('operationCancelled'))
           } else if (execOptions.type === ExecType.Nested) {
-            pexecInCurrentTab(command).then(resolve, reject)
+            pexecInCurrentTab(command, tab).then(resolve, reject)
           } else {
             REPL.qexec(command, undefined, undefined, { tab }).then(resolve, reject)
           }


### PR DESCRIPTION
this is annoying. if i have a table on the left, and a sidecar drilldown on the right, then click the delete button in the sidecar... the delete command is executed on the left, which scrolls my table offscreen. if i'm trying to delete multiple elements, this is annoying

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
