### PR TITLE
fix(plugins/plugin-kubectl): edit button ignores context and kubeconfig options

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/modes/EditButton.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/EditButton.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react'
-import { ModeRegistration, i18n } from '@kui-shell/core'
+import { Arguments, ModeRegistration, i18n } from '@kui-shell/core'
 import Icons from '@kui-shell/plugin-client-common/mdist/components/spi/Icons'
 
 import { KubeResource, isCrudableKubeResource } from '../../model/resource'
@@ -52,13 +52,14 @@ const yamlMode: ModeRegistration<KubeResource> = {
     inPlace: true,
 
     kind: 'drilldown' as const,
-    command: async (_, resource: KubeResource, args: { argvNoOptions: string[] }) => {
-      const [{ fqnOf }, { getCommandFromArgs }] = await Promise.all([
+    command: async (_, resource: KubeResource, args: Pick<Arguments, 'argvNoOptions' | 'parsedOptions'>) => {
+      const [{ fqnOf }, { withKubeconfigFrom }, { getCommandFromArgs }] = await Promise.all([
         import('../../../controller/kubectl/fqn'),
+        import('../../../controller/kubectl/options'),
         import('../../util/util')
       ])
 
-      return `${getCommandFromArgs(args)} edit ${fqnOf(resource)}`
+      return withKubeconfigFrom(args, `${getCommandFromArgs(args)} edit ${fqnOf(resource)}`)
     }
   }
 }


### PR DESCRIPTION
Fixes #9083 
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
