### PR TITLE
feat: improve helm drilldown view

### DIFF
--- a/plugins/plugin-kubectl/helm/src/test/helm/helm.ts
+++ b/plugins/plugin-kubectl/helm/src/test/helm/helm.ts
@@ -63,7 +63,7 @@ describe(`helm commands ${process.env.MOCHA_RUN_TARGET || ''}`, function (this: 
   const checkHelmInstall = async (res: ReplExpect.AppAndCount) => {
     await ReplExpect.ok(res)
     await SidecarExpect.open(res)
-    await SidecarExpect.showingLeftNav('Overview')(res)
+    await SidecarExpect.showing(name)(res)
   }
 
   it('should update the helm repo to add bitnami', () => {

--- a/plugins/plugin-kubectl/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/options.ts
@@ -330,7 +330,11 @@ export function isForAllNamespaces(parsedOptions: KubeOptions) {
 }
 
 /** Copy over any kubeconfig/context/cluster/namespace specifications from the given args */
-export function withKubeconfigFrom(args: Pick<Arguments<KubeOptions>, 'parsedOptions'>, cmdline: string): string {
+export function withKubeconfigFrom(
+  args: Pick<Arguments<KubeOptions>, 'parsedOptions'>,
+  cmdline: string,
+  context = 'context'
+): string {
   let extras = ' '
 
   if (args.parsedOptions.kubeconfig && !/--kubeconfig/.test(cmdline)) {
@@ -338,7 +342,11 @@ export function withKubeconfigFrom(args: Pick<Arguments<KubeOptions>, 'parsedOpt
   }
 
   if (args.parsedOptions.context && !/--context/.test(cmdline)) {
-    extras += ` --context ${args.parsedOptions.context}`
+    extras += ` --${context} ${args.parsedOptions.context}`
+  }
+
+  if (args.parsedOptions.context && !/--kube-context/.test(cmdline)) {
+    extras += ` --${context} ${args.parsedOptions.context}`
   }
 
   if (args.parsedOptions.cluster && !/--cluster/.test(cmdline)) {


### PR DESCRIPTION
Show managed resources and values, and offer a drilldown to managed resources.

Note: in this case, i clicked on the Show Managed Resources, but (at the time) there were none. This drilldown assumes that the helm chart uses the kubernetes label protocol of `app.kubernetes.io/name=${chartName}`

<img width="620" alt="Screenshot 2023-02-02 at 4 48 16 PM" src="https://user-images.githubusercontent.com/4741620/216457105-163dd40f-6c74-4087-a381-36df8a322fb5.png">


<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [ ] Your PR consists of a single commit (i.e. squash your commits)
- [ ] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
