### PR TITLE
fix: Kui component may mount client notebooks multiple times

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -114,10 +114,12 @@ type State = KuiConfiguration & {
  *
  */
 export class Kui extends React.PureComponent<Props, State> {
+  static {
+    Kui.mountGuidebooks()
+  }
+
   public constructor(props: Props) {
     super(props)
-
-    this.mountGuidebooks()
 
     let { commandLine } = this.props
 
@@ -213,7 +215,7 @@ export class Kui extends React.PureComponent<Props, State> {
   }
 
   /** Mount any guidebooks referenced by the `@kui-shell/client/config.d/notebooks.json` model */
-  private mountGuidebooks() {
+  private static mountGuidebooks() {
     // FIXME: require versus import; fixing this will require some
     // refactoring of the plugin-core-support logic
     const { notebookVFS } = require('@kui-shell/plugin-core-support')


### PR DESCRIPTION
This can be forced by enabling React.StrictMode (which intentionally repeats component instantiation)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
