### PR TITLE
feat: bump to xtermjs 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -949,19 +949,6 @@
       "resolved": "packages/webpack",
       "link": true
     },
-    "node_modules/@kui-shell/xterm-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-1.0.2.tgz",
-      "integrity": "sha512-3+vpz8sAwkDbzjZRckNBodyodBRdTz97s/nVYknnVEu2sUmjFQKat9fmoSr1MRqGRs99YaC1mBVUl5jNToRWqA==",
-      "dependencies": {
-        "xterm": "4.10.0"
-      }
-    },
-    "node_modules/@kui-shell/xterm-helpers/node_modules/xterm": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.10.0.tgz",
-      "integrity": "sha512-Wn66I8YpSVkgP3R95GjABC6Eb21pFfnCSnyIqKIIoUI13ohvwd0KGVzUDfyEFfSAzKbPJfrT2+vt7SfUXBZQKQ=="
-    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -17517,16 +17504,24 @@
       }
     },
     "node_modules/xterm": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
-      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.0.0.tgz",
+      "integrity": "sha512-tmVsKzZovAYNDIaUinfz+VDclraQpPUnAME+JawosgWRMphInDded/PuY0xmU5dOhyeYZsI0nz5yd8dPYsdLTA=="
     },
     "node_modules/xterm-addon-fit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz",
-      "integrity": "sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz",
+      "integrity": "sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg==",
       "peerDependencies": {
-        "xterm": "^4.0.0"
+        "xterm": "^5.0.0"
+      }
+    },
+    "node_modules/xterm-addon-webgl": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-webgl/-/xterm-addon-webgl-0.13.0.tgz",
+      "integrity": "sha512-xL4qBQWUHjFR620/8VHCtrTMVQsnZaAtd1IxFoiKPhC63wKp6b+73a45s97lb34yeo57PoqZhE9Jq5pB++ksPQ==",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/y18n": {
@@ -17841,7 +17836,7 @@
       "version": "12.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kui-shell/xterm-helpers": "1.0.2",
+        "@kui-shell/xterm-helpers": "2.0.0",
         "cookie": "0.5.0",
         "debug": "4.3.4",
         "globby": "11.0.4",
@@ -17852,8 +17847,17 @@
         "tmp": "0.2.1",
         "uuid": "9.0.0",
         "ws": "7.5.9",
-        "xterm": "4.19.0",
-        "xterm-addon-fit": "0.5.0"
+        "xterm": "5.0.0",
+        "xterm-addon-fit": "0.6.0",
+        "xterm-addon-webgl": "^0.13.0"
+      }
+    },
+    "plugins/plugin-bash-like/node_modules/@kui-shell/xterm-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-2.0.0.tgz",
+      "integrity": "sha512-wa2vQK4sq+IR91TfI38MTl6rvrJuAQ9YAPPZ6HHhcFGNEZjVYPiTUxmuCdyqBj10Q3ew+Apeh/JVkdjSxbZURA==",
+      "dependencies": {
+        "xterm": "5.0.0"
       }
     },
     "plugins/plugin-bash-like/node_modules/globby": {
@@ -17981,7 +17985,10 @@
         "pluralize": "8.0.0",
         "semver": "7.3.7",
         "tmp": "0.2.1",
-        "uuid": "9.0.0"
+        "uuid": "9.0.0",
+        "xterm": "^5.0.0",
+        "xterm-addon-fit": "^0.6.0",
+        "xterm-addon-webgl": "^0.13.0"
       }
     },
     "plugins/plugin-kubectl-tray-menu": {
@@ -18686,7 +18693,7 @@
     "@kui-shell/plugin-bash-like": {
       "version": "file:plugins/plugin-bash-like",
       "requires": {
-        "@kui-shell/xterm-helpers": "1.0.2",
+        "@kui-shell/xterm-helpers": "2.0.0",
         "cookie": "0.5.0",
         "debug": "4.3.4",
         "globby": "11.0.4",
@@ -18697,10 +18704,19 @@
         "tmp": "0.2.1",
         "uuid": "9.0.0",
         "ws": "7.5.9",
-        "xterm": "4.19.0",
-        "xterm-addon-fit": "0.5.0"
+        "xterm": "5.0.0",
+        "xterm-addon-fit": "0.6.0",
+        "xterm-addon-webgl": "^0.13.0"
       },
       "dependencies": {
+        "@kui-shell/xterm-helpers": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-2.0.0.tgz",
+          "integrity": "sha512-wa2vQK4sq+IR91TfI38MTl6rvrJuAQ9YAPPZ6HHhcFGNEZjVYPiTUxmuCdyqBj10Q3ew+Apeh/JVkdjSxbZURA==",
+          "requires": {
+            "xterm": "5.0.0"
+          }
+        },
         "globby": {
           "version": "11.0.4",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -18801,7 +18817,10 @@
         "pluralize": "8.0.0",
         "semver": "7.3.7",
         "tmp": "0.2.1",
-        "uuid": "9.0.0"
+        "uuid": "9.0.0",
+        "xterm": "^5.0.0",
+        "xterm-addon-fit": "^0.6.0",
+        "xterm-addon-webgl": "^0.13.0"
       }
     },
     "@kui-shell/plugin-kubectl-tray-menu": {
@@ -18911,21 +18930,6 @@
         "webpack-cli": "4.10.0",
         "webpack-dev-server": "4.11.0",
         "zip-webpack-plugin": "4.0.1"
-      }
-    },
-    "@kui-shell/xterm-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@kui-shell/xterm-helpers/-/xterm-helpers-1.0.2.tgz",
-      "integrity": "sha512-3+vpz8sAwkDbzjZRckNBodyodBRdTz97s/nVYknnVEu2sUmjFQKat9fmoSr1MRqGRs99YaC1mBVUl5jNToRWqA==",
-      "requires": {
-        "xterm": "4.10.0"
-      },
-      "dependencies": {
-        "xterm": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.10.0.tgz",
-          "integrity": "sha512-Wn66I8YpSVkgP3R95GjABC6Eb21pFfnCSnyIqKIIoUI13ohvwd0KGVzUDfyEFfSAzKbPJfrT2+vt7SfUXBZQKQ=="
-        }
       }
     },
     "@leichtgewicht/ip-codec": {
@@ -31215,14 +31219,20 @@
       "dev": true
     },
     "xterm": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
-      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.0.0.tgz",
+      "integrity": "sha512-tmVsKzZovAYNDIaUinfz+VDclraQpPUnAME+JawosgWRMphInDded/PuY0xmU5dOhyeYZsI0nz5yd8dPYsdLTA=="
     },
     "xterm-addon-fit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz",
-      "integrity": "sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz",
+      "integrity": "sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg==",
+      "requires": {}
+    },
+    "xterm-addon-webgl": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-webgl/-/xterm-addon-webgl-0.13.0.tgz",
+      "integrity": "sha512-xL4qBQWUHjFR620/8VHCtrTMVQsnZaAtd1IxFoiKPhC63wKp6b+73a45s97lb34yeo57PoqZhE9Jq5pB++ksPQ==",
       "requires": {}
     },
     "y18n": {

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -24,7 +24,7 @@
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
   "dependencies": {
-    "@kui-shell/xterm-helpers": "1.0.2",
+    "@kui-shell/xterm-helpers": "2.0.0",
     "cookie": "0.5.0",
     "debug": "4.3.4",
     "globby": "11.0.4",
@@ -35,8 +35,9 @@
     "tmp": "0.2.1",
     "uuid": "9.0.0",
     "ws": "7.5.9",
-    "xterm": "4.19.0",
-    "xterm-addon-fit": "0.5.0"
+    "xterm": "5.0.0",
+    "xterm-addon-fit": "0.6.0",
+    "xterm-addon-webgl": "^0.13.0"
   },
   "kui": {
     "exclude": {

--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -683,14 +683,14 @@ function getFontProperties(flush: boolean) {
 const injectFont = (terminal: XTerminal, flush = false) => {
   try {
     const { fontFamily, fontSize } = getFontProperties(flush)
-    terminal.setOption('fontFamily', fontFamily)
-    terminal.setOption('fontSize', fontSize)
+    terminal.options.fontFamily = fontFamily
+    terminal.options.fontSize = fontSize
 
     debug('fontSize', fontSize)
 
     // FIXME. not tied to theme
-    terminal.setOption('fontWeight', 400)
-    terminal.setOption('fontWeightBold', 600)
+    terminal.options.fontWeight = 400
+    terminal.options.fontWeightBold = 600
   } catch (err) {
     console.error('Error setting terminal font size', err)
   }
@@ -877,7 +877,7 @@ export const doExec = (
           const { fontFamily, fontSize } = getFontProperties(false)
           // creating terminal
           terminal = new XTerminal({
-            rendererType: 'dom',
+            allowProposedApi: true,
             cols: (cachedSize && cachedSize.cols) || 80,
             rows: (cachedSize && cachedSize.rows) || 40,
             fontFamily,

--- a/plugins/plugin-kubectl/package.json
+++ b/plugins/plugin-kubectl/package.json
@@ -39,7 +39,10 @@
     "pluralize": "8.0.0",
     "semver": "7.3.7",
     "tmp": "0.2.1",
-    "uuid": "9.0.0"
+    "uuid": "9.0.0",
+    "xterm": "^5.0.0",
+    "xterm-addon-fit": "^0.6.0",
+    "xterm-addon-webgl": "^0.13.0"
   },
   "krew": {
     "commandPrefix": "kubeui"


### PR DESCRIPTION
Caution: this introduces some breaking changes in the xterm API. Nothing at the Kui level has changed, but if other plugins are assuming the `xterm` npm comes in via kui, they may encounter breaking changes.

This PR also introduces the use of the webgl renderer for the kubectl Terminal and Logs tabs.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
