### PR TITLE
fix: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/packages/proxy/Dockerfile
+++ b/packages/proxy/Dockerfile
@@ -73,7 +73,7 @@ RUN debconf-set-selections /tmp/preseed.txt && \
     apt update && apt install -y --no-install-recommends build-essential python sed git tzdata nginx ca-certificates bash git python build-essential curl upx gettext-base unzip && \
     cd /usr/share/nginx/html/kui && npm link ./app --no-package-lock && \
     (cd /tmp && mkdir npty && cd npty && npm init -y && npm install node-pty@$NODE_PTY_VERSION && cd /usr/share/nginx/html/kui/dist/headless && cp /tmp/npty/node_modules/node-pty/build/Release/pty.node . && cp pty.node pty-proxy.node && mkdir -p ../build/Release && cp /tmp/npty/node_modules/node-pty/build/Release/spawn-helper ../build/Release) && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/kubectl && upx /usr/local/bin/kubectl && \
+    curl -LO https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/kubectl && upx /usr/local/bin/kubectl && \
     curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar zxf - && mv linux-amd64/helm /usr/local/bin/helm && chmod +x /usr/local/bin/helm && upx /usr/local/bin/helm && rm -rf linux-amd64 && \
     curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz | tar zxf - && \
       mv oc /usr/local/bin && \

--- a/packages/proxy/Dockerfile.http
+++ b/packages/proxy/Dockerfile.http
@@ -36,7 +36,7 @@ ENV KUBE_LATEST_VERSION="v1.13.2"
 ENV KUI_HELM_CLIENTS_DIR=/usr/local/bin
 ENV HELM_LATEST_VERSION="${KUI_HELM_CLIENTS_DIR}"/helm-2.12
 
-RUN (apk add --no-cache ca-certificates bash git python make g++ && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl) & \
+RUN (apk add --no-cache ca-certificates bash git python make g++ && wget -q https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl) & \
     (wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.9.0-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm-2.9 && chmod +x /usr/local/bin/helm-2.9) & \
     (wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm-2.10 && chmod +x /usr/local/bin/helm-2.10) & \
     (wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm-2.11 && chmod +x /usr/local/bin/helm-2.11) & \

--- a/tools/travis/microk8s.sh
+++ b/tools/travis/microk8s.sh
@@ -64,8 +64,8 @@ echo "smashing microk8s kubeconfig into .kube/config [SUCCESS]"
 kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 
 # Download and install kubectl (microk8s has its own kubectl, make sure we override it with the version we want)
-echo "Downloading this kubectl: https://storage.googleapis.com/kubernetes-release/release/v${TRAVIS_KUBE_VERSION}/bin/linux/amd64/kubectl"
-  curl --retry 10 -LO https://storage.googleapis.com/kubernetes-release/release/v${TRAVIS_KUBE_VERSION}/bin/linux/amd64/kubectl && \
+echo "Downloading this kubectl: https://dl.k8s.io/release/v${TRAVIS_KUBE_VERSION}/bin/linux/amd64/kubectl"
+  curl --retry 10 -LO https://dl.k8s.io/release/v${TRAVIS_KUBE_VERSION}/bin/linux/amd64/kubectl && \
        sudo cp kubectl /usr/local/bin/kubectl && \
        sudo chmod a+rx /usr/local/bin/kubectl
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396


#### Required Items

- [x] Your PR consists of a single commit (i.e. squash your commits)
- [x] Your commit and PR title starts with one of `fix:` | `test:` | `chore:` | `doc:`, to indicate the nature of the fix (see [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits))

#### Optional Items

- [ ] 💥 This PR involves a breaking change. If so, include "BREAKING CHANGE: ...why..." in the commit and PR message.
