### PR TITLE
fix: remove electron/remote dep from core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@electron/remote": "^2.0.9",
         "@kui-shell/client": "file:plugins/plugin-client-default",
         "@kui-shell/core": "file:packages/core",
         "@kui-shell/plugin-bash-like": "file:plugins/plugin-bash-like",
@@ -1593,6 +1594,15 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "node_modules/@types/properties-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/properties-parser/-/properties-parser-0.3.0.tgz",
+      "integrity": "sha512-8wK33jr6tdaxQJ3TAGUkJcOD1iTvbOeR4Kou9cnZIs558K2tfcl2dAstKB38Cl2aoXqr/YPWF6H0S4EjIsJVtA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -17135,18 +17145,15 @@
       "version": "13.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@electron/remote": "^2.0.9",
         "colors": "^1.4.0",
         "columnify": "^1.6.0",
         "debug": "^4.3.4",
         "fs-extra": "^11.1.0",
         "mkdirp": "^1.0.4",
         "pretty-ms": "^7.0.1",
-        "properties-parser": "^0.3.1",
         "tmp": "^0.2.1",
         "trie-search": "^1.3.6",
         "uuid": "^9.0.0",
-        "word-wrap": "^1.2.3",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -17296,6 +17303,7 @@
         "debug": "^4.3.4",
         "globby": "^11.0.4",
         "node-pty": "0.11.0-beta27",
+        "properties-parser": "0.3.1",
         "shelljs": "^0.8.5",
         "slash": "^3.0.0",
         "speed-date": "^1.0.0",
@@ -17309,6 +17317,7 @@
       "devDependencies": {
         "@types/cookie": "^0.5.1",
         "@types/debug": "^4.1.7",
+        "@types/properties-parser": "0.3.0",
         "@types/shelljs": "^0.8.11",
         "@types/tmp": "^0.2.3",
         "@types/uuid": "^9.0.0"
@@ -18285,7 +18294,6 @@
     "@kui-shell/core": {
       "version": "file:packages/core",
       "requires": {
-        "@electron/remote": "^2.0.9",
         "@types/debug": "^4.1.7",
         "@types/fs-extra": "^9.0.13",
         "@types/mkdirp": "^1.0.2",
@@ -18298,11 +18306,9 @@
         "fs-extra": "^11.1.0",
         "mkdirp": "^1.0.4",
         "pretty-ms": "^7.0.1",
-        "properties-parser": "^0.3.1",
         "tmp": "^0.2.1",
         "trie-search": "^1.3.6",
         "uuid": "^9.0.0",
-        "word-wrap": "^1.2.3",
         "yargs-parser": "^21.1.1"
       },
       "dependencies": {
@@ -18348,6 +18354,7 @@
         "@kui-shell/xterm-helpers": "^2.1.0",
         "@types/cookie": "^0.5.1",
         "@types/debug": "^4.1.7",
+        "@types/properties-parser": "0.3.0",
         "@types/shelljs": "^0.8.11",
         "@types/tmp": "^0.2.3",
         "@types/uuid": "^9.0.0",
@@ -18355,6 +18362,7 @@
         "debug": "^4.3.4",
         "globby": "^11.0.4",
         "node-pty": "0.11.0-beta27",
+        "properties-parser": "0.3.1",
         "shelljs": "^0.8.5",
         "slash": "^3.0.0",
         "speed-date": "^1.0.0",
@@ -19098,6 +19106,15 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "@types/properties-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/properties-parser/-/properties-parser-0.3.0.tgz",
+      "integrity": "sha512-8wK33jr6tdaxQJ3TAGUkJcOD1iTvbOeR4Kou9cnZIs558K2tfcl2dAstKB38Cl2aoXqr/YPWF6H0S4EjIsJVtA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/qs": {
       "version": "6.9.7",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "npm": ">=6.9.0"
   },
   "dependencies": {
+    "@electron/remote": "^2.0.9",
     "@kui-shell/client": "file:plugins/plugin-client-default",
     "@kui-shell/core": "file:packages/core",
     "@kui-shell/plugin-bash-like": "file:plugins/plugin-bash-like",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,18 +43,15 @@
     "@types/yargs-parser": "^21.0.0"
   },
   "dependencies": {
-    "@electron/remote": "^2.0.9",
     "colors": "^1.4.0",
     "columnify": "^1.6.0",
     "debug": "^4.3.4",
     "fs-extra": "^11.1.0",
     "mkdirp": "^1.0.4",
     "pretty-ms": "^7.0.1",
-    "properties-parser": "^0.3.1",
     "tmp": "^0.2.1",
     "trie-search": "^1.3.6",
     "uuid": "^9.0.0",
-    "word-wrap": "^1.2.3",
     "yargs-parser": "^21.1.1"
   },
   "publishConfig": {

--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -264,7 +264,11 @@ export async function createWindow(
         }
 
         if (electronRemoteNeedsInit) {
-          require('@electron/remote/main').initialize()
+          // some hacks to allow @kui-shell/core to avoid specifying a
+          // direct dependence on @electron/remote; this dep pulls in
+          // all of electron, which some clients will not need
+          const foolWebpackHack = 'index.js'
+          require('@electron/remote/main/' + foolWebpackHack).initialize()
           electronRemoteNeedsInit = false
         }
 

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/cookie": "^0.5.1",
     "@types/debug": "^4.1.7",
+    "@types/properties-parser": "0.3.0",
     "@types/shelljs": "^0.8.11",
     "@types/tmp": "^0.2.3",
     "@types/uuid": "^9.0.0"
@@ -40,6 +41,7 @@
     "debug": "^4.3.4",
     "globby": "^11.0.4",
     "node-pty": "0.11.0-beta27",
+    "properties-parser": "0.3.1",
     "shelljs": "^0.8.5",
     "slash": "^3.0.0",
     "speed-date": "^1.0.0",

--- a/plugins/plugin-bash-like/src/pty/prefetch.ts
+++ b/plugins/plugin-bash-like/src/pty/prefetch.ts
@@ -18,7 +18,6 @@ import Debug from 'debug'
 const debug = Debug('plugins/bash-like/pty/prefetch')
 
 import { exec } from 'child_process'
-import * as propertiesParser from 'properties-parser'
 
 /**
  * Preprocess bash/zsh environment variables
@@ -37,7 +36,7 @@ function prefetchEnv() {
     const shell = await getLoginShell()
     debug('prefetchEnv got shell', shell)
 
-    exec(`${shell} -l -c printenv`, (err, stdout, stderr) => {
+    exec(`${shell} -l -c printenv`, async (err, stdout, stderr) => {
       try {
         if (stderr) {
           debug(stderr)
@@ -46,6 +45,7 @@ function prefetchEnv() {
           debug('error in prefetchEnv 1', err)
           reject(err)
         } else {
+          const { default: propertiesParser } = await import('properties-parser')
           const env = propertiesParser.parse(stdout.toString())
           debug('got env', env)
           for (const key in env) {


### PR DESCRIPTION
This PR also removes some old unused deps from the core. Doing this identified a missing dep in plugin-bash-like (on properties-parser). This PR thus also adds that dep to plugin-bash-like, and adds the properties-parser types, and then shifts a require to an import.

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
