### PR TITLE
fix: prescan for offline clients may fail to register commands

### DIFF
--- a/packages/core/src/core/capabilities.ts
+++ b/packages/core/src/core/capabilities.ts
@@ -20,6 +20,8 @@ import Debug from 'debug'
 const debug = Debug('core/capabilities')
 debug('loading')
 
+import { isOffline } from '../api/Client'
+
 export { CapabilityRegistration as Registration } from '../models/plugin'
 
 /**
@@ -75,7 +77,10 @@ export const inBrowser = () => {
     return true
   }
 
-  if (!isHeadless() && typeof document !== 'undefined' && document.body.classList.contains('not-electron')) {
+  if (
+    isOffline() ||
+    (!isHeadless() && typeof document !== 'undefined' && document.body.classList.contains('not-electron'))
+  ) {
     setMedia(Media.Browser)
     return true
   } else {


### PR DESCRIPTION
`Capabilities.inBrowser()` should return true when prescanning for command registrations for offline clients.

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
