### PR TITLE
fix: add side-effect: false

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "bin": {
     "kui": "bin/kui"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,6 +11,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/IBM/kui.git"

--- a/plugins/plugin-bash-like/fs/package.json
+++ b/plugins/plugin-bash-like/fs/package.json
@@ -22,6 +22,10 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "publishConfig": {
     "access": "private"
   }

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -23,6 +23,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@kui-shell/xterm-helpers": "2.0.0",
     "cookie": "0.5.0",

--- a/plugins/plugin-carbon-themes/package.json
+++ b/plugins/plugin-carbon-themes/package.json
@@ -23,6 +23,10 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -20,6 +20,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.2.1",
     "@mdi/font": "7.1.96",

--- a/plugins/plugin-client-default/package.json
+++ b/plugins/plugin-client-default/package.json
@@ -6,6 +6,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "license": "Apache-2.0",
   "author": "Mengting Yan",
   "homepage": "https://github.com/IBM/kui#readme",

--- a/plugins/plugin-core-support/package.json
+++ b/plugins/plugin-core-support/package.json
@@ -23,6 +23,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@electron/remote": "2.0.9",
     "@supercharge/promise-pool": "2.3.2",

--- a/plugins/plugin-core-themes/package.json
+++ b/plugins/plugin-core-themes/package.json
@@ -23,6 +23,10 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/plugin-electron-components/package.json
+++ b/plugins/plugin-electron-components/package.json
@@ -20,6 +20,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@electron/remote": "2.0.9",
     "@patternfly/react-core": "^4.264.0",

--- a/plugins/plugin-git/package.json
+++ b/plugins/plugin-git/package.json
@@ -23,6 +23,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/plugin-kubectl-tray-menu/package.json
+++ b/plugins/plugin-kubectl-tray-menu/package.json
@@ -25,6 +25,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "debug": "4.3.4"
   },

--- a/plugins/plugin-kubectl/helm/package.json
+++ b/plugins/plugin-kubectl/helm/package.json
@@ -27,6 +27,10 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@kui-shell/core": "8.0.6",
     "@IBM/kui": "*",

--- a/plugins/plugin-kubectl/logs/package.json
+++ b/plugins/plugin-kubectl/logs/package.json
@@ -26,6 +26,10 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {},
   "krew": {
     "commandPrefix": "kubeui"

--- a/plugins/plugin-kubectl/oc/package.json
+++ b/plugins/plugin-kubectl/oc/package.json
@@ -28,6 +28,10 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@kui-shell/plugin-kubectl": "*"
   },

--- a/plugins/plugin-kubectl/odo/package.json
+++ b/plugins/plugin-kubectl/odo/package.json
@@ -28,6 +28,10 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@kui-shell/plugin-kubectl": "*"
   },

--- a/plugins/plugin-kubectl/package.json
+++ b/plugins/plugin-kubectl/package.json
@@ -27,6 +27,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@kui-shell/jsonpath": "1.1.1",
     "bytes-iec": "3.1.1",

--- a/plugins/plugin-patternfly4-themes/package.json
+++ b/plugins/plugin-patternfly4-themes/package.json
@@ -23,6 +23,10 @@
   "main": "dist/index.js",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/plugin-s3/package.json
+++ b/plugins/plugin-s3/package.json
@@ -28,6 +28,10 @@
   "typedocMain": "src/index.ts",
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@patternfly/react-table": "^4.111.45",
     "common-path-prefix": "3.0.0",


### PR DESCRIPTION
this might not help much, but by adding side-effect: false to a module, we are telling webpack that it can do more splitting and tree shaking optimizations

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
