### PR TITLE
chore: optimize plugin-client-common imports of kui-shell/core (second pass)

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Editor/DiffEditor.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/DiffEditor.tsx
@@ -20,8 +20,8 @@ import { editor as Monaco } from 'monaco-editor'
 
 import { eventBus, eventChannelUnsafe, TabLayoutChangeEvent } from '@kui-shell/core/mdist/api/Events'
 import type { MultiModalResponse } from '@kui-shell/core'
-import { isFile } from '@kui-shell/plugin-bash-like/fs'
 
+import { isFile } from '.'
 import getKuiFontSize from './lib/fonts'
 import { language } from './lib/file-types'
 import defaultMonacoOptions, { Options as MonacoOptions } from './lib/defaults'

--- a/plugins/plugin-client-common/src/components/Content/Editor/RevertFileButton.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/RevertFileButton.tsx
@@ -18,7 +18,7 @@ import React from 'react'
 import { editor as Monaco } from 'monaco-editor'
 import { i18n } from '@kui-shell/core/mdist/api/i18n'
 import type { Button, REPL } from '@kui-shell/core'
-import { File, FStat } from '@kui-shell/plugin-bash-like/fs'
+import type { File, FStat } from '@kui-shell/plugin-bash-like/fs'
 
 import Icons from '../../spi/Icons'
 

--- a/plugins/plugin-client-common/src/components/Content/Editor/SaveFileButton.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/SaveFileButton.tsx
@@ -18,7 +18,7 @@ import React from 'react'
 import { editor as Monaco } from 'monaco-editor'
 import { i18n } from '@kui-shell/core/mdist/api/i18n'
 import type { Button, REPL } from '@kui-shell/core'
-import { File } from '@kui-shell/plugin-bash-like/fs'
+import type { File } from '@kui-shell/plugin-bash-like/fs'
 
 import Icons from '../../spi/Icons'
 

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -18,7 +18,7 @@ import React from 'react'
 import { extname } from 'path'
 import { IDisposable, editor as Monaco, Range } from 'monaco-editor'
 
-import { File, isFile } from '@kui-shell/plugin-bash-like/fs'
+import type { File } from '@kui-shell/plugin-bash-like/fs'
 import {
   Button,
   Events,
@@ -45,6 +45,10 @@ import defaultMonacoOptions, { Options as MonacoOptions } from './lib/defaults'
 import '../../../../web/scss/components/Editor/Editor.scss'
 
 const strings = i18n('plugin-client-common', 'editor')
+
+export function isFile(file: File | MultiModalResponse): file is File {
+  return file.apiVersion === 'kui-shell/v1' && file.kind === 'File'
+}
 
 type Props = MonacoOptions &
   ToolbarProps & {


### PR DESCRIPTION


This also removes a few uses of plugin-bash-like from plugin-client-common. The two are now orthogonal.

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
