### PR TITLE
fix: plugin-kubectl is missing explicit dep on plugin-kubectl-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17485,6 +17485,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@kui-shell/jsonpath": "^1.1.1",
+        "@kui-shell/plugin-kubectl-core": "*",
         "bytes-iec": "^3.1.1",
         "command-exists": "^1.2.9",
         "debug": "^4.3.4",
@@ -18751,6 +18752,7 @@
       "version": "file:plugins/plugin-kubectl",
       "requires": {
         "@kui-shell/jsonpath": "^1.1.1",
+        "@kui-shell/plugin-kubectl-core": "*",
         "@types/debug": "^4.1.7",
         "@types/fs-extra": "^9.0.13",
         "@types/js-yaml": "^4.0.5",

--- a/plugins/plugin-kubectl/package.json
+++ b/plugins/plugin-kubectl/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@kui-shell/jsonpath": "^1.1.1",
+    "@kui-shell/plugin-kubectl-core": "*",
     "bytes-iec": "^3.1.1",
     "command-exists": "^1.2.9",
     "debug": "^4.3.4",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
