### PR TITLE
fix: UpdateChecker may call setState before mount

### DIFF
--- a/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
+++ b/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
@@ -111,8 +111,6 @@ export default class UpdateChecker extends React.PureComponent<Props, State> {
   public constructor(props: Props) {
     super(props)
 
-    setTimeout(() => this.checkForUpdates(), this.props.lag || DEFAULT_LAG)
-
     this.state = {
       pinger: this.initPinger(),
       currentVersion: undefined,
@@ -208,8 +206,9 @@ export default class UpdateChecker extends React.PureComponent<Props, State> {
     }
   }
 
-  public componentDidMount() {
-    this.getCurrentVersion()
+  public async componentDidMount() {
+    await this.getCurrentVersion()
+    setTimeout(() => this.checkForUpdates(), this.props.lag || DEFAULT_LAG)
   }
 
   /** Bye! */


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
