### PR TITLE
fix: bump to madwizard 2.4.11 to pick up missing Profile export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10007,9 +10007,9 @@
       }
     },
     "node_modules/madwizard": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-2.4.10.tgz",
-      "integrity": "sha512-YNS6SzsbPWEf6HqFYToMZLLaIF2eh5QLd0sPZGiTNVBtEZOtSI/Pe2NyA8DGgDSmKhfi9OA+e9nGSlEe5bkZPw==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-2.4.11.tgz",
+      "integrity": "sha512-CI6DkadKwKTZsXfd5KsUlz1B3BcK1JLKiTMH3is8alvpI+AlTOD1vftdcCwH49408/tAKk7Vkrk2/qY/JqRjug==",
       "dependencies": {
         "chalk": "^5.2.0",
         "cli-highlight": "^2.1.11",
@@ -18458,7 +18458,7 @@
         "anser": "2.1.1",
         "ansi-regex": "6.0.1",
         "html-entities": "2.3.3",
-        "madwizard": "^2.4.10",
+        "madwizard": "^2.4.11",
         "monaco-editor": "0.34.1",
         "monaco-editor-webpack-plugin": "7.0.1",
         "needle": "^3.2.0",
@@ -19701,7 +19701,7 @@
         "anser": "2.1.1",
         "ansi-regex": "6.0.1",
         "html-entities": "2.3.3",
-        "madwizard": "^2.4.10",
+        "madwizard": "^2.4.11",
         "monaco-editor": "0.34.1",
         "monaco-editor-webpack-plugin": "7.0.1",
         "needle": "^3.2.0",
@@ -26374,9 +26374,9 @@
       }
     },
     "madwizard": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-2.4.10.tgz",
-      "integrity": "sha512-YNS6SzsbPWEf6HqFYToMZLLaIF2eh5QLd0sPZGiTNVBtEZOtSI/Pe2NyA8DGgDSmKhfi9OA+e9nGSlEe5bkZPw==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-2.4.11.tgz",
+      "integrity": "sha512-CI6DkadKwKTZsXfd5KsUlz1B3BcK1JLKiTMH3is8alvpI+AlTOD1vftdcCwH49408/tAKk7Vkrk2/qY/JqRjug==",
       "requires": {
         "chalk": "^5.2.0",
         "cli-highlight": "^2.1.11",

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -34,7 +34,7 @@
     "anser": "2.1.1",
     "ansi-regex": "6.0.1",
     "html-entities": "2.3.3",
-    "madwizard": "^2.4.10",
+    "madwizard": "^2.4.11",
     "monaco-editor": "0.34.1",
     "monaco-editor-webpack-plugin": "7.0.1",
     "react-markdown": "8.0.4",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
