### PR TITLE
chore: bump react-markdown 8.0.3 -> 8.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13828,41 +13828,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-markdown": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.3.tgz",
-      "integrity": "sha512-We36SfqaKoVNpN1QqsZwWSv/OZt5J15LNgTLWynwAN5b265hrQrsjMtlRNwUvS+YyR3yDM8HpTNc4pK9H/Gc0A==",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "@types/prop-types": "^15.0.0",
-        "@types/unist": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^2.0.0",
-        "prop-types": "^15.0.0",
-        "property-information": "^6.0.0",
-        "react-is": "^18.0.0",
-        "remark-parse": "^10.0.0",
-        "remark-rehype": "^10.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "style-to-object": "^0.3.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0",
-        "vfile": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16",
-        "react": ">=16"
-      }
-    },
-    "node_modules/react-markdown/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -18361,7 +18326,7 @@
         "madwizard": "^2.0.4",
         "monaco-editor": "0.34.1",
         "monaco-editor-webpack-plugin": "7.0.1",
-        "react-markdown": "8.0.3",
+        "react-markdown": "8.0.4",
         "rehype-raw": "6.1.1",
         "rehype-slug": "5.1.0",
         "remark-code-frontmatter": "1.0.0",
@@ -18376,6 +18341,41 @@
         "turndown": "7.1.1",
         "turndown-plugin-gfm": "1.0.2",
         "which": "3.0.0"
+      }
+    },
+    "plugins/plugin-client-common/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "plugins/plugin-client-common/node_modules/react-markdown": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.4.tgz",
+      "integrity": "sha512-2oxHa6oDxc1apg/Gnc1Goh06t3B617xeywqI/92wmDV9FELI6ayRkwge7w7DoEqM0gRpZGTNU6xQG+YpJISnVg==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.3.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
       }
     },
     "plugins/plugin-client-common/node_modules/which": {
@@ -19567,7 +19567,7 @@
         "madwizard": "^2.0.4",
         "monaco-editor": "0.34.1",
         "monaco-editor-webpack-plugin": "7.0.1",
-        "react-markdown": "8.0.3",
+        "react-markdown": "8.0.4",
         "rehype-raw": "6.1.1",
         "rehype-slug": "5.1.0",
         "remark-code-frontmatter": "1.0.0",
@@ -19584,6 +19584,33 @@
         "which": "3.0.0"
       },
       "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        },
+        "react-markdown": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.4.tgz",
+          "integrity": "sha512-2oxHa6oDxc1apg/Gnc1Goh06t3B617xeywqI/92wmDV9FELI6ayRkwge7w7DoEqM0gRpZGTNU6xQG+YpJISnVg==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "@types/prop-types": "^15.0.0",
+            "@types/unist": "^2.0.0",
+            "comma-separated-tokens": "^2.0.0",
+            "hast-util-whitespace": "^2.0.0",
+            "prop-types": "^15.0.0",
+            "property-information": "^6.0.0",
+            "react-is": "^18.0.0",
+            "remark-parse": "^10.0.0",
+            "remark-rehype": "^10.0.0",
+            "space-separated-tokens": "^2.0.0",
+            "style-to-object": "^0.3.0",
+            "unified": "^10.0.0",
+            "unist-util-visit": "^4.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
         "which": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
@@ -28955,35 +28982,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "react-markdown": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.3.tgz",
-      "integrity": "sha512-We36SfqaKoVNpN1QqsZwWSv/OZt5J15LNgTLWynwAN5b265hrQrsjMtlRNwUvS+YyR3yDM8HpTNc4pK9H/Gc0A==",
-      "requires": {
-        "@types/hast": "^2.0.0",
-        "@types/prop-types": "^15.0.0",
-        "@types/unist": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^2.0.0",
-        "prop-types": "^15.0.0",
-        "property-information": "^6.0.0",
-        "react-is": "^18.0.0",
-        "remark-parse": "^10.0.0",
-        "remark-rehype": "^10.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "style-to-object": "^0.3.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0",
-        "vfile": "^5.0.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-        }
-      }
     },
     "readable-stream": {
       "version": "3.6.0",

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -33,7 +33,7 @@
     "madwizard": "^2.0.4",
     "monaco-editor": "0.34.1",
     "monaco-editor-webpack-plugin": "7.0.1",
-    "react-markdown": "8.0.3",
+    "react-markdown": "8.0.4",
     "rehype-raw": "6.1.1",
     "rehype-slug": "5.1.0",
     "remark-code-frontmatter": "1.0.0",

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/table.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/table.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { TableRowProps, TableCellProps } from 'react-markdown/lib/ast-to-react'
+import { TableRowProps, TableDataCellProps, TableHeaderCellProps } from 'react-markdown/lib/ast-to-react'
 import { TableComposable, Thead, Tbody, Th, Tr, Td } from '@patternfly/react-table'
 
 export function table(props: React.TableHTMLAttributes<HTMLTableElement>) {
@@ -38,7 +38,7 @@ export function tr(props: TableRowProps) {
   return <Tr className={props.className}>{props.children}</Tr>
 }
 
-export function th(props: TableCellProps) {
+export function th(props: TableHeaderCellProps) {
   // hmm, without modifier=wrap, PatternFly (or is it electron
   // 13?)... if the td content is narrower than the th content, they
   // seem to favor favor ellipsis for that wider column header. This
@@ -50,6 +50,6 @@ export function th(props: TableCellProps) {
   )
 }
 
-export function td(props: TableCellProps) {
+export function td(props: TableDataCellProps) {
   return <Td className={props.className}>{props.children}</Td>
 }


### PR DESCRIPTION
Hmm, despite this being a patch level bump, there was a breaking change to the type declarations.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
