### PR TITLE
fix: plugin-madwizard should not load notebook vfs in headless

### DIFF
--- a/plugins/plugin-madwizard/src/preload.ts
+++ b/plugins/plugin-madwizard/src/preload.ts
@@ -21,7 +21,7 @@ import { Capabilities } from '@kui-shell/core'
  *
  */
 export default async function preloadMadwizard() {
-  if (!Capabilities.inProxy()) {
+  if (!Capabilities.isHeadless()) {
     const playgroundGuidebooks = [
       'plugin://plugin-madwizard/notebooks/playground.md',
       'plugin://plugin-madwizard/notebooks/hello.md',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
