### PR TITLE
chore: bump to madwizard 0.22.0 to pick up much-reduced bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10198,123 +10198,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/madwizard": {
-      "version": "0.21.7",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.21.7.tgz",
-      "integrity": "sha512-3mb/vxaQVdcBQY1UTR3Prt87pL/m2QZD0LaQRG04a0pSuvbnYxni7W2SF+MAFPm8OrKi2PrLlxRCVTa3WLggWw==",
-      "dependencies": {
-        "chalk": "^5.0.1",
-        "cli-highlight": "^2.1.11",
-        "columnify": "^1.6.0",
-        "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
-        "env-paths": "^2.2.1",
-        "expand-home-dir": "^0.0.3",
-        "figures": "^5.0.0",
-        "front-matter": "^4.0.2",
-        "hast-util-raw": "^7.2.2",
-        "hast-util-to-mdast": "^8.4.0",
-        "hast-util-to-string": "^2.0.0",
-        "js-yaml": "^4.1.0",
-        "make-fetch-happen": "^10.2.1",
-        "mdast-util-to-markdown": "^1.3.0",
-        "mkdirp": "^1.0.4",
-        "ora": "^6.1.2",
-        "remark-directive": "^2.0.1",
-        "remark-frontmatter": "^4.0.1",
-        "remark-parse": "^10.0.1",
-        "remark-rehype": "^10.1.0",
-        "terminal-link": "^3.0.0",
-        "tmp": "^0.2.1",
-        "to-vfile": "^7.2.3",
-        "unified": "^10.1.2",
-        "unist-builder": "^3.0.0",
-        "unist-util-visit": "^4.1.1",
-        "unist-util-visit-parents": "^5.1.1",
-        "uuid": "^9.0.0",
-        "vfile": "^5.3.4",
-        "which": "^2.0.2",
-        "write-file-atomic": "^4.0.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "madwizard": "bin/madwizard.js",
-        "mw": "bin/madwizard.js"
-      }
-    },
-    "node_modules/madwizard/node_modules/chalk": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/madwizard/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/madwizard/node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-      "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/madwizard/node_modules/is-unicode-supported": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.2.0.tgz",
-      "integrity": "sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/madwizard/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/madwizard/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -19087,7 +18970,7 @@
         "@patternfly/react-table": "4.104.7",
         "anser": "2.1.1",
         "html-entities": "2.3.3",
-        "madwizard": ">=0.21.7",
+        "madwizard": ">=0.22.0",
         "monaco-editor": "0.34.0",
         "monaco-editor-webpack-plugin": "7.0.1",
         "react-markdown": "8.0.3",
@@ -19105,6 +18988,109 @@
         "turndown": "7.1.1",
         "turndown-plugin-gfm": "1.0.2",
         "which": "2.0.2"
+      }
+    },
+    "plugins/plugin-client-common/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "plugins/plugin-client-common/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/plugin-client-common/node_modules/figures": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/plugin-client-common/node_modules/is-unicode-supported": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.2.0.tgz",
+      "integrity": "sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/plugin-client-common/node_modules/madwizard": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.22.0.tgz",
+      "integrity": "sha512-FGkMiTcprkNDBuPk0cS+M/OJesdx2wO+0l8oHE1X37gWw7xxil4QqOXTYhmUO5t6HzOoge5hynmEVCfUgKakGg==",
+      "dependencies": {
+        "chalk": "^5.0.1",
+        "cli-highlight": "^2.1.11",
+        "columnify": "^1.6.0",
+        "debug": "^4.3.4",
+        "enquirer": "^2.3.6",
+        "env-paths": "^2.2.1",
+        "expand-home-dir": "^0.0.3",
+        "figures": "^5.0.0",
+        "front-matter": "^4.0.2",
+        "hast-util-raw": "^7.2.2",
+        "hast-util-to-mdast": "^8.4.0",
+        "hast-util-to-string": "^2.0.0",
+        "js-yaml": "^4.1.0",
+        "make-fetch-happen": "^10.2.1",
+        "mdast-util-to-markdown": "^1.3.0",
+        "mkdirp": "^1.0.4",
+        "ora": "^6.1.2",
+        "remark-directive": "^2.0.1",
+        "remark-frontmatter": "^4.0.1",
+        "remark-parse": "^10.0.1",
+        "remark-rehype": "^10.1.0",
+        "terminal-link": "^3.0.0",
+        "tmp": "^0.2.1",
+        "to-vfile": "^7.2.3",
+        "unified": "^10.1.2",
+        "unist-builder": "^3.0.0",
+        "unist-util-visit": "^4.1.1",
+        "unist-util-visit-parents": "^5.1.1",
+        "uuid": "^9.0.0",
+        "vfile": "^5.3.4",
+        "which": "^2.0.2",
+        "write-file-atomic": "^4.0.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "madwizard": "bin/madwizard.js",
+        "mw": "bin/madwizard.js"
+      }
+    },
+    "plugins/plugin-client-common/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "plugins/plugin-client-common/node_modules/which": {
@@ -19894,7 +19880,7 @@
         "@patternfly/react-table": "4.104.7",
         "anser": "2.1.1",
         "html-entities": "2.3.3",
-        "madwizard": ">=0.21.7",
+        "madwizard": ">=0.22.0",
         "monaco-editor": "0.34.0",
         "monaco-editor-webpack-plugin": "7.0.1",
         "react-markdown": "8.0.3",
@@ -19914,6 +19900,75 @@
         "which": "2.0.2"
       },
       "dependencies": {
+        "chalk": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+        },
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        },
+        "figures": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+          "requires": {
+            "escape-string-regexp": "^5.0.0",
+            "is-unicode-supported": "^1.2.0"
+          }
+        },
+        "is-unicode-supported": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.2.0.tgz",
+          "integrity": "sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ=="
+        },
+        "madwizard": {
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.22.0.tgz",
+          "integrity": "sha512-FGkMiTcprkNDBuPk0cS+M/OJesdx2wO+0l8oHE1X37gWw7xxil4QqOXTYhmUO5t6HzOoge5hynmEVCfUgKakGg==",
+          "requires": {
+            "chalk": "^5.0.1",
+            "cli-highlight": "^2.1.11",
+            "columnify": "^1.6.0",
+            "debug": "^4.3.4",
+            "enquirer": "^2.3.6",
+            "env-paths": "^2.2.1",
+            "expand-home-dir": "^0.0.3",
+            "figures": "^5.0.0",
+            "front-matter": "^4.0.2",
+            "hast-util-raw": "^7.2.2",
+            "hast-util-to-mdast": "^8.4.0",
+            "hast-util-to-string": "^2.0.0",
+            "js-yaml": "^4.1.0",
+            "make-fetch-happen": "^10.2.1",
+            "mdast-util-to-markdown": "^1.3.0",
+            "mkdirp": "^1.0.4",
+            "ora": "^6.1.2",
+            "remark-directive": "^2.0.1",
+            "remark-frontmatter": "^4.0.1",
+            "remark-parse": "^10.0.1",
+            "remark-rehype": "^10.1.0",
+            "terminal-link": "^3.0.0",
+            "tmp": "^0.2.1",
+            "to-vfile": "^7.2.3",
+            "unified": "^10.1.2",
+            "unist-builder": "^3.0.0",
+            "unist-util-visit": "^4.1.1",
+            "unist-util-visit-parents": "^5.1.1",
+            "uuid": "^9.0.0",
+            "vfile": "^5.3.4",
+            "which": "^2.0.2",
+            "write-file-atomic": "^4.0.2",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -27296,85 +27351,6 @@
         "node-addon-api": "^3.1.0",
         "node-gyp-build": "^4.2.1",
         "readable-stream": "^3.6.0"
-      }
-    },
-    "madwizard": {
-      "version": "0.21.7",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.21.7.tgz",
-      "integrity": "sha512-3mb/vxaQVdcBQY1UTR3Prt87pL/m2QZD0LaQRG04a0pSuvbnYxni7W2SF+MAFPm8OrKi2PrLlxRCVTa3WLggWw==",
-      "requires": {
-        "chalk": "^5.0.1",
-        "cli-highlight": "^2.1.11",
-        "columnify": "^1.6.0",
-        "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
-        "env-paths": "^2.2.1",
-        "expand-home-dir": "^0.0.3",
-        "figures": "^5.0.0",
-        "front-matter": "^4.0.2",
-        "hast-util-raw": "^7.2.2",
-        "hast-util-to-mdast": "^8.4.0",
-        "hast-util-to-string": "^2.0.0",
-        "js-yaml": "^4.1.0",
-        "make-fetch-happen": "^10.2.1",
-        "mdast-util-to-markdown": "^1.3.0",
-        "mkdirp": "^1.0.4",
-        "ora": "^6.1.2",
-        "remark-directive": "^2.0.1",
-        "remark-frontmatter": "^4.0.1",
-        "remark-parse": "^10.0.1",
-        "remark-rehype": "^10.1.0",
-        "terminal-link": "^3.0.0",
-        "tmp": "^0.2.1",
-        "to-vfile": "^7.2.3",
-        "unified": "^10.1.2",
-        "unist-builder": "^3.0.0",
-        "unist-util-visit": "^4.1.1",
-        "unist-util-visit-parents": "^5.1.1",
-        "uuid": "^9.0.0",
-        "vfile": "^5.3.4",
-        "which": "^2.0.2",
-        "write-file-atomic": "^4.0.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
-        },
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        },
-        "figures": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-          "requires": {
-            "escape-string-regexp": "^5.0.0",
-            "is-unicode-supported": "^1.2.0"
-          }
-        },
-        "is-unicode-supported": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.2.0.tgz",
-          "integrity": "sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ=="
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "make-dir": {

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -29,7 +29,7 @@
     "@patternfly/react-table": "4.104.7",
     "anser": "2.1.1",
     "html-entities": "2.3.3",
-    "madwizard": ">=0.21.7",
+    "madwizard": ">=0.22.0",
     "monaco-editor": "0.34.0",
     "monaco-editor-webpack-plugin": "7.0.1",
     "react-markdown": "8.0.3",


### PR DESCRIPTION
This should save about 40MiB of unpacked on-disk space!

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
