### PR TITLE
feat: improve support for showing Playground over a given filepath

### DIFF
--- a/packages/builder/bin/prescan.sh
+++ b/packages/builder/bin/prescan.sh
@@ -43,5 +43,5 @@ if [ -d node_modules/@kui-shell/client/notebooks ]; then
     if [ ! -d node_modules/@kui-shell/build/ ]; then
         mkdir node_modules/@kui-shell/build
     fi
-    (echo -n "["; (cd node_modules/\@kui-shell/client/notebooks && find . \( -name '*.md' -o -name '*.json' \) -print) | sed 's/\.\///' | xargs -I{} -n1 echo -n '"{}",'; echo -n "]") | sed 's/\,]/]/' > node_modules/@kui-shell/build/client-guidebooks.json
+    (echo -n "["; (cd node_modules/\@kui-shell/client/notebooks && find . \( -name '*.md' -o -name '*.py' -o -name '*.txt' -o -name '*.json' \) -print) | sed 's/\.\///' | xargs -I{} -n1 echo -n '"{}",'; echo -n "]") | sed 's/\,]/]/' > node_modules/@kui-shell/build/client-guidebooks.json
 fi

--- a/packages/core/src/repl/error.ts
+++ b/packages/core/src/repl/error.ts
@@ -24,7 +24,7 @@ function isCustomError(response: KResponse): response is CustomError {
   return err && typeof err === 'object' && typeof err.name === 'string' && typeof err.message === 'string'
 }
 
-export default function isError(response: KResponse): response is ErrorLike {
+export default function isError(response: unknown): response is ErrorLike {
   return (
     response &&
     (response.constructor === Error ||

--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -548,6 +548,9 @@ module.exports = {
       { test: /LICENSE/, use: 'ignore-loader' },
       { test: /license.txt/, use: 'ignore-loader' },
 
+      { test: /notebooks\/.+\.py$/, type: 'asset/source' },
+      { test: /notebooks\/.+\.txt$/, type: 'asset/source' },
+
       // was: file-loader; but that loader does not allow for dynamic
       // loading of markdown *content* in a browser-based client
       { test: /\.md$/, use: 'raw-loader' }, // was: 'snippet-inliner'

--- a/plugins/plugin-bash-like/fs/src/vfs/TrieVFS.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/TrieVFS.ts
@@ -187,9 +187,9 @@ export abstract class TrieVFS<D, L extends Leaf<D> = Leaf<D>> implements VFS {
   public cp(_, srcFilepaths: string[], dstFilepath: string): Promise<string> {
     return Promise.all(
       srcFilepaths.map(async srcFilepath => {
-        const match1 = srcFilepath.match(/^plugin:\/\/plugin-(.*)\/notebooks\/(.*)\.(md|json)$/)
-        const match2 = srcFilepath.match(/^plugin:\/\/client\/notebooks\/(.*)\.(md|json)$/)
-        const match3 = srcFilepath.match(/^plugin:\/\/client\/(.*)\.(md|json)$/)
+        const match1 = srcFilepath.match(/^plugin:\/\/plugin-(.*)\/notebooks\/(.*)\.(md|json|txt|py)$/)
+        const match2 = srcFilepath.match(/^plugin:\/\/client\/notebooks\/(.*)\.(md|json|txt|py)$/)
+        const match3 = srcFilepath.match(/^plugin:\/\/client\/(.*)\.(md|json|txt)$/)
         const match = match1 || match2 || match3
         if (match) {
           const dir = dirname(dstFilepath)

--- a/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Sidebar.tsx
@@ -88,7 +88,13 @@ export default class Sidebar extends React.PureComponent<Props, State> {
   /** User has clicked to select a given Guidebook */
   private onSelect(_: Guidebook) {
     const quiet = !this.props.noTopTabs
-    pexecInCurrentTab(`${this.props.guidebooksCommand || 'replay'} ${encodeComponent(_.filepath)}`, undefined, quiet)
+
+    // if the notebooks.json entry has a `play` field, then pass this
+    // through the commentary delegate, which just wraps the `play`
+    // command into a full-screen/maximized in-place replay of the
+    // filepath
+    const cmd = _.play ? `commentary delegate '${_.play}'` : this.props.guidebooksCommand || 'replay'
+    pexecInCurrentTab(`${cmd} ${encodeComponent(_.filepath)}`, undefined, quiet)
 
     this.setState({
       currentGuidebook: _.notebook,

--- a/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Guidebooks.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-export type Guidebook = { notebook: string; filepath: string }
+/** An leaf node in config.d/notebooks.json */
+export type Guidebook = { notebook: string; filepath: string; play?: string }
+
+/** An interior node in config.d/notebooks.json */
+// eslint-disable-next-line no-use-before-define
 type Menu = { label: string; submenu: MenuItem[]; expanded?: boolean }
+
+/** Any node in config.d/notebooks.json */
 export type MenuItem = Guidebook | Menu | object
 
 export function isGuidebook(item: MenuItem): item is Guidebook {

--- a/plugins/plugin-core-support/src/notebooks/vfs/index.ts
+++ b/plugins/plugin-core-support/src/notebooks/vfs/index.ts
@@ -16,16 +16,8 @@
 
 import { TrieVFS, VFS, mount } from '@kui-shell/plugin-bash-like/fs'
 
-interface Tutorial {
-  name: string
-  tutorial: Record<string, any> // FIXME type for snapshot
-
-  path: string
-  nameForDisplay: string
-}
-
 type NotebookLeaf = TrieVFS.Leaf<{ srcFilepath: string }>
-type NotebookEntry = TrieVFS.Directory | NotebookLeaf
+// type NotebookEntry = TrieVFS.Directory | NotebookLeaf
 
 export class NotebookVFS extends TrieVFS.TrieVFS<NotebookLeaf['data']> implements VFS {
   protected viewer() {
@@ -46,7 +38,7 @@ export class NotebookVFS extends TrieVFS.TrieVFS<NotebookLeaf['data']> implement
     const { srcFilepath } = data
 
     const match1 = srcFilepath.match(/^plugin:\/\/plugin-(.*)\/notebooks\/(.*)\.(md|json)$/)
-    const match2 = srcFilepath.match(/^plugin:\/\/client\/notebooks\/(.*)\.(md|json)$/)
+    const match2 = srcFilepath.match(/^plugin:\/\/client\/notebooks\/(.*)\.(md|json|txt|py)$/)
     const match3 = srcFilepath.match(/^plugin:\/\/client\/(.*)\.(md|json)$/)
     const match = match1 || match2 || match3
     if (match) {
@@ -75,6 +67,18 @@ export class NotebookVFS extends TrieVFS.TrieVFS<NotebookLeaf['data']> implement
                 /* webpackChunkName: "client-notebooks" */ /* webpackMode: "lazy" */ '@kui-shell/client/notebooks/' +
                   file +
                   '.md'
+              )
+            : extension === 'txt'
+            ? import(
+                /* webpackChunkName: "client-notebooks" */ /* webpackMode: "lazy" */ '@kui-shell/client/notebooks/' +
+                  file +
+                  '.txt'
+              )
+            : extension === 'py'
+            ? import(
+                /* webpackChunkName: "client-notebooks" */ /* webpackMode: "lazy" */ '@kui-shell/client/notebooks/' +
+                  file +
+                  '.py'
               )
             : import(
                 /* webpackChunkName: "client-notebooks" */ /* webpackMode: "lazy" */ '@kui-shell/client/notebooks/' +

--- a/plugins/plugin-madwizard/components/src/plugin.ts
+++ b/plugins/plugin-madwizard/components/src/plugin.ts
@@ -77,12 +77,26 @@ export default function registerMadwizardComponentCommands(registrar: Registrar)
   )
 
   /**
-   * Listen for edits
+   * Playground that listens for edits on the provided channel
+   *    madwizard playground <channel>
    *
    */
   registrar.listen(
     '/madwizard/playground',
-    async args => import('./Playground').then(async _ => ({ react: await _.controller(args) })),
+    async args => import('./Playground').then(async _ => ({ react: await _.listenOnChannel(args) })),
+    {
+      needsUI: true
+    }
+  )
+
+  /**
+   * Playground for a given filepath
+   *    madwizard playground file <filepath>
+   *
+   */
+  registrar.listen(
+    '/madwizard/playground/file',
+    async args => import('./Playground').then(async _ => ({ react: await _.readFromFile(args) })),
     {
       needsUI: true
     }


### PR DESCRIPTION
1. adds `madwizard playground file <filepath>`
2. adds `commentary delegate <delegateCommand> <filepath>` which wraps a maximized CommentaryResponse around the given `<delegateComand> <filepath>`

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
