### PR TITLE
fix: CurrentContext/Namespace widgets can be lazily loaded

### DIFF
--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -38,7 +38,8 @@ const SpaceFiller = React.lazy(
   () => import('@kui-shell/plugin-client-common/mdist/components/Client/StatusStripe/SpaceFiller')
 )
 
-import { CurrentContext, CurrentNamespace } from '@kui-shell/plugin-kubectl/components'
+const CurrentContext = React.lazy(() => import('@kui-shell/plugin-kubectl/components/mdist/CurrentContext'))
+const CurrentNamespace = React.lazy(() => import('@kui-shell/plugin-kubectl/components/mdist/CurrentNamespace'))
 
 const Search = React.lazy(() => import('@kui-shell/plugin-electron-components/mdist/components/Search'))
 const CurrentGitBranch = React.lazy(() => import('@kui-shell/plugin-git').then(_ => ({ default: _.CurrentGitBranch })))


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
