### PR TITLE
fix: PlaygroundTerminal should skip  responses

### DIFF
--- a/plugins/plugin-madwizard/components/src/PlaygroundTerminal.tsx
+++ b/plugins/plugin-madwizard/components/src/PlaygroundTerminal.tsx
@@ -58,7 +58,7 @@ export default class PlaygroundTerminal extends React.PureComponent<Props> {
         style={{ backgroundColor: 'var(--color-sidecar-background-02)' }}
       >
         {this.props.commands
-          .filter(_ => _.response)
+          .filter(_ => _.response && typeof _.response !== 'boolean')
           .map(_ => (
             <Flex key={_.cmdline}>
               <FlexItem>


### PR DESCRIPTION
in Kui, this just means "response was successful"

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
