### PR TITLE
fix: add a browser replacement for require('readline')

### DIFF
--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -311,6 +311,12 @@ plugins.push({
 // node 16
 if (inBrowser) {
   plugins.push(
+    new NormalModuleReplacementPlugin(/^readline$/, resource => {
+      resource.request = require.resolve('./readline.js')
+    })
+  )
+
+  plugins.push(
     new NormalModuleReplacementPlugin(/node:/, resource => {
       const mod = resource.request.replace(/^node:/, '')
 


### PR DESCRIPTION
we already had one for `node:readline`

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
