### PR TITLE
chore: bump typescript 4.7.4 -> 4.8.2

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ build/
 packages/builder
 clients/**/*/dist/
 plugins/**/*/dist/
+plugins/**/*/mdist/
 plugins/*/lib/**/*.js
 plugins/*/i18n/**/*.js
 plugins/*/*.js
@@ -18,10 +19,14 @@ packages/core/test/
 packages/core/util/
 packages/core/webapp/
 packages/proxy/kui
+packages/react/dist/
 packages/test/dist/
+packages/*/mdist/
+plugins/*/mdist/
 plugins/*/dist/
 **/*/node_modules/
 **/*.d.ts
 plugins/plugin-apache-composer/tests/data/composer/composer-source-expect-errors/if-bad.js
 kui-stage
 *flycheck*.js
+/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "tmp": "0.2.1",
         "typedoc": "0.23.14",
         "typedoc-plugin-markdown": "3.13.6",
-        "typescript": "4.7.4",
+        "typescript": "4.8.2",
         "uuid": "9.0.0"
       },
       "engines": {
@@ -16978,9 +16978,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -32132,9 +32132,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "tmp": "0.2.1",
     "typedoc": "0.23.14",
     "typedoc-plugin-markdown": "3.13.6",
-    "typescript": "4.7.4",
+    "typescript": "4.8.2",
     "uuid": "9.0.0"
   },
   "husky": {

--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/MeterWidgets.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/MeterWidgets.tsx
@@ -35,7 +35,7 @@ export default class MeterWidgets extends React.PureComponent<Props> {
   private graft(node: React.ReactNode | {}, key?: number) {
     if (React.isValidElement(node)) {
       // ^^^ this check avoids tsc errors
-      return React.cloneElement(node, {
+      return React.cloneElement(node as React.ReactElement<{ key?: number; position: Props['position'] }>, {
         key,
         position: 'top-end' // meter widgets should default to top-end positioning of Popovers
       })

--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/TextWithIconWidget.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/TextWithIconWidget.tsx
@@ -34,19 +34,20 @@ export interface Options {
 }
 
 /** Component-specific Options */
-export interface Props extends Options {
-  text: string
-  viewLevel: ViewLevel
+export type Props = Options &
+  React.PropsWithChildren<{
+    text: string
+    viewLevel: ViewLevel
 
-  title?: string
-  iconIsNarrow?: boolean
-  iconOnclick?: string | (() => void)
-  textOnclick?: string | (() => void)
-  id?: string
+    title?: string
+    iconIsNarrow?: boolean
+    iconOnclick?: string | (() => void)
+    textOnclick?: string | (() => void)
+    id?: string
 
-  /** popover properties specified by client */
-  popover?: Pick<PopoverProps, 'bodyContent' | 'headerContent'> & Partial<PopoverProps>
-}
+    /** popover properties specified by client */
+    popover?: Pick<PopoverProps, 'bodyContent' | 'headerContent'> & Partial<PopoverProps>
+  }>
 
 export default class TextWithIconWidget extends React.PureComponent<Props> {
   /** Render the content (excluding any popover/tooltip wrappers) part */

--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -226,7 +226,7 @@ export default class TabContainer extends React.PureComponent<Props, State> {
   private graft(node: React.ReactNode | {}, uuid: string, key?: number) {
     if (React.isValidElement(node)) {
       // ^^^ this check avoids tsc errors
-      return React.cloneElement(node, {
+      return React.cloneElement(node as React.ReactElement<{ key?: number; uuid: string }>, {
         key,
         uuid
       })

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -371,11 +371,14 @@ export default class TabContent extends React.PureComponent<Props, State> {
   private graft(node: React.ReactNode | {}, key?: number) {
     if (React.isValidElement(node)) {
       // ^^^ this check avoids tsc errors
-      return React.cloneElement(node, {
-        key,
-        uuid: this.props.uuid,
-        active: this.state.active
-      })
+      return React.cloneElement(
+        node as React.ReactElement<{ key?: number; uuid: Props['uuid']; active: State['active'] }>,
+        {
+          key,
+          uuid: this.props.uuid,
+          active: this.state.active
+        }
+      )
     } else {
       return node
     }

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
@@ -54,7 +54,7 @@ export default class Tab extends React.PureComponent<Props, State> {
 
   private onCommandStart: (evt: Event) => void
   private onCommandComplete: (evt: Event) => void
-  private onThemeChange: ({ themeModel: Theme }) => void
+  private onThemeChange: (evt: { themeModel: Themes.Theme }) => void
 
   public constructor(props: Props) {
     super(props)

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
@@ -165,11 +165,7 @@ export default class TopTabStripe extends React.PureComponent<Props> {
   private headerName() {
     return (
       <KuiContext.Consumer>
-        {config => (
-          <div prefix="" className="kui--header--name">
-            {config.productName || 'Kui'}
-          </div>
-        )}
+        {config => <div className="kui--header--name">{config.productName || 'Kui'}</div>}
       </KuiContext.Consumer>
     )
   }

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/a.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/a.tsx
@@ -28,7 +28,7 @@ import { isAbsolute } from '../../../../controller/snippets'
 const Tooltip = React.lazy(() => import('../../../spi/Tooltip'))
 
 export default function a(mdprops: Props, uuid: string, repl: REPL) {
-  return (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+  return function a(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
     const isKuiCommand = props.href.startsWith('#kuiexec?command=')
     const isLocal = !/^http/i.test(props.href)
     const isNotebook = /\.md$/.test(props.href)

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarContainer.tsx
@@ -60,7 +60,10 @@ export default class ToolbarContainer extends React.PureComponent<Props, State> 
   private children() {
     if (React.isValidElement(this.props.children)) {
       // ^^^ this check avoids tsc errors
-      return React.cloneElement(this.props.children, { willUpdateToolbar: this._willUpdateToolbar })
+      return React.cloneElement(
+        this.props.children as React.ReactElement<{ willUpdateToolbar: ToolbarContainer['onToolbarUpdate'] }>,
+        { willUpdateToolbar: this._willUpdateToolbar }
+      )
     } else {
       return this.props.children
     }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/ActiveISearch.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/ActiveISearch.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable header/header */
 /*
- * Copyright 2018, 2020 The Kubernetes Authors
+ * Copyright 2018 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -171,12 +171,15 @@ export default class Block extends React.PureComponent<Props, State> {
 
   private customInput() {
     if (this.props.children && React.isValidElement(this.props.children)) {
-      return React.cloneElement(this.props.children, {
-        idx: this.props.idx,
-        tab: this.props.tab,
-        uuid: this.props.uuid,
-        block: this.state._block
-      })
+      return React.cloneElement(
+        this.props.children as React.ReactElement<Pick<Props, 'idx' | 'tab' | 'uuid'> & { block: State['_block'] }>,
+        {
+          idx: this.props.idx,
+          tab: this.props.tab,
+          uuid: this.props.uuid,
+          block: this.state._block
+        }
+      )
     }
   }
 

--- a/plugins/plugin-client-common/src/components/spi/Loading/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/Loading/model.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react'
-
 export default interface Props {
   className?: string
   description?: string

--- a/plugins/plugin-kubectl/src/test/k8s1/config-map.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/config-map.ts
@@ -18,7 +18,6 @@ import { Common, CLI, ReplExpect, Selectors, SidecarExpect, Util } from '@kui-sh
 import {
   waitForGreen,
   openSidecarByList,
-  defaultModeForGet,
   createNS,
   allocateNS,
   deleteNS,


### PR DESCRIPTION
This PR fixes a few compilation errors caught by the more strict `tsc` in 4.8.2.
This PR also fixes a few long-standing eslint errors.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
