### PR TITLE
fix: add --append-server-path to kubectl proxy commandline

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/proxy/index.ts
+++ b/plugins/plugin-kubectl/src/controller/client/proxy/index.ts
@@ -125,7 +125,7 @@ async function startProxy(command: SupportedCommand, context: string): Promise<S
     const iter = (port = 8001, retryCount = 0) => {
       try {
         debug(`attempting to spawn kubectl proxy on port=${port} context=${context || 'default'}`)
-        const args = ['proxy', '--keepalive=120s', '--port', port.toString()]
+        const args = ['proxy', '--keepalive=120s', '--port', port.toString(), '--append-server-path']
         if (context) {
           args.push('--context')
           args.push(context)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:
Added the `--append-server-path` to `kubectl proxy` invocation so that k8s API endpoints which are not mounted at a host root (/api) will automatically work.

My use case is accessing clusters behind Rancher, where the actual API is behind a per-cluster path such as:

```server: "https://rancher.example.com/k8s/clusters/c-m-geef72a"```

The path portion is not added to the proxied URLs unless the `--append-server-path` argument is provided.

#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
