### PR TITLE
fix: second-instance additionalData may be null

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -734,14 +734,14 @@ export async function initElectron(
         // Someone tried to run a second instance, open a new window
         // to handle it
 
-        const env = !additionalData.env ? process.env : JSON.parse(additionalData.env)
+        const env = !additionalData || !additionalData.env ? process.env : JSON.parse(additionalData.env)
         const {
           argv,
           subwindowPlease,
           subwindowPrefs: defaultSubwindowPrefs
         } = getCommand(commandLine, cwd, env, async () => import('electron'))
 
-        const mySubwindowPrefs = additionalData.subwindowPrefs || defaultSubwindowPrefs
+        const mySubwindowPrefs = (additionalData && additionalData.subwindowPrefs) || defaultSubwindowPrefs
         if (!mySubwindowPrefs.width && widthFromCaller) {
           mySubwindowPrefs.width = widthFromCaller
         }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.
-->

#### Description of what you did:

This works around an issue where the `additionalData` parameter is `null` when using "popup window" mode. Since it is null, env vars, etc. from the second instance will not be transmitted to the first. But for now, we need to fix the bad behavior where one cannot even open a second window.

Fixes #9351
#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
