### PR TITLE
fix: improved fix for externalizing electron/remote

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -264,11 +264,11 @@ export async function createWindow(
         }
 
         if (electronRemoteNeedsInit) {
-          // some hacks to allow @kui-shell/core to avoid specifying a
+          // use the webpackIgnore magic comment to avoid specifying a
           // direct dependence on @electron/remote; this dep pulls in
-          // all of electron, which some clients will not need
-          const foolWebpackHack = 'index.js'
-          require('@electron/remote/main/' + foolWebpackHack).initialize()
+          // all of electron, which some clients will not need. if you
+          // need it, make sure to install @electron/remote yourself.
+          await import(/* webpackIgnore: true */ '@electron/remote/main/index.js').then(_ => _.initialize())
           electronRemoteNeedsInit = false
         }
 
@@ -285,7 +285,10 @@ export async function createWindow(
         }
         const mainWindow = new BrowserWindow(opts) as KuiBrowserWindow
         if (electronRemoteIsNeeded) {
-          require('@electron/remote/main').enable(mainWindow.webContents)
+          // see the webpackIgnore: true comment just above
+          await import(/* webpackIgnore: true */ '@electron/remote/main/index.js').then(_ =>
+            _.enable(mainWindow.webContents)
+          )
         }
         nWindows++
         debug('createWindow::new BrowserWindow success')


### PR DESCRIPTION
- We should be using the `webpackIgnore: true` magic comment, rather than the silly hack we had from #9265
- #9265 missed the second import of electron/remote

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
