### PR TITLE
fix: linked Commentary does not update until a tab switch

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -85,10 +85,15 @@ class Commentary extends React.PureComponent<PropsInternal, State> {
     }
   }
 
-  public componentDidUpdate() {
+  public componentDidUpdate(_, prevState: State) {
     if (this.props.send) {
-      // broadcast new textValue
-      if (this.props.previousActiveKey !== undefined && this.props.activeKey === this.state.initialActiveKey) {
+      // broadcast new textValue if either:
+      // a. different textValue
+      // b. there has been a tab switch above us (i.e. in a contanining component)
+      if (
+        prevState.textValue !== this.state.textValue ||
+        (this.props.previousActiveKey !== undefined && this.props.activeKey === this.state.initialActiveKey)
+      ) {
         Commentary.events.emit(Commentary.editChannel(this.props), this.state.textValue)
       }
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
