### PR TITLE
fix: plugin-electron-components is missing stated needle dependence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19329,7 +19329,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/remote": "2.0.8",
-        "@patternfly/react-core": "^4.264.0"
+        "@patternfly/react-core": "^4.264.0",
+        "needle": "^3.1.0"
       }
     },
     "plugins/plugin-git": {
@@ -20176,7 +20177,8 @@
       "version": "file:plugins/plugin-electron-components",
       "requires": {
         "@electron/remote": "2.0.8",
-        "@patternfly/react-core": "^4.264.0"
+        "@patternfly/react-core": "^4.264.0",
+        "needle": "^3.1.0"
       }
     },
     "@kui-shell/plugin-git": {

--- a/plugins/plugin-electron-components/package.json
+++ b/plugins/plugin-electron-components/package.json
@@ -22,7 +22,8 @@
   "types": "mdist/index.d.ts",
   "dependencies": {
     "@electron/remote": "2.0.8",
-    "@patternfly/react-core": "^4.264.0"
+    "@patternfly/react-core": "^4.264.0",
+    "needle": "^3.1.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
