### PR TITLE
fix: use defer script loading

### DIFF
--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -274,6 +274,7 @@ if (contentSecurityPolicyForDevServer) {
 
 const htmlBuildOptions = Object.assign(
   {
+    scriptLoading: 'defer',
     inject: false
   },
   clientOptions,


### PR DESCRIPTION
fwiw, async script loading currently does not work, due to the way we set up the nonce. there is an inline script in the index.ejs template that uses kuiNonce, but the variable is not declared there (i think due to the way, at least this used to be required, the way the nonce is initialized)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
