### PR TITLE
fix: prescan for /kui/client guidebooks doesn't handle nesting

### DIFF
--- a/packages/builder/bin/prescan.sh
+++ b/packages/builder/bin/prescan.sh
@@ -43,5 +43,5 @@ if [ -d node_modules/@kui-shell/client/notebooks ]; then
     if [ ! -d node_modules/@kui-shell/build/ ]; then
         mkdir node_modules/@kui-shell/build
     fi
-    (echo -n "["; for file in node_modules/@kui-shell/client/notebooks/*.{md,json}; do echo -n "\"$(basename $file)\","; done; echo -n "]") | sed 's/\,]/]/' > node_modules/@kui-shell/build/client-guidebooks.json
+    (echo -n "["; (cd node_modules/\@kui-shell/client/notebooks && find . \( -name '*.md' -o -name '*.json' \) -print) | sed 's/\.\///' | xargs -I{} -n1 echo -n '"{}",'; echo -n "]") | sed 's/\,]/]/' > node_modules/@kui-shell/build/client-guidebooks.json
 fi


### PR DESCRIPTION
if you have a `notebooks/` directory in your `at-kui-shell/client` plugin, this PR allows you to structure your guidebooks into subdirectories.

it also fixes mysterious "*.json" files being mounted into the kui vfs.

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
