### PR TITLE
feat: allow quick testing of fully offline clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "_watch": "bash -c \"npm run kill; export CSP_ALLOWED_HOSTS='http: https: data: filesystem: about: blob: ws: wss:'; kui-watch-webpack\"",
     "watch:webpack": "npm run kill; npm run pty:nodejs && npm run _watch $WATCH_ARGS",
     "watch:browser": "concurrently -n COMPILE,WEBPACK --kill-others 'npm run watch:source' 'npm run watch:webpack'",
+    "watch:browser:offline": "export IS_OFFLINE_CLIENT=true; concurrently -n COMPILE,WEBPACK --kill-others 'npm run watch:source' 'npm run watch:webpack'",
     "watch:electron": "bash -c \"npm run pty:electron && TARGET=electron-renderer npm run _watch\"",
     "watch": "bash -c \"npm run kill; npm run compile && npm run link && concurrently -n COMPILE,WEBPACK --kill-others 'npm run watch:source' 'npm run watch:electron'\"",
     "proxy": "export PORT=8081; npm run kill:proxy; export KUI_USE_HTTP=true; cd packages/proxy/app && npm install && ../../../tools/travis/proxy.sh ../../..",

--- a/packages/core/src/api/Client.ts
+++ b/packages/core/src/api/Client.ts
@@ -24,7 +24,10 @@ export { isPopup } from '../webapp/popup-core'
 /** Is the current client running in offline/disconnected mode? */
 export function isOfflineClient(): boolean {
   try {
-    const { offline, readonly, executable } = require('@kui-shell/client/config.d/client.json')
+    const { offline: offlineFromClientSpec, readonly, executable } = require('@kui-shell/client/config.d/client.json')
+
+    // see @kui-shell/webpack/offline.js for injecting the env var
+    const offline = process.env.IS_OFFLINE_CLIENT || offlineFromClientSpec
 
     if (offline === undefined && readonly !== undefined && executable !== undefined) {
       return readonly && !executable

--- a/packages/webpack/bin/watch.sh
+++ b/packages/webpack/bin/watch.sh
@@ -22,8 +22,10 @@ set -o pipefail
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 export CLIENT_HOME=$(cd "$SCRIPTDIR"/../../ && pwd)
 
-if [ "$(cat "$CLIENT_HOME/node_modules/@kui-shell/client/config.d/client.json" | jq -cr .offline)" = "true" ]; then
-    IS_OFFLINE_CLIENT=true
+if [ -z "$IS_OFFLINE_CLIENT" ]; then
+    if [ "$(cat "$CLIENT_HOME/node_modules/@kui-shell/client/config.d/client.json" | jq -cr .offline)" = "true" ]; then
+        IS_OFFLINE_CLIENT=true
+    fi
 fi
 
 if [ ! -d "$CLIENT_HOME/node_modules/@kui-shell" ]; then

--- a/packages/webpack/build.sh
+++ b/packages/webpack/build.sh
@@ -48,8 +48,10 @@ APPDIR="$STAGING"/node_modules/@kui-shell
 CORE_HOME="$STAGING"/node_modules/@kui-shell/core
 THEME="$CLIENT_HOME"/node_modules/@kui-shell/client
 
-if [ "$(cat "$CLIENT_HOME/node_modules/@kui-shell/client/config.d/client.json" | jq -cr .offline)" = "true" ]; then
-    IS_OFFLINE_CLIENT=true
+if [ -z "$IS_OFFLINE_CLIENT" ]; then
+    if [ "$(cat "$CLIENT_HOME/node_modules/@kui-shell/client/config.d/client.json" | jq -cr .offline)" = "true" ]; then
+        IS_OFFLINE_CLIENT=true
+    fi
 fi
 
 echo "build-webpack CLIENT_HOME=$CLIENT_HOME"

--- a/packages/webpack/offline.js
+++ b/packages/webpack/offline.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const proc = require('process/browser')
+
+const HOME = '~'
+let cwd = HOME
+
+/**
+ * Browser-oriented shims for 'process'
+ *
+ */
+module.exports = Object.assign(proc, {
+  env: {
+    HOME,
+    IS_OFFLINE_CLIENT: 'true'
+  },
+
+  cwd: () => cwd,
+
+  chdir: dir => (cwd = dir),
+
+  stdout: {
+    // yargs expects process.stdout to be defined
+  }
+})

--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -173,7 +173,10 @@ if (inBrowser) {
   plugins.push(
     new ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],
-      process: require.resolve('./process.js')
+      process:
+        process.env.WATCH && process.env.IS_OFFLINE_CLIENT
+          ? require.resolve('./offline.js')
+          : require.resolve('./process.js')
     })
   )
 }

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react'
 
+import { isOffline } from '@kui-shell/core/mdist/api/Client'
 import { inBrowser } from '@kui-shell/core/mdist/api/Capabilities'
 
 import Kui, { Props as KuiProps } from '@kui-shell/plugin-client-common/mdist/components/Client/Kui'
@@ -91,6 +92,8 @@ export default class Client extends React.PureComponent<KuiProps> {
         ? false
         : undefined
 
+    const offline = isOffline()
+
     return (
       <Kui
         noHelp
@@ -126,9 +129,9 @@ export default class Client extends React.PureComponent<KuiProps> {
       >
         <ContextWidgets>
           {!isPopup && <CurrentWorkingDirectory className="kui--hide-in-guidebook" />}
-          <CurrentGitBranch className="kui--hide-in-narrower-windows kui--hide-in-guidebook" />
-          <CurrentContext />
-          <CurrentNamespace />
+          {!offline && <CurrentGitBranch className="kui--hide-in-narrower-windows kui--hide-in-guidebook" />}
+          {!offline && <CurrentContext />}
+          {!offline && <CurrentNamespace />}
         </ContextWidgets>
 
         {!isPopup && <SpaceFiller />}
@@ -136,8 +139,8 @@ export default class Client extends React.PureComponent<KuiProps> {
         <MeterWidgets className="kui--hide-in-narrower-windows">
           {/* <ClusterUtilization /> */}
           {/* !isPopup && <OpenWhiskGridWidget /> */}
-          {inBrowser() && <ProxyOfflineIndicator />}
-          {!isPopup && !inBrowser() && <UpdateChecker />}
+          {!offline && inBrowser() && <ProxyOfflineIndicator />}
+          {!offline && !isPopup && !inBrowser() && <UpdateChecker />}
           <Settings />
           <GitHubIcon />
         </MeterWidgets>

--- a/plugins/plugin-proxy-support/src/preload.ts
+++ b/plugins/plugin-proxy-support/src/preload.ts
@@ -16,7 +16,7 @@
 
 import Debug from 'debug'
 
-import { Capabilities, setEvaluatorImpl } from '@kui-shell/core'
+import { Capabilities, Client, setEvaluatorImpl } from '@kui-shell/core'
 
 import { isDisabled, config } from './lib/config'
 
@@ -27,7 +27,7 @@ const debug = Debug('plugins/proxy-support/preload')
  *
  */
 export const registerCapability: Capabilities.CapabilityRegistration = async () => {
-  if (Capabilities.inBrowser()) {
+  if (Capabilities.inBrowser() && !Client.isOffline()) {
     const { proxyServer } = await config()
     debug('config', proxyServer)
 
@@ -45,7 +45,7 @@ export const registerCapability: Capabilities.CapabilityRegistration = async () 
  *
  */
 export default async () => {
-  if (Capabilities.inBrowser()) {
+  if (Capabilities.inBrowser() && !Client.isOffline()) {
     const { proxyServer } = await config()
     debug('config', proxyServer)
 


### PR DESCRIPTION
Either run `npm run watch:browser:offline` or start up the webpack watchers yourself with `IS_OFFLINE_CLIENT=true`

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
