### PR TITLE
fix: remove unused and outdated remark-code-frontmatter dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13501,81 +13501,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/remark-code-frontmatter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remark-code-frontmatter/-/remark-code-frontmatter-1.0.0.tgz",
-      "integrity": "sha512-5JHn7ixTxPWCMLP4dxt+56uk3aSvIB386KWmO+3FhUqh7EHZNRbCFk4uznU1FgV5AAc3cio+rxNab6fHSV8xng==",
-      "dependencies": {
-        "front-matter": "^3.0.2",
-        "unist-util-visit": "^1.4.1"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/front-matter": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-3.2.1.tgz",
-      "integrity": "sha512-YUhgEhbL6tG+Ok3vTGIoSDKqcr47aSDvyhEqIv8B+YuBJFsPnOiArNXTPp2yO07NL+a0L4+2jXlKlKqyVcsRRA==",
-      "dependencies": {
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
-    },
-    "node_modules/remark-code-frontmatter/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-    },
-    "node_modules/remark-code-frontmatter/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
-      }
-    },
     "node_modules/remark-collapse": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/remark-collapse/-/remark-collapse-0.1.2.tgz",
@@ -17059,6 +16984,7 @@
       }
     },
     "packages/builder": {
+      "name": "@kui-shell/builder",
       "version": "13.1.0",
       "dev": true,
       "hasInstallScript": true,
@@ -17091,6 +17017,7 @@
       "dev": true
     },
     "packages/core": {
+      "name": "@kui-shell/core",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17150,6 +17077,7 @@
       }
     },
     "packages/proxy": {
+      "name": "@kui-shell/proxy",
       "version": "13.1.0",
       "dev": true,
       "hasInstallScript": true,
@@ -17162,6 +17090,7 @@
       }
     },
     "packages/react": {
+      "name": "@kui-shell/react",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17174,6 +17103,7 @@
       }
     },
     "packages/test": {
+      "name": "@kui-shell/test",
       "version": "13.1.0",
       "dev": true,
       "license": "Apache-2.0",
@@ -17190,6 +17120,7 @@
       }
     },
     "packages/webpack": {
+      "name": "@kui-shell/webpack",
       "version": "13.1.0",
       "dev": true,
       "license": "Apache-2.0",
@@ -17240,6 +17171,7 @@
       }
     },
     "plugins/plugin-bash-like": {
+      "name": "@kui-shell/plugin-bash-like",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17277,10 +17209,12 @@
       }
     },
     "plugins/plugin-carbon-themes": {
+      "name": "@kui-shell/plugin-carbon-themes",
       "version": "13.1.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-client-common": {
+      "name": "@kui-shell/plugin-client-common",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17298,7 +17232,6 @@
         "react-markdown": "^8.0.5",
         "rehype-raw": "^6.1.1",
         "rehype-slug": "^5.1.0",
-        "remark-code-frontmatter": "^1.0.0",
         "remark-collapse": "^0.1.2",
         "remark-directive": "^2.0.1",
         "remark-emoji": "^3.1.0",
@@ -17338,6 +17271,7 @@
       "license": "Apache-2.0"
     },
     "plugins/plugin-core-support": {
+      "name": "@kui-shell/plugin-core-support",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17351,10 +17285,12 @@
       }
     },
     "plugins/plugin-core-themes": {
+      "name": "@kui-shell/plugin-core-themes",
       "version": "13.1.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-electron-components": {
+      "name": "@kui-shell/plugin-electron-components",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17366,6 +17302,7 @@
       }
     },
     "plugins/plugin-git": {
+      "name": "@kui-shell/plugin-git",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17373,9 +17310,11 @@
       }
     },
     "plugins/plugin-iter8": {
+      "name": "@kui-shell/plugin-iter8",
       "version": "13.1.0"
     },
     "plugins/plugin-kubectl": {
+      "name": "@kui-shell/plugin-kubectl",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17408,10 +17347,12 @@
       }
     },
     "plugins/plugin-kubectl-core": {
+      "name": "@kui-shell/plugin-kubectl-core",
       "version": "13.1.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-kubectl-tray-menu": {
+      "name": "@kui-shell/plugin-kubectl-tray-menu",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17454,6 +17395,7 @@
       }
     },
     "plugins/plugin-madwizard": {
+      "name": "@kui-shell/plugin-madwizard",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17486,14 +17428,17 @@
       }
     },
     "plugins/plugin-patternfly4-themes": {
+      "name": "@kui-shell/plugin-patternfly4-themes",
       "version": "13.1.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-proxy-support": {
+      "name": "@kui-shell/plugin-proxy-support",
       "version": "13.1.0",
       "license": "Apache-2.0"
     },
     "plugins/plugin-s3": {
+      "name": "@kui-shell/plugin-s3",
       "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18278,7 +18223,6 @@
         "react-markdown": "^8.0.5",
         "rehype-raw": "^6.1.1",
         "rehype-slug": "^5.1.0",
-        "remark-code-frontmatter": "^1.0.0",
         "remark-collapse": "^0.1.2",
         "remark-directive": "^2.0.1",
         "remark-emoji": "^3.1.0",
@@ -27834,73 +27778,6 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
       "dev": true
-    },
-    "remark-code-frontmatter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remark-code-frontmatter/-/remark-code-frontmatter-1.0.0.tgz",
-      "integrity": "sha512-5JHn7ixTxPWCMLP4dxt+56uk3aSvIB386KWmO+3FhUqh7EHZNRbCFk4uznU1FgV5AAc3cio+rxNab6fHSV8xng==",
-      "requires": {
-        "front-matter": "^3.0.2",
-        "unist-util-visit": "^1.4.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
-        "front-matter": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-3.2.1.tgz",
-          "integrity": "sha512-YUhgEhbL6tG+Ok3vTGIoSDKqcr47aSDvyhEqIv8B+YuBJFsPnOiArNXTPp2yO07NL+a0L4+2jXlKlKqyVcsRRA==",
-          "requires": {
-            "js-yaml": "^3.13.1"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
-        },
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        }
-      }
     },
     "remark-collapse": {
       "version": "0.1.2",

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -45,7 +45,6 @@
     "react-markdown": "^8.0.5",
     "rehype-raw": "^6.1.1",
     "rehype-slug": "^5.1.0",
-    "remark-code-frontmatter": "^1.0.0",
     "remark-collapse": "^0.1.2",
     "remark-directive": "^2.0.1",
     "remark-emoji": "^3.1.0",


### PR DESCRIPTION
This should resolve a security warning, as it brings in an outdated version of `frontmatter` 3.0.2

<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
