### PR TITLE
fix: increase default height of popup window

### DIFF
--- a/packages/core/src/webapp/defaults.ts
+++ b/packages/core/src/webapp/defaults.ts
@@ -25,5 +25,5 @@ export default {
 
 export const popupWindowDefaults = {
   width: 900,
-  height: 675
+  height: 900
 }


### PR DESCRIPTION
Becauase drilldown splits the window vertically (now).

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 🐛 Bug fix (fix: ... in the commit title)
- [ ] 💅 Chore (chore: ... in the commit title)
- [ ] 🚀 New feature (feat: ... in the commit title)
- [ ] 💥 Breaking change (add BREAKING CHANGE: ... to the commit message body)

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
