### PR TITLE
fix: race condition in vfs mounting can result in ENOENT

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/index.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/index.ts
@@ -126,22 +126,8 @@ const _currentMounts: VFS[] = []
 function orient(A: VFS, B: VFS) {
   const a = A.mountPath.split(/\//).filter(_ => _)
   const b = B.mountPath.split(/\//).filter(_ => _)
-  let lastCommonIdx = 0
-  const N = Math.min(a.length, b.length)
 
-  while (++lastCommonIdx < N) {
-    if (a[lastCommonIdx] !== b[lastCommonIdx]) {
-      break
-    }
-  }
-
-  if (lastCommonIdx === 0 || a.length === b.length) {
-    return 0
-  } else if (lastCommonIdx === a.length) {
-    return -1
-  } else {
-    return b.length - a.length
-  }
+  return b.length - a.length
 }
 
 /** Low-level mount */


### PR DESCRIPTION
e.g. we might mount in an order that results in /kui/madwizard being overridden by /kui (both being VFS mounts) this is due to a bug in the sorting comparator

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
