### PR TITLE
fix: in-browser, maximized guidebook blocks do not render in second+ splits

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -178,7 +178,6 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
   public constructor(props: Props) {
     super(props)
-
     this.initClipboardEvents()
     this.state = this.initialState()
     this.initSnapshotEvents()
@@ -1492,7 +1491,10 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
         displayedIdx++
       }
 
-      if (scrollback.maximized && Capabilities.inBrowser() && isAnnouncement(_) && idx === 0) {
+      if (scrollback.maximized && Capabilities.inBrowser() && isAnnouncement(_) && sbidx === 0 && idx === 0) {
+        // Notes: the goal here is to avoid rendering the "Welcome to"
+        // announcement; this announcement should be the first block
+        // (idx==0) in the first split (sbidx===0)
         return null
       }
 


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [ ] Your PR consists of a single commit (i.e. squash your commits)
- [ ] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
