### PR TITLE
fix: xterm is not sized to viewport

### DIFF
--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -96,20 +96,13 @@ function setCachedSize(tab: Tab, { rows, cols }: { rows: number; cols: number })
 interface HTerminal extends XTerminal {
   _core: {
     viewport: {
-      _bufferService: {
-        cols: number
-      }
       _charSizeService: {
         width: number
       }
       _renderService: {
         dimensions: {
-          scaledCharWidth: number
-          actualCellWidth: number
-          actualCellHeight: number
-          canvasWidth: number
-          scaledCanvasWidth: number
-          scaledCellWidth: number
+          css: { cell: { width: number; height: number } }
+          device: { cell: { width: number; height: number } }
         }
       }
     }
@@ -245,14 +238,14 @@ class Resizer {
     const hack = _core.viewport
     const dimensions = hack._renderService.dimensions
     const scaledCharWidth = hack._charSizeService.width * window.devicePixelRatio
-    const ratio = scaledCharWidth / dimensions.scaledCharWidth
+    const ratio = scaledCharWidth / dimensions.device.cell.width // was: scaledCharWidth
 
     const { width, height } = this.tab.getSize()
 
-    const cols = Math.floor(width / dimensions.actualCellWidth / ratio)
-    const rows = Math.floor(height / dimensions.actualCellHeight)
+    const cols = Math.floor(width / dimensions.css.cell.width / ratio) // was: actualCellWidth
+    const rows = Math.floor(height / dimensions.css.cell.height) // was: actualCellHeight
 
-    debug('getSize', cols, rows, width, height)
+    debug('getSize', cols, rows, width, height, hack)
 
     const newSize = { rows, cols }
     if (!isNaN(rows) && !isNaN(cols)) {


### PR DESCRIPTION
Regression from the xterm 5.0.0 -> 5.1.0 update.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
