### PR TITLE
feat: update Annotations and Labels tabs to use editor view for json values

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -376,7 +376,7 @@ export default class Editor extends React.PureComponent<Props, State> {
         editor.setValue(await Editor.extractValue(state.content, props.response, props.repl))
 
         // initial default folding level; see https://github.com/kubernetes-sigs/kui/issues/8008
-        editor.getAction('editor.foldLevel2').run()
+        editor.getAction('editor.foldLevel3').run()
       })
 
       const onZoom = () => {

--- a/plugins/plugin-client-common/web/scss/components/Sidecar/Tree.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidecar/Tree.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Kubernetes Authors
+ * Copyright 2022 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,26 @@
  * limitations under the License.
  */
 
-@import 'Base';
-@import 'Tree';
-@import 'Nested';
-@import 'BottomToolbar';
+@import 'mixins';
+
+@include Sidecar {
+  .pf-c-tree-view {
+    --pf-global--spacer--md: 0.75rem;
+
+    dl,
+    dd {
+      margin: 0;
+    }
+  }
+  .pf-c-tree-view__node-toggle {
+    --pf-c-tree-view__node-toggle--Color: var(--color-base04);
+    &:hover {
+      --pf-c-tree-view__node-toggle--Color: var(--color-base05);
+    }
+  }
+  .pf-c-tree-view__node {
+    margin: 0;
+    --pf-c-tree-view__node--Color: var(--color-text-01);
+    --pf-c-tree-view__node--focus--BackgroundColor: var(--color-base02);
+  }
+}

--- a/plugins/plugin-kubectl/src/test/k8s3/labels.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/labels.ts
@@ -78,8 +78,8 @@ describe(`kubectl label handling ${process.env.MOCHA_RUN_TARGET || ''}`, functio
             .then(ReplExpect.ok)
             .then(SidecarExpect.open)
             .then(SidecarExpect.showing('nginx', undefined, undefined, ns))
-            .then(Util.switchToTab('raw'))
-            .then(SidecarExpect.yaml({ metadata: { labels: { [key]: value } } }))
+            .then(Util.switchToTab('labels'))
+            .then(SidecarExpect.yaml({ [key]: value }))
         } catch (err) {
           await Common.oops(this, true)(err)
         }

--- a/plugins/plugin-kubectl/src/test/k8s4/edit.ts
+++ b/plugins/plugin-kubectl/src/test/k8s4/edit.ts
@@ -163,7 +163,7 @@ commands.forEach(command => {
     const parseError = modifyWithError.bind(undefined, 'parse error', Keys.End, 'could not find expected')
 
     /** modify pod {name} so as to add a label of key=value */
-    const modify = (name: string, key = 'foo', value = 'bar', needsUnfold = true) => {
+    const modify = (name: string, key = 'foo', value = 'bar', needsUnfold = false) => {
       it(`should modify the content by adding label ${key}=${value}`, async () => {
         try {
           const actualText = await Util.getValueFromMonaco(res)


### PR DESCRIPTION
1) Annotations tab DescriptionList->Editor
2) in that view, also attempt to parse out annotations that are json values, and fold them into the tree presented in the editor 3) Labels tab funky custom UI->Editor
4) in *that* view, try to map '10' -> 10
5) in YAML tab, don't show .metadata.annotations, .metadata.labels, and .metadata.managedFields 6) in Editor view, fold to depth 3; previously folded to depth 2 mostly because of messy managedFields

Fixes #9072

<img width="615" alt="kubectl annotations handling json annotation values" src="https://user-images.githubusercontent.com/4741620/194771001-38f78010-6ce1-43ec-855c-1a62238c477a.png">



<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
