### PR TITLE
fix: development bin/kubectl-kui should not set NODE_OPTIONS

### DIFF
--- a/bin/kubectl-kui
+++ b/bin/kubectl-kui
@@ -24,7 +24,6 @@ export KUI_POPUP_WINDOW_RESIZE=true
 
 # not very important options to electron
 export NODE_NO_WARNINGS=1
-export NODE_OPTIONS="--no-warnings"
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)                                                              
 


### PR DESCRIPTION
this is no longer supported (not without console warnings) in the latest electron (22)

NOTE: the production kubectl-kui does not have this problem; see packages/builder/dist/electron/build.sh

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
