### PR TITLE
fix: plugin-kubectl still pulls in prior xterm deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18470,9 +18470,9 @@
         "semver": "7.3.8",
         "tmp": "0.2.1",
         "uuid": "9.0.0",
-        "xterm": "^5.0.0",
-        "xterm-addon-fit": "^0.6.0",
-        "xterm-addon-webgl": "^0.13.0"
+        "xterm": "^5.1.0",
+        "xterm-addon-fit": "^0.7.0",
+        "xterm-addon-webgl": "^0.14.0"
       }
     },
     "plugins/plugin-kubectl-tray-menu": {
@@ -18481,22 +18481,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.4"
-      }
-    },
-    "plugins/plugin-kubectl/node_modules/xterm-addon-fit": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz",
-      "integrity": "sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg==",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
-    },
-    "plugins/plugin-kubectl/node_modules/xterm-addon-webgl": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-webgl/-/xterm-addon-webgl-0.13.0.tgz",
-      "integrity": "sha512-xL4qBQWUHjFR620/8VHCtrTMVQsnZaAtd1IxFoiKPhC63wKp6b+73a45s97lb34yeo57PoqZhE9Jq5pB++ksPQ==",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
       }
     },
     "plugins/plugin-patternfly4-themes": {
@@ -19712,23 +19696,9 @@
         "semver": "7.3.8",
         "tmp": "0.2.1",
         "uuid": "9.0.0",
-        "xterm": "^5.0.0",
-        "xterm-addon-fit": "^0.6.0",
-        "xterm-addon-webgl": "^0.13.0"
-      },
-      "dependencies": {
-        "xterm-addon-fit": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz",
-          "integrity": "sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg==",
-          "requires": {}
-        },
-        "xterm-addon-webgl": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/xterm-addon-webgl/-/xterm-addon-webgl-0.13.0.tgz",
-          "integrity": "sha512-xL4qBQWUHjFR620/8VHCtrTMVQsnZaAtd1IxFoiKPhC63wKp6b+73a45s97lb34yeo57PoqZhE9Jq5pB++ksPQ==",
-          "requires": {}
-        }
+        "xterm": "^5.1.0",
+        "xterm-addon-fit": "^0.7.0",
+        "xterm-addon-webgl": "^0.14.0"
       }
     },
     "@kui-shell/plugin-kubectl-tray-menu": {

--- a/plugins/plugin-kubectl/package.json
+++ b/plugins/plugin-kubectl/package.json
@@ -44,9 +44,9 @@
     "semver": "7.3.8",
     "tmp": "0.2.1",
     "uuid": "9.0.0",
-    "xterm": "^5.0.0",
-    "xterm-addon-fit": "^0.6.0",
-    "xterm-addon-webgl": "^0.13.0"
+    "xterm": "^5.1.0",
+    "xterm-addon-fit": "^0.7.0",
+    "xterm-addon-webgl": "^0.14.0"
   },
   "krew": {
     "commandPrefix": "kubeui"


### PR DESCRIPTION
Strange, i hate npm. plugin-kubectl floats its xterm dependences, but apparently the prior versions were pinned by our package-lock.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
