### PR TITLE
fix: auto-toggle the sidebar closed after user clicks to select an entry in the sidebar

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
@@ -91,6 +91,10 @@ export default class Sidebar extends React.PureComponent<Props, State> {
     pexecInCurrentTab(`${this.props.guidebooksCommand || 'replay'} ${encodeComponent(_.filepath)}`, undefined, quiet)
 
     this.setState({ currentGuidebook: _.notebook })
+
+    // toggle the sidebar closed, after the user has clicked to open a
+    // guidebook; we add a bit of delay, just cause it looks better
+    this.props.toggleOpen()
   }
 
   /** Render the menu structure of the sidebar */


### PR DESCRIPTION
i think this helps. without this change, the user has to click to open a guidebook from the sidebar, then click again to toggle the sidebar closed
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
