### PR TITLE
fix: clicking run on guidebook code block can cause all code block text to disappear

### DIFF
--- a/plugins/plugin-client-common/notebooks/code-blocks.md
+++ b/plugins/plugin-client-common/notebooks/code-blocks.md
@@ -7,7 +7,7 @@ Inside a code blocks, you may define metadata, such as an identifier
 when linking code blocks into [Progress Step
 Lists](#progress-step-lists).
 
-```bashy
+```bash
 echo hello
 ```
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/index.ts
@@ -41,20 +41,15 @@ type Args = {
   uuid: string
   choices: Choices.ChoiceState
   codeBlockResponses: CodeBlockResponseFn
-  spliceInCodeExecution: (
-    status: CodeBlockResponse['status'],
-    response: CodeBlockResponse['response'],
-    codeIdx: number
-  ) => void
 }
 
 function typedComponents(args: Args): Components {
-  const { mdprops, repl, uuid, codeBlockResponses, spliceInCodeExecution } = args
+  const { mdprops, repl, uuid, codeBlockResponses } = args
 
   const a = _a(mdprops, uuid, repl)
   const div = _div(mdprops, uuid, args.choices)
   const img = _img(mdprops)
-  const code = _code(mdprops, uuid, codeBlockResponses, spliceInCodeExecution)
+  const code = _code(mdprops, uuid, codeBlockResponses)
   const heading = _heading(uuid)
 
   return {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Inputv2.tsx
@@ -60,9 +60,9 @@ const strings = i18n('plugin-client-common')
  * Thin wrapper over the Badge component that places the badge in the
  * top left of the surrounding CodeBlock component.
  */
-function Badge(props: React.PropsWithChildren<{}>) {
+function Badge(props: React.PropsWithChildren<{ position: 'top-left' | 'top-right' }>) {
   return (
-    <span className="kui--code-block-actions" data-align="top-left">
+    <span className="kui--code-block-actions" data-align={props.position}>
       <BadgeUI>{props.children}</BadgeUI>
     </span>
   )
@@ -296,7 +296,7 @@ export default class CodeBlock<T1, T2, T3> extends StreamingConsumer<Props<T1, T
   /** UI to denote duration of the current Run */
   private timer() {
     return (
-      <Badge>
+      <Badge position="top-right">
         <Timer startTime={this.state.startTime} endTime={this.state.endTime} status={this.state.execution} />
       </Badge>
     )
@@ -315,13 +315,8 @@ export default class CodeBlock<T1, T2, T3> extends StreamingConsumer<Props<T1, T
         </div>
       )
     } else if (this.props.optional) {
-      return <Badge>{strings('Optional')}</Badge>
+      return <Badge position="top-left">{strings('Optional')}</Badge>
     }
-  }
-
-  /** Display e.g. execution timer or optional badge */
-  private badges() {
-    return this.isExecutionInProgress ? this.timer() : this.status()
   }
 
   private actions(showAsExecutable: boolean, butUseSampleOutputOnRun: boolean) {
@@ -354,7 +349,6 @@ export default class CodeBlock<T1, T2, T3> extends StreamingConsumer<Props<T1, T
   private input(showAsExecutable: boolean, butUseSampleOutputOnRun: boolean) {
     return (
       <div className="repl-input-element-wrapper flex-layout flex-fill kui--inverted-color-context kui--relative-positioning">
-        {this.badges()}
         <div className="flex-fill">
           <CodeSnippet
             wordWrap="on"
@@ -365,6 +359,8 @@ export default class CodeBlock<T1, T2, T3> extends StreamingConsumer<Props<T1, T
             tabUUID={this.props.tab ? this.props.tab.uuid : undefined}
           />
         </div>
+        {this.timer()}
+        {this.status()}
         {this.actions(showAsExecutable, butUseSampleOutputOnRun)}
       </div>
     )


### PR DESCRIPTION
also a few cleanups:

1) delay import of `turndown` module; it is rarely used and takes 100ms to load
2) remove old and untested and not-used snapshot logic in Markdown component
3) always show status *and* badge in Inputv2 (i think this was the root cause of the nominal bug)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
