### PR TITLE
feat: add <SimpleMarkdown/> component and `commentary --simple` to allow for fastpath

### DIFF
--- a/packages/core/src/models/CommentaryResponse.ts
+++ b/packages/core/src/models/CommentaryResponse.ts
@@ -61,6 +61,9 @@ export type CommentaryResponse = {
     /** [Optional] REPL controller, but required if you want your Card
      * to have functional kuiexec?command=... links via Markdown */
     repl?: REPL
+
+    /** [Optional] If true, the source specified by `filepath` does not utilize extended markdown, such as tabs and tips */
+    simple?: boolean
   }
 }
 

--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -24,6 +24,7 @@ import { MutabilityContext } from '../Client/MutabilityContext'
 import { CurrentMarkdownTab, CurrentMarkdownTabProps } from './Markdown/components/tabbed'
 
 const Markdown = React.lazy(() => import('./Markdown'))
+const SimpleMarkdown = React.lazy(() => import('./Markdown/Simple'))
 const Button = React.lazy(() => import('../spi/Button'))
 const SimpleEditor = React.lazy(() => import('./Editor/SimpleEditor'))
 
@@ -271,18 +272,31 @@ class Commentary extends React.PureComponent<PropsInternal, State> {
 
   private preview() {
     if (this.props.preview !== false) {
-      return (
-        <Markdown
-          nested
-          execUUID={this.props.execUUID}
-          filepath={this.props.filepath}
-          source={this.state.textValue}
-          codeBlockResponses={this.props.codeBlockResponses}
-          baseUrl={this.props.baseUrl}
-          snippetBasePath={this.props.snippetBasePath}
-          tab={this.props.tab}
-        />
-      )
+      if (this.props.simple) {
+        return (
+          <SimpleMarkdown
+            nested
+            execUUID={this.props.execUUID}
+            filepath={this.props.filepath}
+            baseUrl={this.props.baseUrl}
+            source={this.state.textValue}
+            tab={this.props.tab}
+          />
+        )
+      } else {
+        return (
+          <Markdown
+            nested
+            execUUID={this.props.execUUID}
+            filepath={this.props.filepath}
+            source={this.state.textValue}
+            codeBlockResponses={this.props.codeBlockResponses}
+            baseUrl={this.props.baseUrl}
+            snippetBasePath={this.props.snippetBasePath}
+            tab={this.props.tab}
+          />
+        )
+      }
     }
   }
 

--- a/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown/components/div.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react'
-import { Choices, Parser } from 'madwizard'
+import { isWizard } from 'madwizard/dist/parser'
+import { ChoiceState } from 'madwizard/dist/choices'
 
 import SplitInjector from '../../../Views/Terminal/SplitInjector'
 import SplitPosition from '../../../Views/Terminal/SplitPosition'
@@ -28,14 +29,19 @@ const Wizard = React.lazy(() => import('./Wizard'))
 
 const ReactCommentary = React.lazy(() => import('../../Commentary').then(_ => ({ default: _.ReactCommentary })))
 
-export default function divWrapper(mdprops: MarkdownProps, uuid: string, choices: Choices.ChoiceState) {
+export default function divWrapper(mdprops: MarkdownProps, uuid: string, choices: ChoiceState) {
   const tabbed = _tabbed(uuid, choices)
 
   return function div(props: React.HTMLAttributes<HTMLDivElement> & Partial<PositionProps> & Partial<TabProps>) {
     const maximized = props['data-kui-maximized'] === 'true'
     const position = props['data-kui-split']
     const placeholder = props['data-kui-placeholder']
-    const count = props['data-kui-split-count'] ? parseInt(props['data-kui-split-count'], 10) : undefined
+    const count =
+      typeof props['data-kui-split-count'] === 'number'
+        ? props['data-kui-split-count']
+        : props['data-kui-split-count']
+        ? parseInt(props['data-kui-split-count'], 10)
+        : undefined
 
     // Important! Default to `undefined` so that we pick up the
     // *default* behavior from the Terminal component
@@ -51,7 +57,7 @@ export default function divWrapper(mdprops: MarkdownProps, uuid: string, choices
       // don't create a split if a position wasn't indicated, or if
       // this is the first default-positioned section; if it is
       // maximized, we'll have to go through the injector path
-      const node = Parser.isWizard(props) ? (
+      const node = isWizard(props) ? (
         <Wizard uuid={uuid} {...props} choices={choices} />
       ) : (
         <div data-is-maximized={maximized || undefined}>{props.children}</div>
@@ -74,7 +80,7 @@ export default function divWrapper(mdprops: MarkdownProps, uuid: string, choices
             const node = (
               <ReactCommentary>
                 <div className="padding-content marked-content page-content" data-is-nested>
-                  {Parser.isWizard(props) ? (
+                  {isWizard(props) ? (
                     <Wizard uuid={uuid} {...props} choices={choices} />
                   ) : (
                     props.children || (placeholder ? <span className="italic sub-text">{placeholder}</span> : '')

--- a/plugins/plugin-client-common/src/controller/commentary.ts
+++ b/plugins/plugin-client-common/src/controller/commentary.ts
@@ -25,7 +25,7 @@ import fetchMarkdownFile, { join } from './fetch'
  * commentary command parsedOptions type
  */
 type CommentaryOptions = ParsedOptions &
-  Pick<CommentaryResponse['props'], 'header' | 'edit' | 'preview' | 'receive' | 'send' | 'replace'> & {
+  Pick<CommentaryResponse['props'], 'header' | 'edit' | 'preview' | 'receive' | 'send' | 'replace' | 'simple'> & {
     f: string
     file: string
     title: string
@@ -119,7 +119,8 @@ async function addComment(args: Arguments<CommentaryOptions>): Promise<true | Co
     send,
     title,
     readonly,
-    replace
+    replace,
+    simple
   } = args.parsedOptions
 
   const filepath = args.parsedOptions.file || args.parsedOptions.f
@@ -171,6 +172,7 @@ async function addComment(args: Arguments<CommentaryOptions>): Promise<true | Co
           replace,
           receive,
           send,
+          simple,
           snippetBasePath,
           title,
           children: '',
@@ -188,6 +190,7 @@ async function addComment(args: Arguments<CommentaryOptions>): Promise<true | Co
           replace,
           receive,
           send,
+          simple,
           snippetBasePath,
           title,
           filepath,
@@ -210,7 +213,7 @@ async function addComment(args: Arguments<CommentaryOptions>): Promise<true | Co
  */
 export default function registerCommentaryController(commandTree: Registrar) {
   const flags = {
-    boolean: ['edit', 'header', 'preview', 'readonly', 'replace']
+    boolean: ['edit', 'header', 'preview', 'readonly', 'replace', 'simple']
   }
 
   commandTree.listen('/commentary', addComment, { outputOnly: true, flags })


### PR DESCRIPTION
Sometimes, the client knows that a given markdown file does not have tabs, tips, etc. We can speed up the processing of these.

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
