### PR TITLE
fix: remove markdown button coloring css rule

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -417,7 +417,6 @@ body[kui-theme-style='light'] {
   }
 
   @include MarkdownTabButton {
-    color: var(--color-text-02);
     font-size: $terminal-font-size;
     --pf-c-tabs__link--after--Bottom: 1px;
   }


### PR DESCRIPTION
this rule is way overly broad, applying to any `<button>` inside of a Commentary.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
