### PR TITLE
fix: pod Containers tab may spin forever

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/modes/Summary/impl/Pod.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/Summary/impl/Pod.ts
@@ -33,18 +33,16 @@ import { age, none } from './Generic'
 import toDescriptionList from './convert'
 
 function ready(pod: Pod) {
-  const { containerStatuses } = pod.status
+  const { containerStatuses = [] } = pod.status
 
-  const numerator = !containerStatuses
-    ? 0
-    : containerStatuses.reduce((count, status) => count + (status.ready ? 1 : 0), 0)
+  const numerator = containerStatuses.reduce((count, status) => count + (status.ready ? 1 : 0), 0)
   const denominator = containerStatuses.length
 
   return `${numerator}/${denominator}`
 }
 
 function restarts(pod: Pod) {
-  const { containerStatuses } = pod.status
+  const { containerStatuses = [] } = pod.status
   return containerStatuses.reduce((count, status) => count + status.restartCount, 0)
 }
 
@@ -59,14 +57,20 @@ function readinessGates(pod: Pod) {
 export default function PodSummary(pod: Pod) {
   const { spec, status } = pod
 
-  const model = {
+  const model: Record<string, number | boolean | string> = {
     // Name: metadata.name,
     Ready: ready(pod),
     // Status: status.phase,
     Restarts: restarts(pod),
-    Age: age(pod),
-    IP: status.podIP,
-    Node: spec.nodeName
+    Age: age(pod)
+  }
+
+  if (status.podIP) {
+    model.IP = status.podIP
+  }
+
+  if (spec.nodeName) {
+    model.Node = spec.nodeName
   }
 
   if (spec.readinessGates) {


### PR DESCRIPTION
This can happen for pods that aren't ready yet, where there is a spec.containers but no status.containerStatuses. This PR also fixes a similar issue with the Pod summary view.

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
