### PR TITLE
fix: remove right-border on brand (e.g. "Kui |" -> "Kui")

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_index.scss
@@ -32,23 +32,10 @@ $tab-label-font-size: 0.875rem;
 
   @include HeaderNameContainer {
     align-items: stretch;
-    margin-right: 1em;
     position: relative;
 
     /** Override some media queries */
     padding-right: var(--pf-c-page__header-brand--xl--PaddingRight);
-
-    /* vertical separator */
-    &:after {
-      box-shadow: 1px 0 0px 0 var(--color-table-border3);
-      content: '';
-      height: 60%;
-      width: 1px;
-      right: 1px;
-      top: 50%;
-      transform: translateY(-50%);
-      position: absolute;
-    }
   }
   @include HeaderName {
     color: var(--color-text-01);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
