### PR TITLE
fix: kubernetes resource Annotations tab can show just `{}`

### DIFF
--- a/plugins/plugin-kubectl/src/lib/model/resource.ts
+++ b/plugins/plugin-kubectl/src/lib/model/resource.ts
@@ -773,10 +773,15 @@ export function isSecret(resource: KubeResource): resource is Secret {
   return resource.apiVersion === 'v1' && resource.kind === 'Secret'
 }
 
+export const lastAppliedAnnotationKey = 'kubectl.kubernetes.io/last-applied-configuration'
+
 export function hasAnnotations(resource: KubeResource): resource is KubeResource {
-  return (
-    isKubeResource(resource) && resource.metadata.annotations && Object.keys(resource.metadata.annotations).length > 0
-  )
+  if (isKubeResource(resource) && resource.metadata.annotations) {
+    const keys = Object.keys(resource.metadata.annotations)
+    return keys.length > 1 || (keys.length === 1 && keys[0] !== lastAppliedAnnotationKey)
+  } else {
+    return false
+  }
 }
 
 export function hasLabels(resource: KubeResource): resource is KubeResource {

--- a/plugins/plugin-kubectl/src/lib/view/modes/Annotations.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/Annotations.ts
@@ -16,11 +16,9 @@
 
 import { i18n, ModeRegistration } from '@kui-shell/core'
 
-import { KubeResource, hasAnnotations } from '../../model/resource'
+import { KubeResource, hasAnnotations, lastAppliedAnnotationKey } from '../../model/resource'
 
 const strings = i18n('plugin-kubectl')
-
-const lastApplied = 'kubectl.kubernetes.io/last-applied-configuration'
 
 export function tryParse(value: any) {
   if (typeof value === 'object' || typeof value === 'number' || typeof value === 'boolean') {
@@ -43,7 +41,7 @@ async function content(_, resource: KubeResource) {
     content: dump(
       JSON.parse(
         JSON.stringify(resource.metadata.annotations, (key, value) =>
-          key === lastApplied ? undefined : tryParse(value)
+          key === lastAppliedAnnotationKey ? undefined : tryParse(value)
         )
       )
     )


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
