### PR TITLE
fix: allow clients to build with client-provided webpack-bundle-analyzer

### DIFF
--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -31,7 +31,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const { IgnorePlugin, ProvidePlugin } = require('webpack')
-// const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 
 const sassLoaderChain = [
   {
@@ -150,9 +149,14 @@ console.log('clientHome', process.env.CLIENT_HOME)
  */
 const plugins = []
 
-// if (process.env.WEBPACK_ANALYZER) {
-//  plugins.push(new BundleAnalyzerPlugin())
-// }
+if (process.env.WEBPACK_ANALYZER) {
+  try {
+    const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+    plugins.push(new BundleAnalyzerPlugin())
+  } catch (err) {
+    console.error('Failed to load webpack-bundle-analyzer', err)
+  }
+}
 
 // any compression plugins?
 if (CompressionPlugin) {


### PR DESCRIPTION
It is way too big to ship with kui itself. But if clients want to use it, they can npm install it themselves, and then run the watchers/builders with `WEBPACK_ANALYZER=true`

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
