### PR TITLE
chore: bump typescript 4.8.4 -> 4.9.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,8 @@
         "@types/uuid": "8.3.4",
         "@types/which": "2.0.1",
         "@types/yargs-parser": "21.0.0",
-        "@typescript-eslint/eslint-plugin": "5.45.1",
-        "@typescript-eslint/parser": "5.45.1",
+        "@typescript-eslint/eslint-plugin": "5.46.1",
+        "@typescript-eslint/parser": "5.46.1",
         "colors": "1.4.0",
         "concurrently": "7.6.0",
         "cross-env": "7.0.3",
@@ -79,7 +79,7 @@
         "tmp": "0.2.1",
         "typedoc": "0.23.21",
         "typedoc-plugin-markdown": "3.14.0",
-        "typescript": "4.8.4",
+        "typescript": "4.9.4",
         "uuid": "9.0.0"
       },
       "engines": {
@@ -2230,14 +2230,14 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.1.tgz",
-      "integrity": "sha512-cOizjPlKEh0bXdFrBLTrI/J6B/QMlhwE9auOov53tgB+qMukH6/h8YAK/qw+QJGct/PTbdh2lytGyipxCcEtAw==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz",
+      "integrity": "sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.45.1",
-        "@typescript-eslint/type-utils": "5.45.1",
-        "@typescript-eslint/utils": "5.45.1",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/type-utils": "5.46.1",
+        "@typescript-eslint/utils": "5.46.1",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -2263,14 +2263,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.1.tgz",
-      "integrity": "sha512-JQ3Ep8bEOXu16q0ztsatp/iQfDCtvap7sp/DKo7DWltUquj5AfCOpX2zSzJ8YkAVnrQNqQ5R62PBz2UtrfmCkA==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.1.tgz",
+      "integrity": "sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.45.1",
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/typescript-estree": "5.45.1",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2290,13 +2290,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.1.tgz",
-      "integrity": "sha512-D6fCileR6Iai7E35Eb4Kp+k0iW7F1wxXYrOhX/3dywsOJpJAQ20Fwgcf+P/TDtvQ7zcsWsrJaglaQWDhOMsspQ==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+      "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/visitor-keys": "5.45.1"
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2307,13 +2307,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.45.1.tgz",
-      "integrity": "sha512-aosxFa+0CoYgYEl3aptLe1svP910DJq68nwEJzyQcrtRhC4BN0tJAvZGAe+D0tzjJmFXe+h4leSsiZhwBa2vrA==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz",
+      "integrity": "sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.45.1",
-        "@typescript-eslint/utils": "5.45.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
+        "@typescript-eslint/utils": "5.46.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2334,9 +2334,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.1.tgz",
-      "integrity": "sha512-HEW3U0E5dLjUT+nk7b4lLbOherS1U4ap+b9pfu2oGsW3oPu7genRaY9dDv3nMczC1rbnRY2W/D7SN05wYoGImg==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2347,13 +2347,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.1.tgz",
-      "integrity": "sha512-76NZpmpCzWVrrb0XmYEpbwOz/FENBi+5W7ipVXAsG3OoFrQKJMiaqsBMbvGRyLtPotGqUfcY7Ur8j0dksDJDng==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+      "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/visitor-keys": "5.45.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2374,16 +2374,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.45.1.tgz",
-      "integrity": "sha512-rlbC5VZz68+yjAzQBc4I7KDYVzWG2X/OrqoZrMahYq3u8FFtmQYc+9rovo/7wlJH5kugJ+jQXV5pJMnofGmPRw==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.1.tgz",
+      "integrity": "sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.45.1",
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/typescript-estree": "5.45.1",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -2400,12 +2400,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.1.tgz",
-      "integrity": "sha512-cy9ln+6rmthYWjH9fmx+5FU/JDpjQb586++x2FZlveq7GdGuLLW9a2Jcst2TGekH82bXpfmRNSwP9tyEs6RjvQ==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+      "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.45.1",
+        "@typescript-eslint/types": "5.46.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -16290,9 +16290,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -18138,6 +18138,7 @@
       }
     },
     "packages/builder": {
+      "name": "@kui-shell/builder",
       "version": "12.2.0",
       "dev": true,
       "hasInstallScript": true,
@@ -18163,6 +18164,7 @@
       }
     },
     "packages/core": {
+      "name": "@kui-shell/core",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18188,6 +18190,7 @@
       }
     },
     "packages/proxy": {
+      "name": "@kui-shell/proxy",
       "version": "12.2.0",
       "dev": true,
       "hasInstallScript": true,
@@ -18200,6 +18203,7 @@
       }
     },
     "packages/react": {
+      "name": "@kui-shell/react",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18208,6 +18212,7 @@
       }
     },
     "packages/test": {
+      "name": "@kui-shell/test",
       "version": "12.2.0",
       "dev": true,
       "license": "Apache-2.0",
@@ -18220,6 +18225,7 @@
       }
     },
     "packages/webpack": {
+      "name": "@kui-shell/webpack",
       "version": "12.2.0",
       "dev": true,
       "license": "Apache-2.0",
@@ -18270,6 +18276,7 @@
       }
     },
     "plugins/plugin-bash-like": {
+      "name": "@kui-shell/plugin-bash-like",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18309,10 +18316,12 @@
       }
     },
     "plugins/plugin-carbon-themes": {
+      "name": "@kui-shell/plugin-carbon-themes",
       "version": "12.2.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-client-common": {
+      "name": "@kui-shell/plugin-client-common",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18365,6 +18374,7 @@
       "license": "Apache-2.0"
     },
     "plugins/plugin-core-support": {
+      "name": "@kui-shell/plugin-core-support",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18375,10 +18385,12 @@
       }
     },
     "plugins/plugin-core-themes": {
+      "name": "@kui-shell/plugin-core-themes",
       "version": "12.2.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-electron-components": {
+      "name": "@kui-shell/plugin-electron-components",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18388,6 +18400,7 @@
       }
     },
     "plugins/plugin-git": {
+      "name": "@kui-shell/plugin-git",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18414,9 +18427,11 @@
       }
     },
     "plugins/plugin-iter8": {
+      "name": "@kui-shell/plugin-iter8",
       "version": "12.2.0"
     },
     "plugins/plugin-kubectl": {
+      "name": "@kui-shell/plugin-kubectl",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18438,6 +18453,7 @@
       }
     },
     "plugins/plugin-kubectl-tray-menu": {
+      "name": "@kui-shell/plugin-kubectl-tray-menu",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18445,14 +18461,17 @@
       }
     },
     "plugins/plugin-patternfly4-themes": {
+      "name": "@kui-shell/plugin-patternfly4-themes",
       "version": "12.2.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-proxy-support": {
+      "name": "@kui-shell/plugin-proxy-support",
       "version": "12.2.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-s3": {
+      "name": "@kui-shell/plugin-s3",
       "version": "12.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -20446,14 +20465,14 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.1.tgz",
-      "integrity": "sha512-cOizjPlKEh0bXdFrBLTrI/J6B/QMlhwE9auOov53tgB+qMukH6/h8YAK/qw+QJGct/PTbdh2lytGyipxCcEtAw==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz",
+      "integrity": "sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.45.1",
-        "@typescript-eslint/type-utils": "5.45.1",
-        "@typescript-eslint/utils": "5.45.1",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/type-utils": "5.46.1",
+        "@typescript-eslint/utils": "5.46.1",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -20463,53 +20482,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.1.tgz",
-      "integrity": "sha512-JQ3Ep8bEOXu16q0ztsatp/iQfDCtvap7sp/DKo7DWltUquj5AfCOpX2zSzJ8YkAVnrQNqQ5R62PBz2UtrfmCkA==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.1.tgz",
+      "integrity": "sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.45.1",
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/typescript-estree": "5.45.1",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.1.tgz",
-      "integrity": "sha512-D6fCileR6Iai7E35Eb4Kp+k0iW7F1wxXYrOhX/3dywsOJpJAQ20Fwgcf+P/TDtvQ7zcsWsrJaglaQWDhOMsspQ==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
+      "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/visitor-keys": "5.45.1"
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.45.1.tgz",
-      "integrity": "sha512-aosxFa+0CoYgYEl3aptLe1svP910DJq68nwEJzyQcrtRhC4BN0tJAvZGAe+D0tzjJmFXe+h4leSsiZhwBa2vrA==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz",
+      "integrity": "sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.45.1",
-        "@typescript-eslint/utils": "5.45.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
+        "@typescript-eslint/utils": "5.46.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.1.tgz",
-      "integrity": "sha512-HEW3U0E5dLjUT+nk7b4lLbOherS1U4ap+b9pfu2oGsW3oPu7genRaY9dDv3nMczC1rbnRY2W/D7SN05wYoGImg==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
+      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.1.tgz",
-      "integrity": "sha512-76NZpmpCzWVrrb0XmYEpbwOz/FENBi+5W7ipVXAsG3OoFrQKJMiaqsBMbvGRyLtPotGqUfcY7Ur8j0dksDJDng==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
+      "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/visitor-keys": "5.45.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/visitor-keys": "5.46.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -20518,28 +20537,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.45.1.tgz",
-      "integrity": "sha512-rlbC5VZz68+yjAzQBc4I7KDYVzWG2X/OrqoZrMahYq3u8FFtmQYc+9rovo/7wlJH5kugJ+jQXV5pJMnofGmPRw==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.1.tgz",
+      "integrity": "sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.45.1",
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/typescript-estree": "5.45.1",
+        "@typescript-eslint/scope-manager": "5.46.1",
+        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.1.tgz",
-      "integrity": "sha512-cy9ln+6rmthYWjH9fmx+5FU/JDpjQb586++x2FZlveq7GdGuLLW9a2Jcst2TGekH82bXpfmRNSwP9tyEs6RjvQ==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
+      "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.45.1",
+        "@typescript-eslint/types": "5.46.1",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -30792,9 +30811,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -100,8 +100,8 @@
     "@types/uuid": "8.3.4",
     "@types/which": "2.0.1",
     "@types/yargs-parser": "21.0.0",
-    "@typescript-eslint/eslint-plugin": "5.45.1",
-    "@typescript-eslint/parser": "5.45.1",
+    "@typescript-eslint/eslint-plugin": "5.46.1",
+    "@typescript-eslint/parser": "5.46.1",
     "colors": "1.4.0",
     "concurrently": "7.6.0",
     "cross-env": "7.0.3",
@@ -126,7 +126,7 @@
     "tmp": "0.2.1",
     "typedoc": "0.23.21",
     "typedoc-plugin-markdown": "3.14.0",
-    "typescript": "4.8.4",
+    "typescript": "4.9.4",
     "uuid": "9.0.0"
   },
   "lint-staged": {

--- a/plugins/plugin-kubectl/odo/src/controller/odo/project/list.ts
+++ b/plugins/plugin-kubectl/odo/src/controller/odo/project/list.ts
@@ -25,7 +25,7 @@ import {
   doExecWithRadioTable
 } from '@kui-shell/plugin-kubectl'
 
-import Project from '../../../model/Project'
+import Project, { ProjectStatus } from '../../../model/Project'
 
 /** onSelect handler for the RadioTable view model */
 async function onSelectProject(this: REPL, name: string) {
@@ -46,7 +46,14 @@ export function projectListView(args: Arguments<KubeOptions>, response: KubeReso
       nameColumnTitle: 'PROJECT'
     }
 
-    return doExecWithRadioTable(projects, defaultSelectedIdx, onSelectProject.bind(args.REPL), opts) || response
+    return (
+      doExecWithRadioTable<ProjectStatus, Project>(
+        projects,
+        defaultSelectedIdx,
+        onSelectProject.bind(args.REPL),
+        opts
+      ) || response
+    )
   } else {
     // otherwise, the user did not request a RadioTable view
     return response
@@ -76,7 +83,7 @@ function getRawData(args: Arguments<KubeOptions>): Promise<string> {
 /** Fetch the KubeItems<Project> model */
 export async function projectList(args: Arguments<KubeOptions>) {
   const kuiRawData = await getRawData(args)
-  const list = JSON.parse(kuiRawData) as KubeItems<Project>
+  const list = JSON.parse(kuiRawData) as KubeItems<ProjectStatus, Project>
 
   return Object.assign(list, {
     metadata: {

--- a/plugins/plugin-kubectl/odo/src/model/Project.ts
+++ b/plugins/plugin-kubectl/odo/src/model/Project.ts
@@ -16,7 +16,7 @@
 
 import { KubeResource } from '@kui-shell/plugin-kubectl'
 
-interface ProjectStatus {
+export interface ProjectStatus {
   active: boolean
 }
 

--- a/plugins/plugin-kubectl/src/controller/client/direct/custom-columns.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/custom-columns.ts
@@ -19,7 +19,7 @@ import { Arguments, Row, Table, encodeComponent } from '@kui-shell/core'
 
 import TrafficLight from '../../../lib/model/traffic-light'
 import { KubeOptions, withKubeconfigFrom } from '../../kubectl/options'
-import { KubeItems, isKubeItems, KubeResource } from '../../../lib/model/resource'
+import { KubeStatusAny, KubeItems, isKubeItems, KubeResource } from '../../../lib/model/resource'
 import {
   computeDurations,
   cssForKey,
@@ -74,8 +74,8 @@ function parse(spec: string): CustomColumns {
  * the given CustomColumns.
  *
  */
-export function evaluate(
-  resource: KubeResource,
+export function evaluate<S extends KubeStatusAny, R extends KubeResource<S>>(
+  resource: R,
   args: Pick<Arguments<KubeOptions>, 'parsedOptions'>,
   drilldownCommand: string,
   kind: string,

--- a/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
@@ -29,7 +29,7 @@ import {
 
 import { doStatus } from './status'
 import RawResponse from './response'
-import KubeResource from '../../lib/model/resource'
+import KubeResource, { KubeStatusAny } from '../../lib/model/resource'
 import { KubeOptions } from './options'
 
 import { FinalState } from '../../lib/model/states'
@@ -282,7 +282,7 @@ export const doExecWithStatus =
     }
   }
 
-export async function doExecWithRadioTable<Resource extends KubeResource>(
+export async function doExecWithRadioTable<S extends KubeStatusAny, Resource extends KubeResource<S>>(
   resources: Resource[],
   defaultSelectedIdx: number,
   onSelect: (name: string, resource: Resource) => string,

--- a/plugins/plugin-kubectl/src/index.ts
+++ b/plugins/plugin-kubectl/src/index.ts
@@ -27,6 +27,7 @@ export {
   KubeStatus,
   KubeStatusCondition,
   Pod,
+  PodStatus,
   PodLikeSpec,
   isPod,
   Deployment,


### PR DESCRIPTION
 BREAKING CHANGE: typescript 4.9 is more rigorous about enforcing certain generic types. this identified issues with some types in plugin-kubectl :(
   - KubeItems is now parametric over KubeItems<KubeStatusType, ItemType>
   - KubePartial is the same, now

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
