### PR TITLE
fix(plugins/plugin-kubectl): minor refinements to tray menu

### DIFF
--- a/plugins/plugin-kubectl/src/tray/menus/index.ts
+++ b/plugins/plugin-kubectl/src/tray/menus/index.ts
@@ -36,13 +36,15 @@ export default async function buildContextMenu(
   const { Menu } = await import('electron')
 
   const contextMenu = Menu.buildFromTemplate([
-    ...section('Resources', [workloads(createWindow), networking(createWindow), storage(createWindow)]),
-    ...section('Kubernetes Clusters', contexts(createWindow, updateFn)),
+    ...section('Kubernetes Resources', [workloads(createWindow), networking(createWindow), storage(createWindow)]),
+    ...section('Kubernetes Contexts', contexts(createWindow, updateFn)),
     ...section('Kubernetes Namespaces', namespaces(createWindow, updateFn)),
     { type: 'separator' },
-    { label: `${productName} ${version}`, icon: productIcon, click: () => createWindow([], { width, height }) },
-    { label: `File Bug or Feature Request`, icon: bugIcon, click: () => import('open').then(_ => _.default(bugs.url)) },
-    { label: `Quit ${productName}`, icon: powerOffIcon, role: 'quit' }
+    ...section(`${productName} ${version}`, [
+      { label: 'New Window', icon: productIcon, click: () => createWindow([], { width, height }) },
+      { label: 'Contact Us', icon: bugIcon, click: () => import('open').then(_ => _.default(bugs.url)) },
+      { label: `Quit ${productName}`, icon: powerOffIcon, role: 'quit' }
+    ])
   ])
 
   return contextMenu

--- a/plugins/plugin-kubectl/src/tray/menus/resources/open.ts
+++ b/plugins/plugin-kubectl/src/tray/menus/resources/open.ts
@@ -17,5 +17,5 @@
 import { CreateWindowFunction } from '@kui-shell/core'
 
 export default function openWindowWith(argv: string[], createWindow: CreateWindowFunction) {
-  return () => createWindow(argv, { quietExecCommand: false, width: 800, height: 600 })
+  return () => createWindow(argv, { quietExecCommand: false, width: 1000, height: 800 })
 }


### PR DESCRIPTION
1. make New Window operation explicit
2. Resources -> Kubernetes Resources

<img width="406" alt="kui tray menu v3" src="https://user-images.githubusercontent.com/4741620/188517499-d7231efb-3809-45f4-aa6f-43fe16359e83.png">


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
