### PR TITLE
fix: plugin-madwizard's Terminal component does not pull in base xterm.scss

### DIFF
--- a/plugins/plugin-madwizard/web/scss/components/Terminal/_index.scss
+++ b/plugins/plugin-madwizard/web/scss/components/Terminal/_index.scss
@@ -15,6 +15,7 @@
  */
 
 @import 'mixins';
+@import '@kui-shell/plugin-bash-like/web/scss/xterm.scss';
 
 /** For a few, we need to add !important to prioritize our rules over PatternFly's */
 @include MadwizardToolbar {


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
